### PR TITLE
style: use string literal for magic

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -9,7 +9,8 @@ use std::{
     sync::{atomic::AtomicU64, Arc},
 };
 
-const MAGIC: u64 = 0x7368_6171_6d70_6d63; // b"shaqmpmc"
+/// Unique identifier for MPMC queue in shared memory.
+const MAGIC: u64 = u64::from_be_bytes(*b"shaqmpmc");
 
 pub struct Producer<T> {
     queue: SharedQueue<T>,

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -10,7 +10,8 @@ use std::{
     },
 };
 
-const MAGIC: u64 = 0x7368_6171_7370_7363; // b"shaqspsc"
+/// Unique identifier for SPSC queue in shared memory.
+const MAGIC: u64 = u64::from_be_bytes(*b"shaqspsc");
 
 /// Calculates the minimum file size required for a queue with given capacity.
 /// Note that file size MAY need to be increased beyond this to account for


### PR DESCRIPTION
## Problem

- Constant used magical number.

## Solution

- Cast from string to magical number.