### PR TITLE
fix: guard against `buffer_mask` overflowing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 use core::sync::atomic::AtomicUsize;
 
+// NB: To simplify casting we only support 64bit or wider systems.
+const _: () = assert!(size_of::<usize>() >= size_of::<u64>());
+
 pub mod error;
 pub mod mpmc;
 mod shmem;

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -553,6 +553,11 @@ impl SharedQueueHeader {
             }
         }
 
+        // The buffer mask is stored as u32, so the capacity must fit.
+        if buffer_size_in_items > u32::MAX as usize + 1 {
+            return Err(Error::InvalidBufferSize);
+        }
+
         Ok(buffer_size_in_items)
     }
 
@@ -571,7 +576,7 @@ impl SharedQueueHeader {
         header.producer_publication.store(0, Ordering::Release);
         header.consumer_reservation.store(0, Ordering::Release);
         header.consumer_release.store(0, Ordering::Release);
-        header.buffer_mask = (buffer_size_in_items - 1) as u32;
+        header.buffer_mask = u32::try_from(buffer_size_in_items - 1).unwrap();
         header.version = VERSION;
         header.magic.store(MAGIC, Ordering::Release);
     }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -423,6 +423,11 @@ impl SharedQueueHeader {
             }
         }
 
+        // The buffer mask is stored as u32, so the capacity must fit.
+        if buffer_size_in_items > u32::MAX as usize + 1 {
+            return Err(Error::InvalidBufferSize);
+        }
+
         Ok(buffer_size_in_items)
     }
 
@@ -439,7 +444,7 @@ impl SharedQueueHeader {
         let header = unsafe { header.as_mut() };
         header.write.store(0, Ordering::Release);
         header.read.store(0, Ordering::Release);
-        header.buffer_mask = (buffer_size_in_items - 1) as u32;
+        header.buffer_mask = u32::try_from(buffer_size_in_items - 1).unwrap();
         header.version = VERSION;
         header.magic.store(MAGIC, Ordering::Release);
     }


### PR DESCRIPTION
## Problem

- With a small `T` it's theoretically possible to create a queue with > u32::MAX elements, this would cause the stored buffer_mask to overflow leading to exciting behaviors.

## Solution

- Validate that the queue length is not > u32::MAX - 1 (mask is stored as length - 1).
- Only allow compilation on 64bit or wider architectures to simplify reasoning about casts.