### PR TITLE
Pass header ptr to munmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "shaq"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "core_affinity",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shaq"
 authors = ["Andrew Fitzgerald <apfitzge@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 description = "SPSC FIFO queue backed by shared memory for IPC"
 readme = "README.md"
 homepage = "https://github.com/apfitzge/shaq"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,9 +259,9 @@ impl<T> Drop for SharedQueue<T> {
         }
 
         #[allow(unreachable_code)]
-        // SAFETY: buffer is mmapped and of size `file_size`.
+        // SAFETY: header is mmapped and of size `file_size`.
         unsafe {
-            libc::munmap(self.buffer.as_ptr().cast(), self.file_size);
+            libc::munmap(self.header.as_ptr().cast(), self.file_size);
         }
     }
 }


### PR DESCRIPTION
### Problem
- We're passing `buffer` pointer to `munmap` on `Drop`, but we've mapped from `header`.
- This causes unmapping to fail, and since we're in `Drop` this is happening silently.

### Solution
- Pass `header` to `munmap`