### PR TITLE
feat: MAJOR + PATCH versions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 #[derive(Debug)]
 pub enum Error {
-    InvalidVersion,
+    InvalidVersion { expected: u16, actual: u16 },
     InvalidBufferSize,
     Io(std::io::Error),
     Mmap(std::io::Error),
@@ -13,7 +13,14 @@ impl std::error::Error for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidVersion => write!(f, "invalid version"),
+            Self::InvalidVersion { expected, actual } => write!(
+                f,
+                "invalid version; expected={}.{}; found={}.{}",
+                expected >> 8,
+                expected & 0xFF,
+                actual >> 8,
+                actual & 0xFF,
+            ),
             Self::InvalidBufferSize => write!(f, "invalid buffer size"),
             Self::Io(err) => write!(f, "io; err={err}"),
             Self::Mmap(err) => write!(f, "mmap; err={err}"),
@@ -24,5 +31,18 @@ impl Display for Error {
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         Self::Io(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_version_display() {
+        let expected: u16 = 1u16 << 8; // 1.0
+        let actual: u16 = (3u16 << 8) | 7; // 3.7
+        let err = Error::InvalidVersion { expected, actual };
+        assert_eq!(err.to_string(), "invalid version; expected=1.0; found=3.7");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ pub mod mpmc;
 mod shmem;
 pub mod spsc;
 
-pub(crate) const VERSION: u8 = 1;
+pub(crate) const VERSION_MAJOR: u8 = 1;
+pub(crate) const VERSION_PATCH: u8 = 0;
+pub(crate) const VERSION: u16 = (VERSION_MAJOR as u16) << 8 | VERSION_PATCH as u16;
 
 /// `AtomicUsize` with 64-byte alignment for better performance.
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod mpmc;
 mod shmem;
 pub mod spsc;
 
-pub(crate) const VERSION_MAJOR: u8 = 1;
+pub(crate) const VERSION_MAJOR: u8 = 2;
 pub(crate) const VERSION_PATCH: u8 = 0;
 pub(crate) const VERSION: u16 = (VERSION_MAJOR as u16) << 8 | VERSION_PATCH as u16;
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -8,7 +8,7 @@ use crate::{
 use core::{
     marker::PhantomData,
     ptr::NonNull,
-    sync::atomic::{AtomicU8, Ordering},
+    sync::atomic::{AtomicU16, Ordering},
 };
 use std::fs::File;
 
@@ -477,7 +477,7 @@ struct SharedQueueHeader {
     /// Producers use it to determine how much free space is available.
     consumer_release: CacheAlignedAtomicSize,
     buffer_mask: usize,
-    version: AtomicU8,
+    version: AtomicU16,
 }
 
 impl SharedQueueHeader {
@@ -548,8 +548,12 @@ impl SharedQueueHeader {
             //         memory is aligned to the page size, which is sufficient for the
             //         alignment of `SharedQueueHeader`.
             let header = unsafe { header.as_ref() };
-            if header.version.load(Ordering::SeqCst) != VERSION {
-                return Err(Error::InvalidVersion);
+            let actual_version = header.version.load(Ordering::SeqCst);
+            if actual_version != VERSION {
+                return Err(Error::InvalidVersion {
+                    expected: VERSION,
+                    actual: actual_version,
+                });
             }
             let buffer_size_in_items = header.buffer_mask.wrapping_add(1);
             if buffer_size_in_items != Self::calculate_buffer_size_in_items::<T>(file_size)? {

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -6,7 +6,7 @@ use crate::{
 use core::ptr::NonNull;
 use std::{
     fs::File,
-    sync::atomic::{AtomicU8, Ordering},
+    sync::atomic::{AtomicU16, Ordering},
 };
 
 /// Calculates the minimum file size required for a queue with given capacity.
@@ -366,7 +366,7 @@ struct SharedQueueHeader {
     write: CacheAlignedAtomicSize,
     read: CacheAlignedAtomicSize,
     buffer_size: usize,
-    version: AtomicU8,
+    version: AtomicU16,
 }
 
 impl SharedQueueHeader {
@@ -437,8 +437,12 @@ impl SharedQueueHeader {
             //         memory is aligned to the page size, which is sufficient for the
             //         alignment of `SharedQueueHeader`.
             let header = unsafe { header.as_ref() };
-            if header.version.load(Ordering::SeqCst) != VERSION {
-                return Err(Error::InvalidVersion);
+            let actual_version = header.version.load(Ordering::SeqCst);
+            if actual_version != VERSION {
+                return Err(Error::InvalidVersion {
+                    expected: VERSION,
+                    actual: actual_version,
+                });
             }
             if header.buffer_size != Self::calculate_buffer_size_in_items::<T>(file_size)? {
                 return Err(Error::InvalidBufferSize);


### PR DESCRIPTION
## Problem

- Sometimes we want to break the binary format to fix a bug in an old release. However, we can't simply increment the major because that would collide with new majors.

## Solution

- Extend the version field from u8 -> u16 and store and additional PATCH version that can be incremented separately.
- Still requires exact match so two users of the same MAJOR version with different PATCH versions will refuse to connect.