### PR TITLE
Add as_ref to Read guards

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -318,7 +318,7 @@ fn run_mpmc_producer(
 ) {
     run_producer_loop::<Item, _>(exit, report_prefix, total_items_produced, move || {
         // SAFETY: we write the batch below.
-        let Some(mut batch) = (unsafe { producer.reserve_batch(SYNC_CADENCE) }) else {
+        let Some(mut batch) = (unsafe { producer.reserve_write_batch(SYNC_CADENCE) }) else {
             producer_reserve_failures.fetch_add(1, Ordering::Relaxed);
             return None;
         };
@@ -338,7 +338,7 @@ fn run_mpmc_consumer(
     consumer_reserve_failures: Arc<AtomicU64>,
 ) {
     run_consumer_loop(exit, move || {
-        let Some(batch) = consumer.try_read_batch(SYNC_CADENCE) else {
+        let Some(batch) = consumer.reserve_read_batch(SYNC_CADENCE) else {
             consumer_reserve_failures.fetch_add(1, Ordering::Relaxed);
             return;
         };

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -560,12 +560,6 @@ pub struct ReadGuard<'a, T> {
 }
 
 impl<'a, T> ReadGuard<'a, T> {
-    /// Returns a shared reference to the reserved slot.
-    pub fn as_ref(&self) -> &T {
-        // SAFETY: The cell was reserved for reading and is initialized.
-        unsafe { self.cell.as_ref() }
-    }
-
     pub fn as_ptr(&self) -> *const T {
         // SAFETY: The cell was reserved for reading.
         self.cell.as_ptr()
@@ -574,6 +568,14 @@ impl<'a, T> ReadGuard<'a, T> {
     pub fn read(self) -> T {
         // SAFETY: The cell was reserved for reading and holds an initialized value.
         unsafe { self.cell.as_ptr().read() }
+    }
+}
+
+impl<'a, T> AsRef<T> for ReadGuard<'a, T> {
+    /// Returns a shared reference to the reserved slot.
+    fn as_ref(&self) -> &T {
+        // SAFETY: The cell was reserved for reading and is initialized.
+        unsafe { self.cell.as_ref() }
     }
 }
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -653,6 +653,7 @@ impl<'a, T> WriteBatch<'a, T> {
     /// - `index < count`
     /// - `T` must be valid for any bytes.
     pub unsafe fn as_mut(&mut self, index: usize) -> &mut T {
+        debug_assert!(index < self.count);
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for writing.
         unsafe { self.buffer.add(position & self.buffer_mask).as_mut() }
@@ -664,6 +665,7 @@ impl<'a, T> WriteBatch<'a, T> {
     /// - The slot is uninitialized; caller must fully initialize `T`.
     /// - `index < count`
     pub unsafe fn as_mut_ptr(&mut self, index: usize) -> *mut T {
+        debug_assert!(index < self.count);
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for writing.
         unsafe { self.buffer.add(position & self.buffer_mask).as_ptr() }
@@ -674,6 +676,7 @@ impl<'a, T> WriteBatch<'a, T> {
     /// # Safety
     /// - `index < count`
     pub unsafe fn write(&mut self, index: usize, value: T) {
+        debug_assert!(index < self.count);
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for writing
         unsafe { self.buffer.add(position & self.buffer_mask).write(value) }
@@ -713,6 +716,7 @@ impl<'a, T> ReadBatch<'a, T> {
     /// # Safety
     /// - `index` must be less than `self.len()`
     pub unsafe fn as_ref(&self, index: usize) -> &T {
+        debug_assert!(index < self.count);
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for reading and is initialized.
         unsafe { self.buffer.add(position & self.buffer_mask).as_ref() }
@@ -723,6 +727,7 @@ impl<'a, T> ReadBatch<'a, T> {
     /// # Safety
     /// - `index` must be less than `self.len()`
     pub unsafe fn as_ptr(&self, index: usize) -> *const T {
+        debug_assert!(index < self.count);
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for reading.
         unsafe { self.buffer.add(position & self.buffer_mask).as_ptr() }
@@ -733,6 +738,7 @@ impl<'a, T> ReadBatch<'a, T> {
     /// # Safety
     /// - `index` must be less than `self.len()`
     pub unsafe fn read(&self, index: usize) -> T {
+        debug_assert!(index < self.count);
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for reading.
         unsafe { self.buffer.add(position & self.buffer_mask).read() }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -113,10 +113,15 @@ impl<T> Producer<T> {
             None => return Err(items),
         };
 
+        let mut written = 0;
         for (index, item) in items.enumerate() {
+            debug_assert!(index < guard.count);
             // SAFETY: index is not out of bounds
             unsafe { guard.write(index, item) };
+            written = index + 1;
         }
+        debug_assert_eq!(written, guard.count);
+
         Ok(())
     }
 


### PR DESCRIPTION
### Problem
- Write(Batch|Guard) allows using as a ptr or mutable reference
- Read(Batch|Guard) do not have a similar as_ref

### Changes
- Add as_ref to ReadBatch and ReadGuard 