### PR TITLE
Version 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "shaq"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "core_affinity",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shaq"
 authors = ["Andrew Fitzgerald <apfitzge@gmail.com>"]
-version = "0.2.0"
+version = "1.0.0"
 description = "SPSC FIFO queue backed by shared memory for IPC"
 readme = "README.md"
 homepage = "https://github.com/apfitzge/shaq"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 #[derive(Debug)]
 pub enum Error {
+    InvalidVersion,
     InvalidBufferSize,
     Io(std::io::Error),
     Mmap(std::io::Error),
@@ -12,6 +13,7 @@ impl std::error::Error for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::InvalidVersion => write!(f, "invalid version"),
             Self::InvalidBufferSize => write!(f, "invalid buffer size"),
             Self::Io(err) => write!(f, "io; err={err}"),
             Self::Mmap(err) => write!(f, "mmap; err={err}"),


### PR DESCRIPTION
- Make setting/reading version atomic (seqcst)
- Bump cargo version to 1.0.0 for release

