### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "shaq"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "core_affinity",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shaq"
 authors = ["Andrew Fitzgerald <apfitzge@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 description = "SPSC FIFO queue backed by shared memory for IPC"
 readme = "README.md"
 homepage = "https://github.com/apfitzge/shaq"


### PR DESCRIPTION
Bumping version for updating to File interface.
Release v1.0.0 pending on finalized interfaces for release of scheduler-bindings in agave, until then semver is not respected.