### PR TITLE
Add try_read_ptr and try_write

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -95,7 +95,8 @@ fn run_producer(mut producer: Producer<Item>, exit: Arc<AtomicBool>) {
     while !exit.load(Ordering::Acquire) {
         producer.sync();
         for _ in 0..SYNC_CADENCE {
-            let Some(mut spot) = producer.reserve() else {
+            // SAFETY: ptr written below with fill
+            let Some(mut spot) = (unsafe { producer.reserve() }) else {
                 break;
             };
             unsafe {


### PR DESCRIPTION
### Problem

- Most common use-case for reading is to just get the ptr and immediately take a reference
- This is currently not ergonomic for users, and requires unsafe

### Changes
- Add `Consumer::try_read_ptr` which returns a ptr
- `Consumer::try_read` now returns a ref
- `Consumer::finalize` takes a mut ref to self
- `Producer::try_write` can write an item
- `Producer::commit` takes a mut ref to self