### PR TITLE
impl Sync for mpmc queues

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -118,6 +118,7 @@ impl<T> Producer<T> {
 }
 
 unsafe impl<T> Send for Producer<T> {}
+unsafe impl<T> Sync for Producer<T> {}
 
 pub struct Consumer<T> {
     queue: SharedQueue<T>,
@@ -213,6 +214,7 @@ impl<T> Consumer<T> {
 }
 
 unsafe impl<T> Send for Consumer<T> {}
+unsafe impl<T> Sync for Consumer<T> {}
 
 /// Calculates the minimum file size required for a queue with given capacity.
 /// Note that file size MAY need to be increased beyond this to account for


### PR DESCRIPTION
### Problem
- The MPMC queues cannot be shared between threads in a process in an Arc
- This means each joiner must `join`. This means a syscall per join, as well as separate mappings of the region

### Changes
- Implement Sync for the MPMC queues
	- No internal data like in SPSC that prevents this
- Change example to use Arc-wrapped queue handles  