### PR TITLE
Reject ZST

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -539,6 +539,13 @@ impl SharedQueueHeader {
     }
 
     const fn calculate_buffer_size_in_items<T: Sized>(file_size: usize) -> Result<usize, Error> {
+        const {
+            assert!(
+                core::mem::size_of::<T>() > 0,
+                "zero-sized types are not supported"
+            )
+        }
+
         let buffer_offset = Self::buffer_offset::<T>();
         if file_size < buffer_offset {
             return Err(Error::InvalidBufferSize);

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -409,6 +409,13 @@ impl SharedQueueHeader {
     }
 
     const fn calculate_buffer_size_in_items<T: Sized>(file_size: usize) -> Result<usize, Error> {
+        const {
+            assert!(
+                core::mem::size_of::<T>() > 0,
+                "zero-sized types are not supported"
+            )
+        }
+
         let buffer_offset = Self::buffer_offset::<T>();
         if file_size < buffer_offset {
             return Err(Error::InvalidBufferSize);


### PR DESCRIPTION
### Problem
- ZST will currently cause a panic

### Changes
- Just reject them with an compile-time error instead of panicking