### PR TITLE
build: relax libc to 0.2.180

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 include = ["src/*.rs", "Cargo.toml"]
 
 [target."cfg(unix)".dependencies]
-libc = { version = "0.2.182" }
+libc = { version = "0.2.180" }
 
 [target."cfg(windows)".dependencies]
 windows-sys = { version = "0.59", features = [


### PR DESCRIPTION
- `nix 0.31.1` takes a hard version lock on `libc 0.2.180` (https://crates.io/crates/nix/0.31.1/dependencies).
- These automated commits make shaq unbuildable in any crate that uses `nix` (most notably shaq master no longer builds in `agave`).
 - 24a2428753c8e56c45dacf38d49917b8e9d6d9d3
 - ef35399ecaf59b590ff3fcb89194aee1da801128

For now we just relax the `libc` requirement but this issue raises a meta question as to what dependabot's role is and whether it's worth enduring subtle breakages like this.