### PR TITLE
Support hugepages in map_file

### DIFF
--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -3,12 +3,25 @@ use std::{fs::File, os::fd::AsRawFd, ptr::NonNull};
 
 /// Maps a file into memory.
 pub(crate) fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
+    #[cfg(target_os = "linux")]
+    {
+        // On linux first attempt to map with hugepages. Fall back to regular on failure.
+        let r = map_file_with_flags(file, size, libc::MAP_SHARED | libc::MAP_HUGETLB);
+        if r.is_ok() {
+            return r;
+        }
+    }
+
+    map_file_with_flags(file, size, libc::MAP_SHARED)
+}
+
+fn map_file_with_flags(file: &File, size: usize, flags: libc::c_int) -> Result<NonNull<u8>, Error> {
     let addr = unsafe {
         libc::mmap(
             core::ptr::null_mut(),
             size,
             libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_SHARED,
+            flags,
             file.as_raw_fd(),
             0,
         )


### PR DESCRIPTION
### Problem
- We should support hugepage backing for shmem

### Changes
- map_file will try to map with hugepages on linux. falling back to regular pages on failure