### PR TITLE
Additional unsafe conditions + unsafe join on mpmc

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -258,7 +258,7 @@ fn run_mpmc(producers: usize, consumers: usize, verbose: bool) {
                     }
 
                     // SAFETY: Queue was created once and this handle joins as a consumer.
-                    let consumer = MpmcConsumer::join(&file).unwrap();
+                    let consumer = unsafe { MpmcConsumer::join(&file) }.unwrap();
                     run_mpmc_consumer(consumer, exit, consumer_reserve_failures);
                 })
                 .unwrap(),
@@ -282,7 +282,7 @@ fn run_mpmc(producers: usize, consumers: usize, verbose: bool) {
                         }
 
                         // SAFETY: Queue was created once and this handle joins as a producer.
-                        let producer = MpmcProducer::join(&file).unwrap();
+                        let producer = unsafe { MpmcProducer::join(&file) }.unwrap();
                         run_mpmc_producer(
                             producer,
                             exit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ impl<T: Sized> Producer<T> {
     ///
     /// # Safety
     /// - The provided file must be uniquely created as a Producer.
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -43,6 +46,11 @@ impl<T: Sized> Producer<T> {
     ///
     /// # Safety
     /// - The provided file must be uniquely joined as a Producer.
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
+    /// - The same `T` must be used by the [`Consumer`] that is joined with the
+    ///   same file.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -146,6 +154,9 @@ impl<T: Sized> Consumer<T> {
     ///
     /// # Safety
     /// - The provided file must be uniquely created as a Consumer.
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -157,6 +168,11 @@ impl<T: Sized> Consumer<T> {
     ///
     /// # Safety
     /// - The provided file must be uniquely joined as a Consumer.
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
+    /// - The same `T` must be used by the [`Producer`] that is joined with the
+    ///   same file.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with

--- a/src/mpmc/mod.rs
+++ b/src/mpmc/mod.rs
@@ -18,6 +18,9 @@ impl<T> Producer<T> {
     ///
     /// # Safety
     /// - The provided file must be uniquely created as a Producer.
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -26,7 +29,14 @@ impl<T> Producer<T> {
     }
 
     /// Joins an existing producer for the shared queue in the provided file.
-    pub fn join(file: &File) -> Result<Self, Error> {
+    ///
+    /// # Safety
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
+    /// - The same `T` must be used by the [`Consumer`]s that are joined with
+    ///   the same file.
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -115,6 +125,9 @@ impl<T> Consumer<T> {
     ///
     /// # Safety
     /// - The provided file must be uniquely created as a Consumer.
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
         let header = SharedQueueHeader::create::<T>(file, file_size)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
@@ -123,7 +136,14 @@ impl<T> Consumer<T> {
     }
 
     /// Joins an existing consumer for the shared queue in the provided file.
-    pub fn join(file: &File) -> Result<Self, Error> {
+    ///
+    /// # Safety
+    /// - The queue does not validate `T` across processes.
+    /// - If a process may read, dereference, mutate, or drop a queued value,
+    ///   that operation must be valid for that value in that process.
+    /// - The same `T` must be used by the [`Producer`]s that are joined with
+    ///   the same file.
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
         let (header, file_size) = SharedQueueHeader::join::<T>(file)?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.


### PR DESCRIPTION
### Problem
- The constraints on `T` that are no (easily) expressed via actual trait bounds:
	- note that while we could do this with something like bytemuck pod, it would require us to propagate `#[derive(Pod)]` in a bunch of places. and probably enforces more than we actually need to - see below bullet.
- `T` should be safe to share amongst different processes**
	- This is not *entirely* true, in the case of 2 way communication. For example if I expect the original message to be passed back to me in a response. I could include a pointer in the original message - and only use it in the same sending process. This is use is sound (albeit pretty unsafe) and there's no need imo to prevent somebody from doing this.
- `T` should be the same on both ends of a queue. ie. producing T should have consumers of T.

### Solution
- Add additional unsafe constraints on create/join
- mpmc join functions become unsafe