### PR TITLE
build: allow "building" shaq on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ license-file = "LICENSE"
 edition = "2021"
 include = ["src/*.rs", "Cargo.toml"]
 
-
-[dependencies]
+[target."cfg(unix)".dependencies]
 libc = { version = "0.2.174" }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use core::{ptr::NonNull, sync::atomic::AtomicUsize};
 use std::{fs::File, sync::atomic::Ordering};
 


### PR DESCRIPTION
Right now if a downstream consumer somehow gets `shaq` in their dependency tree, then windows builds will fail. This relaxes that such that the downstream consumer has to actually use unix only elements of shaq (or a crate that depends on shaq) for this to break builds. This is not strictly required but is slightly more forgiving to downstream users.