### PR TITLE
feat: impl `Send` for `Producer` and `Consumer`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,8 @@ impl<T: Sized> Producer<T> {
     }
 }
 
+unsafe impl<T> Send for Producer<T> where T: Sized {}
+
 /// Consumer side of the SPSC shared queue.
 pub struct Consumer<T: Sized> {
     queue: SharedQueue<T>,
@@ -196,6 +198,8 @@ impl<T: Sized> Consumer<T> {
         self.queue.load_write();
     }
 }
+
+unsafe impl<T> Send for Consumer<T> where T: Sized {}
 
 struct SharedQueue<T: Sized> {
     header: NonNull<SharedQueueHeader>,


### PR DESCRIPTION
Implement `Send` for `Producer`/`Consumer` as raw pointers are not strictly non-Send (they're only non Send as a lint). Therefore provided our API is correct the entire struct should be safe to `Send` across threads. If our API is not correct then we have issues regardless of this impl.