### PR TITLE
feat: impl `Display` and `Error` for error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,22 @@
+use std::fmt::Display;
+
 #[derive(Debug)]
 pub enum Error {
     InvalidBufferSize,
     Io(std::io::Error),
     Mmap(std::io::Error),
+}
+
+impl std::error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidBufferSize => write!(f, "invalid buffer size"),
+            Self::Io(err) => write!(f, "io; err={err}"),
+            Self::Mmap(err) => write!(f, "mmap; err={err}"),
+        }
+    }
 }
 
 impl From<std::io::Error> for Error {


### PR DESCRIPTION
Implements `Display` and `Error` to improve downstream developer experience (for instance enables auto deriving `From` impls with `thiserror`)