### PR TITLE
consistent unsafe joining

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -72,7 +72,8 @@ fn main() {
                 core_affinity::set_for_current(id);
             }
 
-            let producer = shaq::Producer::create(&queue_file, 16 * 1024 * 1024).unwrap();
+            let producer =
+                unsafe { shaq::Producer::create(&queue_file, 16 * 1024 * 1024) }.unwrap();
             begin_signal.store(true, Ordering::Release);
             run_producer(producer, exit);
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,11 @@ pub struct Producer<T: Sized> {
 impl<T: Sized> Producer<T> {
     /// Creates a new producer for the shared queue in the provided file with
     /// the given size.
-    pub fn create(file: &File, file_size: usize) -> Result<Self, Error> {
+    ///
+    /// # Safety
+    /// - The provided file must be uniquely accessed as a Producer and
+    ///   not yet joined by a Consumer.
+    pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -33,8 +37,9 @@ impl<T: Sized> Producer<T> {
 
     /// Joins an existing producer for the shared queue in the provided file.
     ///
-    /// # SAFETY: The provided file must be uniquely accessed as a Producer.
-    pub fn join(file: &File) -> Result<Self, Error> {
+    /// # Safety
+    /// - The provided file must be uniquely accessed as a Producer.
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -134,6 +139,9 @@ pub struct Consumer<T: Sized> {
 impl<T: Sized> Consumer<T> {
     /// Creates a new consumer for the shared queue in the provided file with
     /// the given size.
+    ///
+    /// # SAFETY: The provided file must be uniquely accessed as a Consumer and
+    ///           not yet joined by a Producer.
     pub fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@ impl<T: Sized> Producer<T> {
     /// the given size.
     ///
     /// # Safety
-    /// - The provided file must be uniquely accessed as a Producer and
-    ///   not yet joined by a Consumer.
+    /// - The provided file must be created accessed as a Producer.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -38,7 +37,7 @@ impl<T: Sized> Producer<T> {
     /// Joins an existing producer for the shared queue in the provided file.
     ///
     /// # Safety
-    /// - The provided file must be uniquely accessed as a Producer.
+    /// - The provided file must be uniquely joined as a Producer.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -140,8 +139,7 @@ impl<T: Sized> Consumer<T> {
     /// Creates a new consumer for the shared queue in the provided file with
     /// the given size.
     ///
-    /// # SAFETY: The provided file must be uniquely accessed as a Consumer and
-    ///           not yet joined by a Producer.
+    /// # SAFETY: The provided file must be uniquely created as a Consumer.
     pub fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -152,7 +150,7 @@ impl<T: Sized> Consumer<T> {
     /// Joins an existing consumer for the shared queue in the provided file.
     ///
     /// # Safety
-    /// - The provided file must be uniquely accessed as a Consumer.
+    /// - The provided file must be uniquely joined as a Consumer.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ impl<T: Sized> Producer<T> {
     /// the given size.
     ///
     /// # Safety
-    /// - The provided file must be created accessed as a Producer.
+    /// - The provided file must be uniquely created as a Producer.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -139,8 +139,9 @@ impl<T: Sized> Consumer<T> {
     /// Creates a new consumer for the shared queue in the provided file with
     /// the given size.
     ///
-    /// # SAFETY: The provided file must be uniquely created as a Consumer.
-    pub fn create(file: &File, file_size: usize) -> Result<Self, Error> {
+    /// # Safety
+    /// - The provided file must be uniquely created as a Consumer.
+    pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.


### PR DESCRIPTION
- functions marked with `unsafe` condutions yet were not actually `unsafe`.