### PR TITLE
Add len() to Producer/Consumer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,11 @@ impl<T: Sized> Producer<T> {
         self.queue.capacity()
     }
 
+    /// Return the current length of the queue.
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
     /// Reserves a position, and increments the cached write position.
     /// Returns `None` if the queue is full.
     /// Returns a pointer to the reserved position.
@@ -116,6 +121,11 @@ impl<T: Sized> Consumer<T> {
     /// Return the capacity of the queue in items.
     pub fn capacity(&self) -> usize {
         self.queue.capacity()
+    }
+
+    /// Return the current length of the queue.
+    pub fn len(&self) -> usize {
+        self.queue.len()
     }
 
     /// Attempts to read a value from the queue.
@@ -208,6 +218,10 @@ impl<T: Sized> SharedQueue<T> {
 
     fn capacity(&self) -> usize {
         self.buffer_mask + 1
+    }
+
+    fn len(&self) -> usize {
+        self.cached_write.wrapping_sub(self.cached_read)
     }
 
     fn mask(&self, index: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,11 @@ impl<T: Sized> Producer<T> {
         self.queue.len()
     }
 
+    /// Returns true if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
     /// Reserves a position, and increments the cached write position.
     /// Returns `None` if the queue is full.
     /// Returns a pointer to the reserved position.
@@ -126,6 +131,11 @@ impl<T: Sized> Consumer<T> {
     /// Return the current length of the queue.
     pub fn len(&self) -> usize {
         self.queue.len()
+    }
+
+    /// Returns true if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
     }
 
     /// Attempts to read a value from the queue.
@@ -222,6 +232,10 @@ impl<T: Sized> SharedQueue<T> {
 
     fn len(&self) -> usize {
         self.cached_write.wrapping_sub(self.cached_read)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.cached_write == self.cached_read
     }
 
     fn mask(&self, index: usize) -> usize {


### PR DESCRIPTION
- Useful to get the current length of the queue
- Add a method, `len()`, to get it
- Add `is_empty` to stop clippy from yapping