### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,21 @@ permissions:
 
 jobs:
   check-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Cache Cargo registry + build
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -28,13 +34,19 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Rustfmt check
+        if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --all -- --check
 
       - name: Clippy lint
+        if: matrix.os == 'ubuntu-latest'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Build release
+        if: matrix.os == 'ubuntu-latest'
         run: cargo build --release
+
+      - name: Cargo check
+        run: cargo check --all-targets
 
       - name: Run tests
         run: cargo test --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -119,6 +119,7 @@ dependencies = [
  "core_affinity",
  "ctrlc",
  "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -151,9 +152,82 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,14 @@ include = ["src/*.rs", "Cargo.toml"]
 [target."cfg(unix)".dependencies]
 libc = { version = "0.2.182" }
 
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Memory",
+] }
+
 [dev-dependencies]
 core_affinity = "0.8.3"
 ctrlc = "3.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,13 +270,6 @@ struct SharedQueue<T: Sized> {
 
 impl<T> Drop for SharedQueue<T> {
     fn drop(&mut self) {
-        // Tests do not mmap so skip unmapping in tests.
-        #[cfg(test)]
-        {
-            return;
-        }
-
-        #[allow(unreachable_code)]
         // SAFETY: header is mmapped and of size `file_size`.
         unsafe {
             unmap_file(self.header.cast::<u8>(), self.file_size);
@@ -477,30 +470,18 @@ impl core::ops::Deref for CacheAlignedAtomicSize {
 }
 
 #[cfg(test)]
-pub(crate) mod aligned_buffer {
-    #[repr(C, align(64))]
-    pub struct AlignedBuffer<const N: usize>(pub [u8; N]);
-}
-
-#[cfg(test)]
 mod tests {
-    use crate::aligned_buffer::AlignedBuffer;
-
     use super::*;
+    use crate::shmem::create_temp_shmem_file;
     use std::sync::atomic::AtomicU64;
 
-    fn create_test_queue<T: Sized>(buffer: &mut [u8]) -> (Producer<T>, Consumer<T>) {
-        let file_size = buffer.len();
-        let buffer_size_in_items =
-            SharedQueueHeader::calculate_buffer_size_in_items::<T>(file_size)
-                .expect("Invalid buffer size");
-        let header = NonNull::new(buffer.as_mut_ptr().cast()).expect("Failed to create header");
-        unsafe { SharedQueueHeader::initialize(header, buffer_size_in_items) };
+    fn create_test_queue<T: Sized>(file_size: usize) -> (File, Producer<T>, Consumer<T>) {
+        let file = create_temp_shmem_file().unwrap();
+        let producer =
+            unsafe { Producer::create(&file, file_size) }.expect("Failed to create producer");
+        let consumer = unsafe { Consumer::join(&file) }.expect("Failed to join consumer");
 
-        (
-            unsafe { Producer::from_header(header, file_size) }.expect("Failed to create producer"),
-            unsafe { Consumer::from_header(header, file_size) }.expect("Failed to create consumer"),
-        )
+        (file, producer, consumer)
     }
 
     #[test]
@@ -509,9 +490,7 @@ mod tests {
         const BUFFER_CAPACITY: usize = 1024;
         const BUFFER_SIZE: usize = minimum_file_size::<Item>(BUFFER_CAPACITY);
 
-        let mut buffer = Box::new(AlignedBuffer([0; BUFFER_SIZE]));
-        let slice = buffer.0.as_mut_slice();
-        let (mut producer, mut consumer) = create_test_queue::<Item>(slice);
+        let (_file, mut producer, mut consumer) = create_test_queue::<Item>(BUFFER_SIZE);
 
         assert_eq!(producer.capacity(), BUFFER_CAPACITY);
         assert_eq!(consumer.capacity(), BUFFER_CAPACITY);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-#![cfg(unix)]
-
-use crate::{error::Error, shmem::map_file};
+use crate::{
+    error::Error,
+    shmem::{map_file, unmap_file},
+};
 use core::{ptr::NonNull, sync::atomic::AtomicUsize};
 use std::{
     fs::File,
@@ -278,7 +279,7 @@ impl<T> Drop for SharedQueue<T> {
         #[allow(unreachable_code)]
         // SAFETY: header is mmapped and of size `file_size`.
         unsafe {
-            libc::munmap(self.header.as_ptr().cast(), self.file_size);
+            unmap_file(self.header.cast::<u8>(), self.file_size);
         }
     }
 }

--- a/src/mpmc/mod.rs
+++ b/src/mpmc/mod.rs
@@ -232,7 +232,6 @@ struct SharedQueue<T> {
 
 impl<T> Drop for SharedQueue<T> {
     fn drop(&mut self) {
-        #[allow(unreachable_code)]
         // SAFETY: header is mmapped and of size `file_size`.
         unsafe {
             unmap_file(self.header.cast::<u8>(), self.file_size);

--- a/src/mpmc/mod.rs
+++ b/src/mpmc/mod.rs
@@ -232,12 +232,6 @@ struct SharedQueue<T> {
 
 impl<T> Drop for SharedQueue<T> {
     fn drop(&mut self) {
-        // Tests do not mmap so skip unmapping in tests.
-        #[cfg(test)]
-        {
-            return;
-        }
-
         #[allow(unreachable_code)]
         // SAFETY: header is mmapped and of size `file_size`.
         unsafe {
@@ -671,30 +665,24 @@ impl<'a, T> Drop for ReadBatch<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::aligned_buffer::AlignedBuffer;
+    use crate::shmem::create_temp_shmem_file;
 
     type Item = u64;
     const BUFFER_CAPACITY: usize = 512;
     const BUFFER_SIZE: usize = minimum_file_size::<Item>(BUFFER_CAPACITY);
 
-    fn create_test_queue<T: Sized>(buffer: &mut [u8]) -> (Producer<T>, Consumer<T>) {
-        let file_size = buffer.len();
-        let buffer_size_in_items =
-            SharedQueueHeader::calculate_buffer_size_in_items::<T>(file_size)
-                .expect("Invalid buffer size");
-        let header = NonNull::new(buffer.as_mut_ptr().cast()).expect("Failed to create header");
-        unsafe { SharedQueueHeader::initialize(header, buffer_size_in_items) };
+    fn create_test_queue<T: Sized>(file_size: usize) -> (File, Producer<T>, Consumer<T>) {
+        let file = create_temp_shmem_file().unwrap();
+        let producer =
+            unsafe { Producer::create(&file, file_size) }.expect("Failed to create producer");
+        let consumer = unsafe { Consumer::join(&file) }.expect("Failed to join consumer");
 
-        (
-            unsafe { Producer::from_header(header, file_size) }.expect("Failed to create producer"),
-            unsafe { Consumer::from_header(header, file_size) }.expect("Failed to create consumer"),
-        )
+        (file, producer, consumer)
     }
 
     #[test]
     fn test_producer_consumer() {
-        let mut buffer = AlignedBuffer([0u8; BUFFER_SIZE]);
-        let (producer, consumer) = create_test_queue::<Item>(&mut buffer.0);
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
         let capacity =
             SharedQueueHeader::calculate_buffer_size_in_items::<Item>(BUFFER_SIZE).unwrap();
 
@@ -711,8 +699,7 @@ mod tests {
 
     #[test]
     fn test_reserve_and_try_read_ptr() {
-        let mut buffer = AlignedBuffer([0u8; BUFFER_SIZE]);
-        let (producer, consumer) = create_test_queue::<Item>(&mut buffer.0);
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
 
         let mut guard = unsafe { producer.reserve() }.expect("reserve failed");
         unsafe {
@@ -728,8 +715,7 @@ mod tests {
 
     #[test]
     fn test_reserve_batch_and_try_read_batch() {
-        let mut buffer = AlignedBuffer([0u8; BUFFER_SIZE]);
-        let (producer, consumer) = create_test_queue::<Item>(&mut buffer.0);
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
 
         let mut batch = unsafe { producer.reserve_batch(4) }.expect("reserve_batch failed");
         for index in 0..batch.len() {
@@ -749,8 +735,7 @@ mod tests {
 
     #[test]
     fn test_batch_write_exact_read_upto_max() {
-        let mut buffer = AlignedBuffer([0u8; BUFFER_SIZE]);
-        let (producer, consumer) = create_test_queue::<Item>(&mut buffer.0);
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
 
         unsafe {
             assert!(producer.reserve_batch(0).is_none());
@@ -774,25 +759,11 @@ mod tests {
 
     #[test]
     fn test_multiple_producers_consumers() {
-        let mut buffer = AlignedBuffer([0u8; BUFFER_SIZE]);
+        let (file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
+        let producer2 = unsafe { Producer::join(&file) }.expect("Failed to create producer2");
+        let consumer2 = unsafe { Consumer::join(&file) }.expect("Failed to create consumer2");
 
-        let file_size = buffer.0.len();
-        let buffer_size_in_items =
-            SharedQueueHeader::calculate_buffer_size_in_items::<Item>(file_size)
-                .expect("Invalid buffer size");
-        let header = NonNull::new(buffer.0.as_mut_ptr().cast()).expect("Failed to create header");
-        unsafe { SharedQueueHeader::initialize(header, buffer_size_in_items) };
-
-        let producer =
-            unsafe { Producer::from_header(header, file_size) }.expect("Failed to create producer");
-        let producer2 = unsafe { Producer::from_header(header, file_size) }
-            .expect("Failed to create producer2");
-        let consumer = unsafe { Consumer::<Item>::from_header(header, file_size) }
-            .expect("Failed to create consumer");
-        let consumer2 = unsafe { Consumer::from_header(header, file_size) }
-            .expect("Failed to create consumer2");
-        let capacity = buffer_size_in_items;
-
+        let capacity = BUFFER_CAPACITY;
         for i in 0..(capacity / 2) {
             assert_eq!(producer.try_write((i * 2) as Item), Ok(()));
             assert_eq!(producer2.try_write((i * 2 + 1) as Item), Ok(()));

--- a/src/mpmc/mod.rs
+++ b/src/mpmc/mod.rs
@@ -1,6 +1,10 @@
 //! DPDK-style bounded MPMC ring queue
 
-use crate::{error::Error, shmem::map_file, CacheAlignedAtomicSize, VERSION};
+use crate::{
+    error::Error,
+    shmem::{map_file, unmap_file},
+    CacheAlignedAtomicSize, VERSION,
+};
 use core::{
     marker::PhantomData,
     ptr::NonNull,
@@ -237,7 +241,7 @@ impl<T> Drop for SharedQueue<T> {
         #[allow(unreachable_code)]
         // SAFETY: header is mmapped and of size `file_size`.
         unsafe {
-            libc::munmap(self.header.as_ptr().cast(), self.file_size);
+            unmap_file(self.header.cast::<u8>(), self.file_size);
         }
     }
 }

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -59,12 +59,12 @@ pub(crate) fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
 
     let mmap = unsafe { MapViewOfFile(mapping, FILE_MAP_ALL_ACCESS, 0, 0, size) };
 
-    unsafe {
-        CloseHandle(mapping);
-    }
-
     if mmap.Value.is_null() {
         return Err(Error::Mmap(std::io::Error::last_os_error()));
+    }
+
+    unsafe {
+        CloseHandle(mapping);
     }
 
     Ok(NonNull::new(mmap.Value.cast()).expect("already checked for null"))

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -1,8 +1,11 @@
 use crate::error::Error;
-use std::{fs::File, os::fd::AsRawFd, ptr::NonNull};
+use std::{fs::File, ptr::NonNull};
 
 /// Maps a file into memory.
+#[cfg(unix)]
 pub(crate) fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
+    use std::os::fd::AsRawFd;
+
     let addr = unsafe {
         libc::mmap(
             core::ptr::null_mut(),
@@ -18,4 +21,63 @@ pub(crate) fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
     }
 
     Ok(NonNull::new(addr.cast()).expect("already checked for null"))
+}
+
+/// Unmaps a previously mapped file view.
+#[cfg(unix)]
+pub(crate) unsafe fn unmap_file(addr: NonNull<u8>, size: usize) {
+    let _ = unsafe { libc::munmap(addr.as_ptr().cast(), size) };
+}
+
+/// Maps a file into memory.
+#[cfg(windows)]
+pub(crate) fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::Memory::{
+        CreateFileMappingW, MapViewOfFile, FILE_MAP_ALL_ACCESS, PAGE_READWRITE,
+    };
+
+    let size_u64 = u64::try_from(size).map_err(|_| Error::InvalidBufferSize)?;
+    let size_high = (size_u64 >> 32) as u32;
+    let size_low = size_u64 as u32;
+
+    let mapping = unsafe {
+        CreateFileMappingW(
+            file.as_raw_handle() as HANDLE,
+            core::ptr::null(),
+            PAGE_READWRITE,
+            size_high,
+            size_low,
+            core::ptr::null(),
+        )
+    };
+
+    if mapping.is_null() {
+        return Err(Error::Mmap(std::io::Error::last_os_error()));
+    }
+
+    let mmap = unsafe { MapViewOfFile(mapping, FILE_MAP_ALL_ACCESS, 0, 0, size) };
+
+    unsafe {
+        CloseHandle(mapping);
+    }
+
+    if mmap.Value.is_null() {
+        return Err(Error::Mmap(std::io::Error::last_os_error()));
+    }
+
+    Ok(NonNull::new(mmap.Value.cast()).expect("already checked for null"))
+}
+
+/// Unmaps a previously mapped file view.
+#[cfg(windows)]
+pub(crate) unsafe fn unmap_file(addr: NonNull<u8>, _size: usize) {
+    use windows_sys::Win32::System::Memory::{UnmapViewOfFile, MEMORY_MAPPED_VIEW_ADDRESS};
+
+    let _ = unsafe {
+        UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
+            Value: addr.cast().as_ptr(),
+        })
+    };
 }


### PR DESCRIPTION
### Problem
- We're unlikely to be able to deprecate Windows support in agave in the immediate future
- This gets in the way of our plans to use the shmem stuff more widely

### Solution
- Add support for windows