### PR TITLE
Add broadcast

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -492,9 +492,7 @@ fn run_broadcast_producer(
         };
         for index in 0..batch.len() {
             // SAFETY: `index < len`; the reserved cell is ours to initialize.
-            unsafe {
-                (*batch.as_mut_ref(index)).assume_init_mut().data.fill(42);
-            }
+            unsafe { batch.as_mut_ref(index).write(Item { data: [42; 512] }) };
         }
         Some(batch.len())
     });

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -493,7 +493,7 @@ fn run_broadcast_producer(
         for index in 0..batch.len() {
             // SAFETY: `index < len`; the reserved cell is ours to initialize.
             unsafe {
-                (*batch.as_mut_ptr(index)).data.fill(42);
+                (*batch.as_mut_ref(index)).assume_init_mut().data.fill(42);
             }
         }
         Some(batch.len())

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -6,6 +6,7 @@ use common::{
     run_total_throughput_loop, setup_exit_handler, Item, SYNC_CADENCE,
 };
 use shaq::{
+    broadcast::{BroadcastConfig, Consumer as BroadcastConsumer, Producer as BroadcastProducer},
     error::WaitError,
     mpmc::{Consumer as MpmcConsumer, Producer as MpmcProducer},
     spsc::{Consumer as SpscConsumer, Producer as SpscProducer},
@@ -20,9 +21,14 @@ use std::{
 
 const QUEUE_SIZE: usize = 16 * 1024 * 1024;
 
+/// Per-lane ring capacity (in items) for the broadcast queue; each producer
+/// gets its own ring of this size.
+const BROADCAST_CAPACITY: usize = 16 * 1024;
+
 enum Mode {
     Spsc,
     Mpmc { producers: usize, consumers: usize },
+    Broadcast { producers: usize, consumers: usize },
 }
 
 struct Config {
@@ -38,6 +44,10 @@ fn main() {
             producers,
             consumers,
         } => run_mpmc(producers, consumers, config.verbose),
+        Mode::Broadcast {
+            producers,
+            consumers,
+        } => run_broadcast(producers, consumers, config.verbose),
     }
 }
 
@@ -80,6 +90,19 @@ fn parse_config_or_exit() -> Config {
                 consumers,
             }
         }
+        Some("broadcast") => {
+            let producers = parse_usize_arg(positional.get(1).cloned(), 2, "producers");
+            let consumers = parse_usize_arg(positional.get(2).cloned(), 2, "consumers");
+            if positional.len() > 3 {
+                eprintln!("Too many arguments for broadcast mode");
+                print_usage();
+                std::process::exit(2);
+            }
+            Mode::Broadcast {
+                producers,
+                consumers,
+            }
+        }
         Some(mode) => {
             eprintln!("Unknown mode: {mode}");
             print_usage();
@@ -103,7 +126,7 @@ fn parse_usize_arg(value: Option<String>, default: usize, name: &str) -> usize {
 
 fn print_usage() {
     eprintln!(
-        "Usage: cargo run --example enqueue_dequeue -- [-v|--verbose] [spsc|mpmc [producers] [consumers]]"
+        "Usage: cargo run --example enqueue_dequeue -- [-v|--verbose] [spsc|mpmc [producers] [consumers]|broadcast [producers] [consumers]]"
     );
 }
 
@@ -345,6 +368,139 @@ fn run_mpmc_producer(
 
 fn run_mpmc_consumer(
     consumer: Arc<MpmcConsumer<Item>>,
+    exit: Arc<AtomicBool>,
+    consumer_reserve_failures: Arc<AtomicU64>,
+) {
+    let wait_timeout = Duration::from_millis(10);
+    run_consumer_loop(exit, move || {
+        let batch = match consumer.reserve_read_batch_timeout(SYNC_CADENCE, wait_timeout) {
+            Ok(batch) => batch,
+            Err(WaitError::Timeout) => {
+                consumer_reserve_failures.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+        let _ = batch.len();
+    });
+}
+
+fn run_broadcast(producers: usize, consumers: usize, verbose: bool) {
+    // Every consumer sees every producer's items, so reuse the mpmc core layout.
+    let (consumer_cores, producer_cores) = mpmc_core_ids(consumers, producers);
+    let exit = setup_exit_handler();
+    let queue_path = "/tmp/shaq_broadcast";
+    let queue_file = prepare_queue_file(queue_path);
+    let total_items_produced = Arc::new(AtomicU64::new(0));
+    let producer_reserve_failures = Arc::new(AtomicU64::new(0));
+    let consumer_reserve_failures = Arc::new(AtomicU64::new(0));
+
+    // SAFETY: This thread uniquely creates the queue. The handle is dropped
+    // immediately, freeing its lane for the producer threads to claim.
+    unsafe {
+        let _ = BroadcastProducer::<Item>::create(
+            &queue_file,
+            BroadcastConfig {
+                capacity: BROADCAST_CAPACITY,
+                producer_slots: producers,
+                consumer_slots: consumers,
+            },
+        )
+        .unwrap();
+    }
+
+    let mut handles = Vec::new();
+
+    for (idx, core_id) in consumer_cores.into_iter().enumerate() {
+        let exit = exit.clone();
+        let consumer_file = queue_file.try_clone().unwrap();
+        let consumer_reserve_failures = consumer_reserve_failures.clone();
+        handles.push(
+            std::thread::Builder::new()
+                .name(format!("shaqBroadcastConsumer{idx}"))
+                .spawn(move || {
+                    if let Some(core_id) = core_id {
+                        println!("Consumer {idx} core id: {}", core_id.id);
+                        core_affinity::set_for_current(core_id);
+                    }
+
+                    // SAFETY: the queue is created above; each thread joins a
+                    // unique consumer index.
+                    let consumer =
+                        unsafe { BroadcastConsumer::<Item>::join(&consumer_file) }.unwrap();
+                    run_broadcast_consumer(consumer, exit, consumer_reserve_failures);
+                })
+                .unwrap(),
+        );
+    }
+
+    for (idx, core_id) in producer_cores.into_iter().enumerate() {
+        let exit = exit.clone();
+        let producer_file = queue_file.try_clone().unwrap();
+        let report_prefix = verbose.then(|| format!("Producer {idx}"));
+        let total_items_produced = total_items_produced.clone();
+        let producer_reserve_failures = producer_reserve_failures.clone();
+        handles.push(
+            std::thread::Builder::new()
+                .name(format!("shaqBroadcastProducer{idx}"))
+                .spawn(move || {
+                    if let Some(core_id) = core_id {
+                        println!("Producer {idx} core id: {}", core_id.id);
+                        core_affinity::set_for_current(core_id);
+                    }
+
+                    // SAFETY: the queue is created above; each thread joins a
+                    // unique lane.
+                    let producer =
+                        unsafe { BroadcastProducer::<Item>::join(&producer_file) }.unwrap();
+                    run_broadcast_producer(
+                        producer,
+                        exit,
+                        report_prefix,
+                        total_items_produced,
+                        producer_reserve_failures,
+                    );
+                })
+                .unwrap(),
+        );
+    }
+
+    run_total_throughput_loop::<Item>(
+        exit.clone(),
+        total_items_produced,
+        producer_reserve_failures,
+        consumer_reserve_failures,
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    cleanup_queue_file(queue_path);
+}
+
+fn run_broadcast_producer(
+    mut producer: BroadcastProducer<Item>,
+    exit: Arc<AtomicBool>,
+    report_prefix: Option<String>,
+    total_items_produced: Arc<AtomicU64>,
+    producer_reserve_failures: Arc<AtomicU64>,
+) {
+    run_producer_loop::<Item, _>(exit, report_prefix, total_items_produced, move || {
+        let Some(mut batch) = producer.reserve_write_batch(SYNC_CADENCE) else {
+            producer_reserve_failures.fetch_add(1, Ordering::Relaxed);
+            return None;
+        };
+        for index in 0..batch.len() {
+            // SAFETY: `index < len`; the reserved cell is ours to initialize.
+            unsafe {
+                (*batch.as_mut_ptr(index)).data.fill(42);
+            }
+        }
+        Some(batch.len())
+    });
+}
+
+fn run_broadcast_consumer(
+    mut consumer: BroadcastConsumer<Item>,
     exit: Arc<AtomicBool>,
     consumer_reserve_failures: Arc<AtomicU64>,
 ) {

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -486,7 +486,7 @@ fn run_broadcast_producer(
 ) {
     run_producer_loop::<Item, _>(exit, report_prefix, total_items_produced, move || {
         // SAFETY: every reserved slot is initialized before `batch` is dropped.
-        let Some(mut batch) = (unsafe { producer.reserve_write_batch(SYNC_CADENCE) }) else {
+        let Some(mut batch) = (unsafe { producer.try_reserve_write_batch(SYNC_CADENCE) }) else {
             producer_reserve_failures.fetch_add(1, Ordering::Relaxed);
             return None;
         };

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -485,7 +485,8 @@ fn run_broadcast_producer(
     producer_reserve_failures: Arc<AtomicU64>,
 ) {
     run_producer_loop::<Item, _>(exit, report_prefix, total_items_produced, move || {
-        let Some(mut batch) = producer.reserve_write_batch(SYNC_CADENCE) else {
+        // SAFETY: every reserved slot is initialized before `batch` is dropped.
+        let Some(mut batch) = (unsafe { producer.reserve_write_batch(SYNC_CADENCE) }) else {
             producer_reserve_failures.fetch_add(1, Ordering::Relaxed);
             return None;
         };

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -522,6 +522,7 @@ impl<T> Producer<T> {
     /// Writes items from a slice into this producer's lane.
     ///
     /// Returns `false` if there is not enough space.
+    #[must_use]
     pub fn try_write_slice(&mut self, items: &[T]) -> bool
     where
         T: Copy,

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,7 +1,579 @@
 //! Multi-producer / multi-consumer broadcast queue.
 //!
 //! Each producer owns a [`producer_lane::ProducerLane`]; every consumer reads
-//! every lane. The producer/consumer handles and the shared region wiring land
-//! in later commits.
+//! every lane. This module wires the shared region (header + global consumer
+//! ownership + producer-lane blocks) and the [`Producer`] handle.
+
+// Some of this (e.g. the global consumer-ownership table, used by the consumer
+// side) has no non-test callers, so dead-code warnings are silenced.
+#![allow(dead_code)]
 
 mod producer_lane;
+
+use core::marker::PhantomData;
+use core::mem::{align_of, size_of};
+use core::num::NonZeroUsize;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicU64, Ordering};
+use std::fs::File;
+use std::sync::Arc;
+
+use crate::error::Error;
+use crate::shmem::Region;
+use crate::{normalized_capacity, VERSION};
+
+use producer_lane::ProducerLane;
+
+const MAGIC: u64 = u64::from_be_bytes(*b"shaqcast");
+
+/// Consumer-index ownership states for the global `consumer_state` table, read
+/// and written by the consumer side.
+const CONSUMER_FREE: u64 = 0;
+const CONSUMER_ACTIVE: u64 = 1;
+
+/// Runtime configuration for a broadcast queue.
+///
+/// `capacity` is the per-lane ring capacity (rounded up to a power of two);
+/// `producer_slots` / `consumer_slots` bound the lanes / consumers.
+pub struct BroadcastConfig {
+    pub capacity: usize,
+    pub producer_slots: usize,
+    pub consumer_slots: usize,
+}
+
+/// Shared header at the start of the region. The producer-lane cursors and the
+/// per-consumer reserve limits live in the lane blocks; only consumer-index
+/// ownership is global (the `consumer_state` table after this header).
+#[repr(C)]
+struct SharedQueueHeader {
+    magic: AtomicU64,
+    version: u32,
+    capacity: u32, // per-lane ring capacity (power of two)
+    producer_slots: u32,
+    consumer_slots: u32,
+}
+
+/// Byte offsets and sizes of the region's sections (a construction-time helper;
+/// `SharedQueue` keeps only the runtime scalars from it).
+struct Layout {
+    capacity: u32,
+    producer_slots: usize,
+    consumer_slots: usize,
+    consumer_state_offset: usize,
+    producer_blocks_offset: usize,
+    block_stride: usize,
+    total: usize,
+}
+
+impl Layout {
+    fn new<T>(config: &BroadcastConfig) -> Option<Self> {
+        let capacity = normalized_capacity(config.capacity);
+        if capacity == 0 || capacity > u32::MAX as usize {
+            return None;
+        }
+        if config.producer_slots == 0
+            || config.producer_slots > u32::MAX as usize
+            || config.consumer_slots == 0
+            || config.consumer_slots > u32::MAX as usize
+        {
+            return None;
+        }
+        let capacity = capacity as u32;
+
+        let consumer_state_offset =
+            size_of::<SharedQueueHeader>().next_multiple_of(align_of::<AtomicU64>());
+        let consumer_state_bytes = config.consumer_slots.checked_mul(size_of::<AtomicU64>())?;
+
+        let block_align = ProducerLane::<T>::block_align();
+        let producer_blocks_offset = consumer_state_offset
+            .checked_add(consumer_state_bytes)?
+            .checked_next_multiple_of(block_align)?;
+        let block_stride = ProducerLane::<T>::block_size(capacity, config.consumer_slots)
+            .next_multiple_of(block_align);
+        let producer_blocks_bytes = block_stride.checked_mul(config.producer_slots)?;
+        let total = producer_blocks_offset.checked_add(producer_blocks_bytes)?;
+
+        Some(Self {
+            capacity,
+            producer_slots: config.producer_slots,
+            consumer_slots: config.consumer_slots,
+            consumer_state_offset,
+            producer_blocks_offset,
+            block_stride,
+            total,
+        })
+    }
+
+    /// Reconstructs and validates the layout from an initialized header.
+    fn from_header<T>(header: &SharedQueueHeader, region_size: usize) -> Result<Self, Error> {
+        let capacity = header.capacity as usize;
+        let config = BroadcastConfig {
+            capacity,
+            producer_slots: header.producer_slots as usize,
+            consumer_slots: header.consumer_slots as usize,
+        };
+        // `capacity` is already a power of two; `normalized_capacity` is a no-op,
+        // so the recomputed layout must match the stored capacity exactly.
+        let layout = Layout::new::<T>(&config).ok_or(Error::InvalidBufferSize)?;
+        if layout.capacity as usize != capacity || region_size < layout.total {
+            return Err(Error::InvalidBufferSize);
+        }
+        Ok(layout)
+    }
+}
+
+/// A handle onto the shared region: the header plus the section base pointers.
+/// Cloneable — every producer/consumer shares one mapping.
+struct SharedQueue<T> {
+    region: Arc<Region>,
+    header: NonNull<SharedQueueHeader>,
+    consumer_state: NonNull<AtomicU64>,
+    producer_blocks: NonNull<u8>,
+    // Runtime scalars (the layout offsets are construction-only, so not kept).
+    capacity: u32,
+    producer_slots: usize,
+    consumer_slots: usize,
+    block_stride: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T> SharedQueue<T> {
+    /// Initializes a broadcast region and returns a handle.
+    ///
+    /// # Safety
+    /// - `region` must be initialized as a broadcast queue at most once.
+    unsafe fn create_in_region(
+        region: &Arc<Region>,
+        config: &BroadcastConfig,
+    ) -> Result<Self, Error> {
+        let layout = Layout::new::<T>(config).ok_or(Error::InvalidBufferSize)?;
+        if region.size() < layout.total {
+            return Err(Error::InvalidBufferSize);
+        }
+        // SAFETY: region is large enough and (per the contract) initialized once.
+        unsafe { Self::initialize(region, &layout) };
+        Ok(Self::from_region(Arc::clone(region), layout))
+    }
+
+    /// Validates an initialized broadcast region and returns a handle.
+    ///
+    /// # Safety
+    /// - `region` must reference memory laid out by [`Self::create_in_region`].
+    unsafe fn join_region(region: &Arc<Region>) -> Result<Self, Error> {
+        let header = region.addr().cast::<SharedQueueHeader>();
+        // SAFETY: regions are page-aligned (>= align_of::<SharedQueueHeader>()).
+        let header_ref = unsafe { header.as_ref() };
+        if header_ref.magic.load(Ordering::Acquire) != MAGIC {
+            return Err(Error::InvalidMagic);
+        }
+        if header_ref.version != VERSION {
+            return Err(Error::InvalidVersion {
+                expected: VERSION,
+                actual: header_ref.version,
+            });
+        }
+        let layout = Layout::from_header::<T>(header_ref, region.size())?;
+        Ok(Self::from_region(Arc::clone(region), layout))
+    }
+
+    /// # Safety
+    /// - `region` must be at least `layout.total` bytes and initialized once.
+    unsafe fn initialize(region: &Arc<Region>, layout: &Layout) {
+        let base = region.addr();
+        // SAFETY: regions are page-aligned and large enough for the header.
+        let header = unsafe { &mut *base.cast::<SharedQueueHeader>().as_ptr() };
+        header.version = VERSION;
+        header.capacity = layout.capacity;
+        header.producer_slots = layout.producer_slots as u32;
+        header.consumer_slots = layout.consumer_slots as u32;
+
+        // Global consumer-ownership table: every index free.
+        // SAFETY: the layout reserves `consumer_slots` AtomicU64s here.
+        let consumer_state = unsafe {
+            base.byte_add(layout.consumer_state_offset)
+                .cast::<AtomicU64>()
+        };
+        for index in 0..layout.consumer_slots {
+            // SAFETY: `index < consumer_slots`.
+            unsafe {
+                consumer_state
+                    .add(index)
+                    .as_ptr()
+                    .write(AtomicU64::new(CONSUMER_FREE))
+            };
+        }
+
+        // Producer-lane blocks.
+        // SAFETY: the layout reserves `producer_slots` blocks of `block_stride`.
+        let producer_blocks = unsafe { base.byte_add(layout.producer_blocks_offset) };
+        for lane in 0..layout.producer_slots {
+            // SAFETY: `lane < producer_slots`; blocks are `block_stride` apart.
+            let block = unsafe { producer_blocks.byte_add(lane.wrapping_mul(layout.block_stride)) };
+            // SAFETY: the block is sized for `(capacity, consumer_slots)`.
+            unsafe { ProducerLane::<T>::init(block, layout.consumer_slots) };
+        }
+
+        // Publish initialization last.
+        header.magic.store(MAGIC, Ordering::Release);
+    }
+
+    fn from_region(region: Arc<Region>, layout: Layout) -> Self {
+        let base = region.addr();
+        let header = base.cast::<SharedQueueHeader>();
+        // SAFETY: offsets lie within the region.
+        let consumer_state = unsafe { base.byte_add(layout.consumer_state_offset).cast() };
+        // SAFETY: offsets lie within the region.
+        let producer_blocks = unsafe { base.byte_add(layout.producer_blocks_offset) };
+        Self {
+            region,
+            header,
+            consumer_state,
+            producer_blocks,
+            capacity: layout.capacity,
+            producer_slots: layout.producer_slots,
+            consumer_slots: layout.consumer_slots,
+            block_stride: layout.block_stride,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn producer_slots(&self) -> usize {
+        self.producer_slots
+    }
+
+    /// A view over producer lane `lane`.
+    fn lane(&self, lane: usize) -> ProducerLane<T> {
+        debug_assert!(lane < self.producer_slots);
+        // SAFETY: `lane < producer_slots`; blocks are `block_stride` apart.
+        let block = unsafe {
+            self.producer_blocks
+                .byte_add(lane.wrapping_mul(self.block_stride))
+        };
+        // SAFETY: the block was initialized with these parameters.
+        unsafe { ProducerLane::from_block(block, self.capacity, self.consumer_slots) }
+    }
+
+    /// Claims a free producer lane, returning its index.
+    fn acquire_producer_lane(&self) -> Result<usize, Error> {
+        for lane in 0..self.producer_slots {
+            if self.lane(lane).try_acquire() {
+                return Ok(lane);
+            }
+        }
+        Err(Error::ProducerSlotsExhausted)
+    }
+}
+
+impl<T> Clone for SharedQueue<T> {
+    fn clone(&self) -> Self {
+        Self {
+            region: Arc::clone(&self.region),
+            header: self.header,
+            consumer_state: self.consumer_state,
+            producer_blocks: self.producer_blocks,
+            capacity: self.capacity,
+            producer_slots: self.producer_slots,
+            consumer_slots: self.consumer_slots,
+            block_stride: self.block_stride,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// SAFETY: the region is shared (file-backed / heap) and access is synchronized
+// by the queue protocol; the pointers are stable for the region's lifetime.
+unsafe impl<T: Send> Send for SharedQueue<T> {}
+unsafe impl<T: Send> Sync for SharedQueue<T> {}
+
+/// A producer: owns one lane and publishes into it. Single-threaded use (its
+/// write ops take `&mut self`); move it between threads to hand off ownership.
+///
+/// Holds the lane view directly (stable for the producer's lifetime); the
+/// `queue` is kept for `try_clone` and to keep the region mapping alive.
+pub struct Producer<T> {
+    queue: SharedQueue<T>,
+    lane: ProducerLane<T>,
+}
+
+impl<T> Producer<T> {
+    /// Creates a broadcast queue in `file` and joins as a producer.
+    ///
+    /// # Safety
+    /// - `file` must be initialized as a broadcast queue exactly once (by the
+    ///   designated initializer), and not resized while any handle is joined.
+    /// - All producers/consumers for `file` must use the same `T`; queued values
+    ///   must be valid to read/overwrite as shared-memory bytes in each process.
+    pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
+        let layout = Layout::new::<T>(&config).ok_or(Error::InvalidBufferSize)?;
+        file.set_len(layout.total as u64)?;
+        let region = Region::map_file(file, layout.total)?;
+        // SAFETY: caller guarantees this mapping is initialized exactly once.
+        let queue = unsafe { SharedQueue::create_in_region(&region, &config) }?;
+        Self::from_queue(queue)
+    }
+
+    /// Joins an existing broadcast queue in `file` as a producer.
+    ///
+    /// # Safety
+    /// - `file` must refer to a live broadcast queue (not resized while joined),
+    ///   with the same `T` as every other handle (see [`Self::create`]).
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
+        let file_size = file.metadata()?.len() as usize;
+        let region = Region::map_file(file, file_size)?;
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join_region(&region) }?;
+        Self::from_queue(queue)
+    }
+
+    fn from_queue(queue: SharedQueue<T>) -> Result<Self, Error> {
+        let index = queue.acquire_producer_lane()?;
+        let lane = queue.lane(index);
+        Ok(Self { queue, lane })
+    }
+
+    /// Claims another free lane on the same queue.
+    pub fn try_clone(&self) -> Result<Self, Error> {
+        Self::from_queue(self.queue.clone())
+    }
+
+    /// Publishes one value, or returns it on backpressure (the slowest consumer
+    /// has not freed the cell that publishing would overwrite).
+    pub fn try_write(&mut self, value: T) -> Result<(), T> {
+        let Some(start) = self.lane.reserve(NonZeroUsize::MIN) else {
+            return Err(value);
+        };
+        // SAFETY: the cell is reserved and not yet published; `T` is moved in.
+        unsafe { self.lane.payload_ptr(start).as_ptr().write(value) };
+        self.lane.publish(start, NonZeroUsize::MIN);
+        Ok(())
+    }
+
+    /// Reserves `count` consecutive cells for in-place writes, or `None` on
+    /// backpressure. The cells become visible when the returned batch is dropped;
+    /// the caller must write all of them first.
+    #[must_use]
+    pub fn reserve_write_batch(&mut self, count: NonZeroUsize) -> Option<WriteBatch<'_, T>> {
+        let start = self.lane.reserve(count)?;
+        Some(WriteBatch {
+            producer: self,
+            start,
+            count,
+        })
+    }
+}
+
+impl<T> Drop for Producer<T> {
+    fn drop(&mut self) {
+        self.lane.release();
+    }
+}
+
+// SAFETY: a producer is single-threaded (write ops take `&mut self`) but may be
+// moved between threads.
+unsafe impl<T: Send> Send for Producer<T> {}
+
+/// A reservation of `count` cells in a producer's lane. Write every cell via
+/// [`Self::write`]/[`Self::as_mut_ptr`], then drop the batch to publish them.
+#[must_use]
+pub struct WriteBatch<'a, T> {
+    producer: &'a mut Producer<T>,
+    start: usize,
+    count: NonZeroUsize,
+}
+
+impl<T> WriteBatch<'_, T> {
+    pub fn len(&self) -> usize {
+        self.count.get()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Pointer to the reserved cell at `index`.
+    ///
+    /// # Safety
+    /// - `index < len`; the cell is uninitialized and the caller must fully
+    ///   initialize `T` before the batch is dropped.
+    pub unsafe fn as_mut_ptr(&mut self, index: usize) -> *mut T {
+        debug_assert!(index < self.count.get());
+        self.producer
+            .lane
+            .payload_ptr(self.start.wrapping_add(index))
+            .as_ptr()
+    }
+
+    /// Writes `value` into the reserved cell at `index`.
+    ///
+    /// # Safety
+    /// - `index < len`.
+    pub unsafe fn write(&mut self, index: usize, value: T) {
+        // SAFETY: forwarded; `index < len` and the cell is reserved.
+        unsafe { self.as_mut_ptr(index).write(value) };
+    }
+}
+
+impl<T> Drop for WriteBatch<'_, T> {
+    fn drop(&mut self) {
+        self.producer.lane.publish(self.start, self.count);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(not(miri))]
+    use crate::shmem::create_temp_shmem_file;
+
+    type Payload = u64;
+    type CreateProducer = fn(BroadcastConfig) -> Producer<Payload>;
+
+    /// In-process (heap-backed) producer. The `Producer` keeps the region alive
+    /// via its `SharedQueue`'s `Arc<Region>`.
+    fn create_heap_producer(config: BroadcastConfig) -> Producer<Payload> {
+        let size = Layout::new::<Payload>(&config).expect("layout").total;
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
+        // SAFETY: freshly allocated region, initialized exactly once here.
+        let queue = unsafe { SharedQueue::<Payload>::create_in_region(&region, &config) }.unwrap();
+        Producer::from_queue(queue).unwrap()
+    }
+
+    /// File-backed producer (mmap). Not run under miri (no mmap).
+    #[cfg(not(miri))]
+    fn create_file_backed_producer(config: BroadcastConfig) -> Producer<Payload> {
+        let file = create_temp_shmem_file().expect("temp file");
+        // SAFETY: a fresh temp file, initialized exactly once here.
+        unsafe { Producer::create(&file, config) }.expect("create")
+    }
+
+    /// Every behavioral test runs against both backings (heap always; file-backed
+    /// when not under miri), matching the other queues.
+    fn producer_creators() -> &'static [CreateProducer] {
+        &[
+            create_heap_producer,
+            #[cfg(not(miri))]
+            create_file_backed_producer,
+        ]
+    }
+
+    /// Reads a published payload from `lane` at `sequence` (test-only).
+    /// Reads a published payload from the producer's own lane (test-only).
+    fn read(producer: &Producer<Payload>, sequence: usize) -> Payload {
+        // SAFETY: `sequence` was published on this lane, so the cell is initialized.
+        unsafe { producer.lane.payload_ptr(sequence).as_ptr().read() }
+    }
+
+    #[test]
+    fn clones_until_lanes_exhausted() {
+        for create in producer_creators() {
+            let p0 = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 2,
+                consumer_slots: 1,
+            });
+            // Two lanes total: the original plus one clone exhausts them.
+            let p1 = p0.try_clone().unwrap();
+            assert!(matches!(p0.try_clone(), Err(Error::ProducerSlotsExhausted)));
+            drop(p1);
+            // The freed lane can be reclaimed.
+            assert!(p0.try_clone().is_ok());
+        }
+    }
+
+    #[test]
+    fn try_write_publishes() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            for value in 0..5u64 {
+                assert!(p.try_write(value * 10).is_ok());
+            }
+            for sequence in 0..5usize {
+                assert_eq!(read(&p, sequence), sequence as u64 * 10);
+            }
+        }
+    }
+
+    #[test]
+    fn write_batch_publishes_on_drop() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            {
+                let mut batch = p
+                    .reserve_write_batch(NonZeroUsize::new(3).unwrap())
+                    .unwrap();
+                assert_eq!(batch.len(), 3);
+                for index in 0..3usize {
+                    // SAFETY: index < len.
+                    unsafe { batch.write(index, (index as u64) + 1) };
+                }
+            }
+            for sequence in 0..3usize {
+                assert_eq!(read(&p, sequence), sequence as u64 + 1);
+            }
+        }
+    }
+
+    #[test]
+    fn backpressure_without_consumers_is_only_capacity() {
+        // No consumers: the producer overwrites freely past one revolution.
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            for value in 0..16u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+        }
+    }
+
+    /// File-backed create then join a second producer (exercises `Producer::join`).
+    #[cfg(not(miri))]
+    #[test]
+    fn file_backed_join_acquires_a_second_lane() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 2,
+            consumer_slots: 1,
+        };
+        let file = create_temp_shmem_file().expect("temp file");
+        // SAFETY: fresh file, initialized once by `create`.
+        let _p0 = unsafe { Producer::<Payload>::create(&file, config) }.unwrap();
+        // SAFETY: same live queue, same `T`.
+        let _p1 = unsafe { Producer::<Payload>::join(&file) }.unwrap();
+        // Both lanes are held now; a third join is refused.
+        // SAFETY: same live queue, same `T`.
+        let third = unsafe { Producer::<Payload>::join(&file) };
+        assert!(matches!(third, Err(Error::ProducerSlotsExhausted)));
+    }
+
+    #[test]
+    fn join_validates_magic_and_version() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let size = Layout::new::<Payload>(&config).unwrap().total;
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
+        // SAFETY: fresh region, initialized once.
+        let _queue = unsafe { SharedQueue::<Payload>::create_in_region(&region, &config) }.unwrap();
+        // SAFETY: initialized above.
+        assert!(unsafe { SharedQueue::<Payload>::join_region(&region) }.is_ok());
+
+        let uninit = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
+        // SAFETY: uninitialized region → magic mismatch.
+        let err = unsafe { SharedQueue::<Payload>::join_region(&uninit) };
+        assert!(matches!(err, Err(Error::InvalidMagic)));
+    }
+}

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -346,6 +346,13 @@ impl<T> SharedQueue<T> {
             .store(CONSUMER_FREE, Ordering::Release);
     }
 
+    /// Force-owns a consumer index whose previous owner died (no CAS). The
+    /// caller guarantees that owner is dead and no live handle uses the index.
+    fn recover_consumer_index(&self, index: usize) {
+        self.consumer_state(index)
+            .store(CONSUMER_ACTIVE, Ordering::Release);
+    }
+
     /// Maps `file`, initializing it as a broadcast queue.
     ///
     /// # Safety
@@ -400,6 +407,7 @@ unsafe impl<T: Send> Sync for SharedQueue<T> {}
 pub struct Producer<T> {
     queue: SharedQueue<T>,
     lane: ProducerLane<T>,
+    index: usize,
 }
 
 impl<T> Producer<T> {
@@ -430,7 +438,54 @@ impl<T> Producer<T> {
     fn from_queue(queue: SharedQueue<T>) -> Result<Self, Error> {
         let index = queue.acquire_producer_lane()?;
         let lane = queue.lane(index);
-        Ok(Self { queue, lane })
+        Ok(Self { queue, lane, index })
+    }
+
+    /// The lane this producer owns. Record it so a replacement can
+    /// [`recover`](Self::recover) the lane if this producer's process dies.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Takes over a lane whose producer died, without the usual ownership
+    /// handshake. The recovered producer continues publishing from the lane's
+    /// last published sequence; any cells the dead producer reserved but never
+    /// published are discarded.
+    ///
+    /// # Safety
+    /// - All of [`Self::join`]'s requirements, plus: the producer that owned
+    ///   `index` must be dead and no other live handle may use that lane — two
+    ///   producers on one lane corrupts it.
+    pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join(file) }?;
+        Self::recover_in_queue(queue, index)
+    }
+
+    fn recover_in_queue(queue: SharedQueue<T>, index: usize) -> Result<Self, Error> {
+        if index >= queue.producer_slots() {
+            return Err(Error::InvalidIndex);
+        }
+        let lane = queue.lane(index);
+        lane.recover();
+        Ok(Self { queue, lane, index })
+    }
+
+    /// Force-releases a lane whose producer died, returning it to the free pool
+    /// (rewinding its reservation first) so a later [`join`](Self::join) /
+    /// [`try_clone`](Self::try_clone) can reclaim it.
+    ///
+    /// # Safety
+    /// - As [`Self::join`], plus: the producer that owned `index` must be dead and
+    ///   no other live handle may use that lane.
+    pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::<T>::join(file) }?;
+        if index >= queue.producer_slots() {
+            return Err(Error::InvalidIndex);
+        }
+        queue.lane(index).force_release();
+        Ok(())
     }
 
     /// Claims another free lane on the same queue.
@@ -442,7 +497,14 @@ impl<T> Producer<T> {
     /// starts at each lane's current reservation, so it only observes items
     /// published after it joins.
     pub fn join_as_consumer(&self) -> Result<Consumer<T>, Error> {
-        Consumer::from_queue(self.queue.clone())
+        Consumer::from_queue(self.queue.clone(), false)
+    }
+
+    /// Like [`Self::join_as_consumer`], but starts up to one ring behind the
+    /// frontier so the consumer reads data published before it joined (see
+    /// [`Consumer::join_from_backlog`]).
+    pub fn join_as_consumer_from_backlog(&self) -> Result<Consumer<T>, Error> {
+        Consumer::from_queue(self.queue.clone(), true)
     }
 
     /// Publishes one value, or returns it on backpressure (the slowest consumer
@@ -607,38 +669,118 @@ impl<T> Consumer<T> {
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
         // SAFETY: caller guarantees this mapping is initialized exactly once.
         let queue = unsafe { SharedQueue::create(file, &config) }?;
-        Self::from_queue(queue)
+        Self::from_queue(queue, false)
     }
 
-    /// Joins an existing broadcast queue in `file` as a consumer.
+    /// Joins an existing broadcast queue in `file` as a consumer, starting at the
+    /// current frontier (only items published after the join).
     ///
     /// # Safety
     /// - Same as [`Producer::join`]: live queue, same `T` across all handles.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::join(file) }?;
-        Self::from_queue(queue)
+        Self::from_queue(queue, false)
     }
 
-    fn from_queue(queue: SharedQueue<T>) -> Result<Self, Error> {
+    /// Like [`Self::join`], but starts up to one ring behind the frontier so the
+    /// consumer reads data published before it joined. Best for slow queues; on a
+    /// fast one that has already lapped, it falls back to the frontier (see
+    /// [`Self::join`]).
+    ///
+    /// # Safety
+    /// - Same as [`Self::join`].
+    pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join(file) }?;
+        Self::from_queue(queue, true)
+    }
+
+    fn from_queue(queue: SharedQueue<T>, from_backlog: bool) -> Result<Self, Error> {
         let index = queue.acquire_consumer_index()?;
-        let producer_slots = queue.producer_slots();
-        // Cache one view per lane and join each at its current reservation,
-        // caching the start positions.
-        let mut lanes = Vec::with_capacity(producer_slots);
-        let mut next_by_lane = Vec::with_capacity(producer_slots);
-        for lane in 0..producer_slots {
-            let lane = queue.lane(lane);
-            next_by_lane.push(lane.join_consumer(index));
-            lanes.push(lane);
-        }
+        // Cache a view per lane (independent of `queue`), and join each — at the
+        // frontier, or up to one ring behind it when `from_backlog`.
+        let lanes: Box<[ProducerLane<T>]> = (0..queue.producer_slots())
+            .map(|lane| queue.lane(lane))
+            .collect();
+        let next_by_lane = lanes
+            .iter()
+            .map(|lane| lane.join_consumer(index, from_backlog))
+            .collect();
         Ok(Self {
             queue,
             index,
-            lanes: lanes.into_boxed_slice(),
-            next_by_lane: next_by_lane.into_boxed_slice(),
+            lanes,
+            next_by_lane,
             scan_start_lane: 0,
         })
+    }
+
+    /// The consumer index this handle owns. Record it so a replacement can
+    /// [`recover`](Self::recover) it if this consumer's process dies.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Takes over a consumer index whose owner died, without the usual ownership
+    /// handshake, **resuming where the dead owner left off** on each lane — its
+    /// unread items are still pinned by its reserve limit, so they are delivered.
+    /// To instead restart fresh, [`force_release`](Self::force_release) the index
+    /// and `join` it however you like.
+    ///
+    /// # Safety
+    /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
+    ///   `index` must be dead and no other live handle may use it — two consumers
+    ///   sharing an index corrupts each other's cursor.
+    pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join(file) }?;
+        Self::recover_in_queue(queue, index)
+    }
+
+    fn recover_in_queue(queue: SharedQueue<T>, index: usize) -> Result<Self, Error> {
+        if index >= queue.consumer_slots() {
+            return Err(Error::InvalidIndex);
+        }
+        queue.recover_consumer_index(index);
+        // Resume each lane at the dead owner's recorded position (read-only, so
+        // its backpressure is never dropped).
+        let lanes: Box<[ProducerLane<T>]> = (0..queue.producer_slots())
+            .map(|lane| queue.lane(lane))
+            .collect();
+        let next_by_lane = lanes
+            .iter()
+            .map(|lane| lane.recover_consumer(index))
+            .collect();
+        Ok(Self {
+            queue,
+            index,
+            lanes,
+            next_by_lane,
+            scan_start_lane: 0,
+        })
+    }
+
+    /// Force-releases a consumer index whose owner died, returning it to the free
+    /// pool: the lanes are un-wedged and a later [`join`](Self::join) /
+    /// [`join_from_backlog`](Self::join_from_backlog) can reclaim it fresh. Use this
+    /// (rather than [`recover`](Self::recover)) when you want to drop the dead
+    /// consumer's backlog and choose a new start position.
+    ///
+    /// # Safety
+    /// - As [`Self::join`], plus: the consumer that owned `index` must be dead and
+    ///   no other live handle may use it.
+    pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::<T>::join(file) }?;
+        if index >= queue.consumer_slots() {
+            return Err(Error::InvalidIndex);
+        }
+        for lane in 0..queue.producer_slots() {
+            queue.lane(lane).release_consumer(index);
+        }
+        queue.release_consumer_index(index);
+        Ok(())
     }
 
     /// Finds the next readable `(lane, sequence)`, scanning round-robin from
@@ -1245,6 +1387,32 @@ mod tests {
     }
 
     #[test]
+    fn from_backlog_consumer_reads_old_data_on_a_slow_queue() {
+        for create in producer_creators() {
+            // The queue has capacity to spare and has not wrapped, so the backlog
+            // is fully retained.
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            for value in 0..3u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            // A from-backlog join starts at the oldest retained item (sequence 0),
+            // so it reads data published before it joined, then keeps up.
+            let mut c = p.join_as_consumer_from_backlog().unwrap();
+            for value in 0..3u64 {
+                // SAFETY: `Payload` is `u64`.
+                assert_eq!(unsafe { c.try_read() }, Some(value));
+            }
+            assert!(p.try_write(99).is_ok());
+            assert_eq!(unsafe { c.try_read() }, Some(99));
+            assert_eq!(unsafe { c.try_read() }, None);
+        }
+    }
+
+    #[test]
     fn reserve_read_timeout_times_out_then_observes_publication() {
         for create in producer_creators() {
             let mut p = create(BroadcastConfig {
@@ -1324,5 +1492,165 @@ mod tests {
                 Err(WaitError::Timeout)
             ));
         }
+    }
+
+    /// Allocates a heap-backed queue and returns the shared handle (recovery
+    /// tests need the queue directly to simulate a crashed handle).
+    fn recovery_queue(config: &BroadcastConfig) -> SharedQueue<Payload> {
+        let size = Layout::new::<Payload>(config).expect("layout").total;
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
+        // SAFETY: freshly allocated region, initialized exactly once.
+        unsafe { SharedQueue::<Payload>::create_in_region(&region, config) }.unwrap()
+    }
+
+    #[test]
+    fn recover_producer_takes_over_a_wedged_lane() {
+        let config = BroadcastConfig {
+            capacity: 8,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+        let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
+
+        // A producer publishes two items, then its process "crashes". A clean
+        // drop would free the lane, so re-mark it ACTIVE to mimic a dead owner
+        // that never released it.
+        {
+            let mut producer = Producer::from_queue(queue.clone()).unwrap();
+            assert!(producer.try_write(1).is_ok());
+            assert!(producer.try_write(2).is_ok());
+        }
+        assert!(queue.lane(0).try_acquire());
+
+        // The only lane is held, so a normal join is refused.
+        assert!(matches!(
+            Producer::from_queue(queue.clone()),
+            Err(Error::ProducerSlotsExhausted)
+        ));
+
+        // Recover the lane and keep publishing where the dead producer stopped.
+        let mut recovered = Producer::recover_in_queue(queue.clone(), 0).unwrap();
+        assert_eq!(recovered.index(), 0);
+        assert!(recovered.try_write(3).is_ok());
+
+        // The consumer (joined before the crash) sees every item in order.
+        for value in 1..=3u64 {
+            // SAFETY: `Payload` is `u64`.
+            assert_eq!(unsafe { consumer.try_read() }, Some(value));
+        }
+        assert_eq!(unsafe { consumer.try_read() }, None);
+    }
+
+    #[test]
+    fn recover_producer_rewinds_unpublished_reservation() {
+        let config = BroadcastConfig {
+            capacity: 8,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+
+        // Mimic a producer that reserved a batch but crashed before publishing:
+        // the reservation runs ahead of the publication.
+        let mut lane = queue.lane(0);
+        assert!(lane.try_acquire());
+        lane.reserve(NonZeroUsize::new(3).unwrap());
+        assert_eq!(lane.reserved(), 3);
+        assert_eq!(lane.published(), 0);
+
+        // Recovery rewinds the reservation back to the publication.
+        let recovered = Producer::recover_in_queue(queue.clone(), 0).unwrap();
+        assert_eq!(recovered.lane.reserved(), 0);
+        assert_eq!(recovered.lane.published(), 0);
+    }
+
+    #[test]
+    fn recover_consumer_resumes_from_last_position() {
+        let config = BroadcastConfig {
+            capacity: 8,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+
+        // A consumer joins at sequence 0, then its process "crashes" with a read
+        // position recorded (next-to-read = 1). Build that state directly (claim
+        // the index, join, record the cursor) so nothing releases the slot.
+        let index = queue.acquire_consumer_index().unwrap();
+        queue.lane(0).join_consumer(index, false);
+
+        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+        for value in 0..3u64 {
+            assert!(producer.try_write(value).is_ok());
+        }
+        queue.lane(0).set_consumer_cursor(index, 1);
+
+        // Recovery resumes at the recorded position: it reads the unread backlog
+        // (items 1, 2), never re-reading item 0.
+        let mut recovered = Consumer::recover_in_queue(queue.clone(), index).unwrap();
+        assert_eq!(recovered.index(), index);
+        // SAFETY: `Payload` is `u64`.
+        assert_eq!(unsafe { recovered.try_read() }, Some(1));
+        assert_eq!(unsafe { recovered.try_read() }, Some(2));
+        assert_eq!(unsafe { recovered.try_read() }, None);
+    }
+
+    #[test]
+    fn force_release_consumer_frees_the_index_for_a_fresh_join() {
+        let config = BroadcastConfig {
+            capacity: 8,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+
+        // The only consumer index is claimed and the lane's limit recorded, then
+        // its owner "crashes" (no release).
+        let index = queue.acquire_consumer_index().unwrap();
+        queue.lane(0).join_consumer(index, false);
+        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+        for value in 0..3u64 {
+            assert!(producer.try_write(value).is_ok());
+        }
+        queue.lane(0).set_consumer_cursor(index, 1);
+
+        // A fresh join can't proceed — the index is still owned.
+        assert!(matches!(
+            Consumer::from_queue(queue.clone(), false),
+            Err(Error::ConsumerSlotsExhausted)
+        ));
+
+        // Force-release frees it (clear limits + free the index); a catch-up join
+        // then reclaims it and reads the still-present backlog from the start.
+        for lane in 0..queue.producer_slots() {
+            queue.lane(lane).release_consumer(index);
+        }
+        queue.release_consumer_index(index);
+        let mut fresh = Consumer::from_queue(queue.clone(), true).unwrap();
+        assert_eq!(fresh.index(), index);
+        for value in 0..3u64 {
+            // SAFETY: `Payload` is `u64`.
+            assert_eq!(unsafe { fresh.try_read() }, Some(value));
+        }
+        assert_eq!(unsafe { fresh.try_read() }, None);
+    }
+
+    #[test]
+    fn recover_rejects_out_of_range_index() {
+        let config = BroadcastConfig {
+            capacity: 8,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+        assert!(matches!(
+            Producer::recover_in_queue(queue.clone(), 1),
+            Err(Error::InvalidIndex)
+        ));
+        assert!(matches!(
+            Consumer::recover_in_queue(queue.clone(), 1),
+            Err(Error::InvalidIndex)
+        ));
     }
 }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -509,7 +509,7 @@ impl<T> Producer<T> {
     pub fn try_write(&mut self, value: T) -> Result<(), T> {
         // SAFETY: on successful reservation, `value` is written before the guard
         // is dropped and publishes the cell.
-        match unsafe { self.reserve_write() } {
+        match unsafe { self.try_reserve_write() } {
             Some(guard) => {
                 guard.write(value);
                 Ok(())
@@ -530,7 +530,7 @@ impl<T> Producer<T> {
         };
 
         // SAFETY: if reservation succeeds, every reserved cell is written below.
-        let mut batch = match unsafe { self.reserve_write_batch(len) } {
+        let mut batch = match unsafe { self.try_reserve_write_batch(len) } {
             Some(batch) => batch,
             None => return false,
         };
@@ -549,7 +549,7 @@ impl<T> Producer<T> {
     /// - The caller must initialize the reserved cell before the guard is
     ///   dropped.
     #[must_use]
-    pub unsafe fn reserve_write(&mut self) -> Option<WriteGuard<'_, T>> {
+    pub unsafe fn try_reserve_write(&mut self) -> Option<WriteGuard<'_, T>> {
         let start = self.lane.try_reserve(NonZeroUsize::MIN)?;
         Some(WriteGuard {
             producer: self,
@@ -564,7 +564,10 @@ impl<T> Producer<T> {
     /// - The caller must initialize every reserved cell before the batch is
     ///   dropped.
     #[must_use]
-    pub unsafe fn reserve_write_batch(&mut self, count: NonZeroUsize) -> Option<WriteBatch<'_, T>> {
+    pub unsafe fn try_reserve_write_batch(
+        &mut self,
+        count: NonZeroUsize,
+    ) -> Option<WriteBatch<'_, T>> {
         let start = self.lane.try_reserve(count)?;
         Some(WriteBatch {
             producer: self,
@@ -886,7 +889,7 @@ impl<T> Consumer<T> {
     /// at the value's sequence, so the producer cannot overwrite it until the
     /// guard is dropped, which advances past it.
     #[must_use]
-    pub fn reserve_read(&mut self) -> Option<ReadGuard<'_, T>> {
+    pub fn try_reserve_read(&mut self) -> Option<ReadGuard<'_, T>> {
         let (lane, sequence) = self.next_readable()?;
         let payload = self.lanes[lane].payload_ptr(sequence);
         Some(ReadGuard {
@@ -903,7 +906,7 @@ impl<T> Consumer<T> {
     /// so the producer cannot overwrite any of the batched cells until the guard
     /// is dropped, which advances past the whole batch.
     #[must_use]
-    pub fn reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
+    pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
         let (lane, start) = self.next_readable()?;
         // `next_readable` guarantees at least one published value past `start`.
         let available = self.lanes[lane].published().wrapping_sub(start);
@@ -925,7 +928,7 @@ impl<T> Consumer<T> {
     ) -> Result<ReadGuard<'_, T>, WaitError> {
         self.wait_until_readable(timeout)?;
         Ok(self
-            .reserve_read()
+            .try_reserve_read()
             .expect("a lane is readable after a successful wait"))
     }
 
@@ -938,7 +941,7 @@ impl<T> Consumer<T> {
     ) -> Result<ReadBatch<'_, T>, WaitError> {
         self.wait_until_readable(timeout)?;
         Ok(self
-            .reserve_read_batch(max)
+            .try_reserve_read_batch(max)
             .expect("a lane is readable after a successful wait"))
     }
 
@@ -1164,7 +1167,7 @@ mod tests {
             {
                 // SAFETY: every reserved slot is initialized below.
                 let mut batch =
-                    unsafe { p.reserve_write_batch(NonZeroUsize::new(3).unwrap()) }.unwrap();
+                    unsafe { p.try_reserve_write_batch(NonZeroUsize::new(3).unwrap()) }.unwrap();
                 assert_eq!(batch.len(), 3);
                 for index in 0..3usize {
                     // SAFETY: index < len.
@@ -1342,7 +1345,7 @@ mod tests {
             let mut c = p.join_as_consumer().unwrap();
             assert!(p.try_write(10).is_ok());
 
-            let guard = c.reserve_read().expect("readable");
+            let guard = c.try_reserve_read().expect("readable");
             // SAFETY: the cell is published.
             assert_eq!(unsafe { *guard.as_ref() }, 10);
 
@@ -1374,18 +1377,18 @@ mod tests {
             // A single write guard publishes its cell when dropped.
             {
                 // SAFETY: the reserved slot is initialized before `guard` is dropped.
-                let mut guard = unsafe { p.reserve_write() }.unwrap();
+                let mut guard = unsafe { p.try_reserve_write() }.unwrap();
                 // SAFETY: `Payload` is `u64`, valid for any bytes.
                 unsafe { *guard.as_mut_ref() = 42 };
             }
             // `write` consumes the guard and publishes on drop too.
             // SAFETY: `write` initializes the reserved slot before publishing.
-            unsafe { p.reserve_write() }.unwrap().write(43);
+            unsafe { p.try_reserve_write() }.unwrap().write(43);
 
             // SAFETY: `Payload` is `u64`; `read` copies out, committing on drop.
-            assert_eq!(unsafe { c.reserve_read().unwrap().read() }, 42);
-            assert_eq!(unsafe { c.reserve_read().unwrap().read() }, 43);
-            assert!(c.reserve_read().is_none());
+            assert_eq!(unsafe { c.try_reserve_read().unwrap().read() }, 42);
+            assert_eq!(unsafe { c.try_reserve_read().unwrap().read() }, 43);
+            assert!(c.try_reserve_read().is_none());
         }
     }
 
@@ -1404,7 +1407,9 @@ mod tests {
 
             // Bounded by `max` (3) below the available run (5); drop commits it.
             {
-                let batch = c.reserve_read_batch(NonZeroUsize::new(3).unwrap()).unwrap();
+                let batch = c
+                    .try_reserve_read_batch(NonZeroUsize::new(3).unwrap())
+                    .unwrap();
                 assert_eq!(batch.len(), 3);
                 for index in 0..3 {
                     // SAFETY: `index < len`; `Payload` is `u64`.
@@ -1414,7 +1419,7 @@ mod tests {
             // Now bounded by the available run (2), not `max`.
             {
                 let batch = c
-                    .reserve_read_batch(NonZeroUsize::new(10).unwrap())
+                    .try_reserve_read_batch(NonZeroUsize::new(10).unwrap())
                     .unwrap();
                 assert_eq!(batch.len(), 2);
                 for index in 0..2 {
@@ -1423,7 +1428,7 @@ mod tests {
                 }
             }
             assert!(c
-                .reserve_read_batch(NonZeroUsize::new(1).unwrap())
+                .try_reserve_read_batch(NonZeroUsize::new(1).unwrap())
                 .is_none());
         }
     }
@@ -1443,7 +1448,9 @@ mod tests {
 
             // The batch holds the whole ring; the producer is fully blocked.
             {
-                let batch = c.reserve_read_batch(NonZeroUsize::new(4).unwrap()).unwrap();
+                let batch = c
+                    .try_reserve_read_batch(NonZeroUsize::new(4).unwrap())
+                    .unwrap();
                 assert_eq!(batch.len(), 4);
                 assert!(p.try_write(99).is_err());
             }
@@ -1485,10 +1492,10 @@ mod tests {
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
 
         // SAFETY: the reserved slot is initialized before the guard is dropped.
-        let mut guard = unsafe { producer.reserve_write() }.unwrap();
+        let mut guard = unsafe { producer.try_reserve_write() }.unwrap();
         let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
 
-        assert!(consumer.reserve_read().is_none());
+        assert!(consumer.try_reserve_read().is_none());
         // SAFETY: `Payload` is `u64`, valid POD-like bytes.
         unsafe { *guard.as_mut_ref() = 42 };
         drop(guard);

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1280,6 +1280,76 @@ mod tests {
         }
     }
 
+    #[cfg(not(miri))]
+    #[test]
+    fn threaded_producer_publish_is_visible_to_all_consumers() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const ITEMS: usize = 257;
+        const BATCH: usize = 7;
+
+        for create in producer_creators() {
+            let mut producer = create(BroadcastConfig {
+                capacity: 32,
+                producer_slots: 1,
+                consumer_slots: 2,
+            });
+            let consumers = [
+                producer.join_as_consumer().unwrap(),
+                producer.join_as_consumer().unwrap(),
+            ];
+            let start = Arc::new(Barrier::new(consumers.len() + 1));
+
+            let consumer_threads: Vec<_> = consumers
+                .into_iter()
+                .map(|mut consumer| {
+                    let start = Arc::clone(&start);
+                    thread::spawn(move || {
+                        start.wait();
+                        let mut seen = Vec::with_capacity(ITEMS);
+                        for _ in 0..ITEMS {
+                            seen.push(
+                                consumer
+                                    .read_timeout(Duration::from_secs(1))
+                                    .expect("published value"),
+                            );
+                        }
+                        assert!(matches!(
+                            consumer.read_timeout(Duration::ZERO),
+                            Err(WaitError::Timeout)
+                        ));
+                        seen
+                    })
+                })
+                .collect();
+
+            let producer_start = Arc::clone(&start);
+            let producer_thread = thread::spawn(move || {
+                producer_start.wait();
+                let mut next = 0usize;
+                while next < ITEMS {
+                    let count = (ITEMS - next).min(BATCH);
+                    let mut batch = [0u64; BATCH];
+                    for (offset, slot) in batch[..count].iter_mut().enumerate() {
+                        *slot = (next + offset) as u64;
+                    }
+                    if producer.try_write_slice(&batch[..count]) {
+                        next += count;
+                    } else {
+                        thread::yield_now();
+                    }
+                }
+            });
+
+            producer_thread.join().expect("producer thread");
+            let expected: Vec<_> = (0..ITEMS as u64).collect();
+            for consumer_thread in consumer_threads {
+                assert_eq!(consumer_thread.join().expect("consumer thread"), expected);
+            }
+        }
+    }
+
     #[test]
     fn slow_consumer_backpressures_producer() {
         for create in producer_creators() {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 use crate::error::{Error, WaitError};
 use crate::futex::{Waiters, SPIN_ATTEMPTS};
 use crate::shmem::Region;
-use crate::{normalized_capacity, CacheAlignedAtomicSize, VERSION};
+use crate::{CacheAlignedAtomicSize, VERSION};
 
 use producer_lane::ProducerLane;
 
@@ -92,8 +92,11 @@ struct Layout {
 
 impl Layout {
     fn new<T>(config: &BroadcastConfig) -> Option<Self> {
-        let capacity = normalized_capacity(config.capacity);
-        if capacity == 0 || capacity > u32::MAX as usize {
+        if config.capacity == 0 {
+            return None;
+        }
+        let capacity = config.capacity.checked_next_power_of_two()?;
+        if capacity > u32::MAX as usize {
             return None;
         }
         // `consumer_slots == 0` is allowed: producers then run free (no consumer
@@ -116,8 +119,8 @@ impl Layout {
         let producer_blocks_offset = consumer_state_offset
             .checked_add(consumer_state_bytes)?
             .checked_next_multiple_of(block_align)?;
-        let block_stride = ProducerLane::<T>::block_size(capacity, config.consumer_slots)
-            .next_multiple_of(block_align);
+        let block_stride = ProducerLane::<T>::block_size(capacity, config.consumer_slots)?
+            .checked_next_multiple_of(block_align)?;
         let producer_blocks_bytes = block_stride.checked_mul(config.producer_slots)?;
         let total = producer_blocks_offset.checked_add(producer_blocks_bytes)?;
 
@@ -140,8 +143,8 @@ impl Layout {
             producer_slots: header.producer_slots as usize,
             consumer_slots: header.consumer_slots as usize,
         };
-        // `capacity` is already a power of two; `normalized_capacity` is a no-op,
-        // so the recomputed layout must match the stored capacity exactly.
+        // `capacity` is already a power of two, so the recomputed layout must
+        // match the stored capacity exactly.
         let layout = Layout::new::<T>(&config).ok_or(Error::InvalidBufferSize)?;
         if layout.capacity as usize != capacity || region_size < layout.total {
             return Err(Error::InvalidBufferSize);
@@ -518,7 +521,7 @@ impl<T> Producer<T> {
     }
 
     /// Joins the same queue as a consumer (sharing the mapping). The consumer
-    /// starts at each lane's current reservation, so it only observes items
+    /// starts at each lane's current publication, so it only observes items
     /// published after it joins.
     pub fn join_as_consumer(&self) -> Result<Consumer<T>, Error> {
         Consumer::from_queue(self.queue.clone(), false)
@@ -853,11 +856,10 @@ impl<T> Consumer<T> {
         let mut lane = self.scan_start_lane;
         for _ in 0..producer_slots {
             let next = self.next_by_lane[lane];
-            if self.lanes[lane].published().wrapping_sub(next) > 0 {
+            // Cursor wrap is not supported - simple comparison works here.
+            if self.lanes[lane].published() > next {
                 return Some((lane, next));
             }
-            // `lane < producer_slots`, so the wrap is a conditional subtract, not
-            // a division.
             lane = lane.wrapping_add(1);
             if lane == producer_slots {
                 lane = 0;
@@ -1269,6 +1271,26 @@ mod tests {
     }
 
     #[test]
+    fn layout_rejects_oversized_capacity_without_panicking() {
+        let config = BroadcastConfig {
+            capacity: usize::MAX,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        assert!(Layout::new::<Payload>(&config).is_none());
+    }
+
+    #[test]
+    fn layout_rejects_zero_capacity() {
+        let config = BroadcastConfig {
+            capacity: 0,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        assert!(Layout::new::<Payload>(&config).is_none());
+    }
+
+    #[test]
     fn every_consumer_observes_every_item_in_order() {
         for create in producer_creators() {
             let mut p = create(BroadcastConfig {
@@ -1461,13 +1483,37 @@ mod tests {
             for value in 0..3u64 {
                 assert!(p.try_write(value).is_ok());
             }
-            // Joins at the current reservation (3), so it sees only later items.
+            // Joins at the current publication (3), so it sees only later items.
             let mut c = p.join_as_consumer().unwrap();
             assert!(p.try_write(99).is_ok());
             // SAFETY: `Payload` is `u64`.
             assert_eq!(unsafe { c.try_read() }, Some(99));
             assert_eq!(unsafe { c.try_read() }, None);
         }
+    }
+
+    #[test]
+    fn consumer_joining_during_unpublished_reservation_waits_for_publication() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+
+        // SAFETY: the reserved slot is initialized before the guard is dropped.
+        let mut guard = unsafe { producer.reserve_write() }.unwrap();
+        let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
+
+        assert!(consumer.reserve_read().is_none());
+        // SAFETY: `Payload` is `u64`, valid POD-like bytes.
+        unsafe { *guard.as_mut_ref() = 42 };
+        drop(guard);
+
+        // SAFETY: `Payload` is `u64`, valid POD-like bytes.
+        assert_eq!(unsafe { consumer.try_read() }, Some(42));
+        assert_eq!(unsafe { consumer.try_read() }, None);
     }
 
     #[test]

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -37,6 +37,7 @@ use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, Ordering};
 use std::fs::File;
+use std::mem::MaybeUninit;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -588,7 +589,7 @@ impl<T> Drop for Producer<T> {
 unsafe impl<T: Send> Send for Producer<T> {}
 
 /// A reservation of one cell in a producer's lane. Write it via
-/// [`Self::write`]/[`Self::as_mut_ptr`], then drop the guard to publish it.
+/// [`Self::write`]/[`Self::as_mut_ref`], then drop the guard to publish it.
 #[must_use]
 pub struct WriteGuard<'a, T> {
     producer: &'a mut Producer<T>,
@@ -596,19 +597,10 @@ pub struct WriteGuard<'a, T> {
 }
 
 impl<T> WriteGuard<'_, T> {
-    /// Pointer to the reserved cell.
-    pub fn as_mut_ptr(&mut self) -> *mut T {
-        self.producer.lane.payload_ptr(self.start).as_ptr()
-    }
-
     /// Mutable reference to the reserved cell.
-    ///
-    /// # Safety
-    /// - The cell is uninitialized; `T` must be valid for any bytes (the caller
-    ///   must not read it before fully initializing it).
-    pub unsafe fn as_mut_ref(&mut self) -> &mut T {
+    pub fn as_mut_ref(&mut self) -> &mut MaybeUninit<T> {
         // SAFETY: forwarded; the cell is reserved for this producer.
-        unsafe { &mut *self.as_mut_ptr() }
+        unsafe { &mut *self.producer.lane.payload_ptr(self.start).as_ptr().cast() }
     }
 
     /// Writes `value` into the reserved cell; the guard publishes it on drop.
@@ -632,7 +624,7 @@ impl<T> Drop for WriteGuard<'_, T> {
 }
 
 /// A reservation of `count` cells in a producer's lane. Write every cell via
-/// [`Self::write`]/[`Self::as_mut_ptr`], then drop the batch to publish them.
+/// [`Self::write`]/[`Self::as_mut_ref`], then drop the batch to publish them.
 #[must_use]
 pub struct WriteBatch<'a, T> {
     producer: &'a mut Producer<T>,
@@ -649,17 +641,19 @@ impl<T> WriteBatch<'_, T> {
         false
     }
 
-    /// Pointer to the reserved cell at `index`.
+    /// Mutable reference to the reserved cell at `index`.
     ///
     /// # Safety
-    /// - `index < len`; the cell is uninitialized and the caller must fully
-    ///   initialize `T` before the batch is dropped.
-    pub unsafe fn as_mut_ptr(&mut self, index: usize) -> *mut T {
+    /// - `index < len`.
+    pub unsafe fn as_mut_ref(&mut self, index: usize) -> &mut MaybeUninit<T> {
         debug_assert!(index < self.count.get());
-        self.producer
+        let ptr = self
+            .producer
             .lane
             .payload_ptr(self.start.wrapping_add(index))
-            .as_ptr()
+            .as_ptr();
+        // SAFETY: forwarded; the cell is reserved for this producer.
+        unsafe { &mut *ptr.cast() }
     }
 
     /// Writes `value` into the reserved cell at `index`.
@@ -668,7 +662,7 @@ impl<T> WriteBatch<'_, T> {
     /// - `index < len`.
     pub unsafe fn write(&mut self, index: usize, value: T) {
         // SAFETY: forwarded; `index < len` and the cell is reserved.
-        unsafe { self.as_mut_ptr(index).write(value) };
+        unsafe { self.as_mut_ref(index).write(value) };
     }
 }
 
@@ -1379,7 +1373,7 @@ mod tests {
                 // SAFETY: the reserved slot is initialized before `guard` is dropped.
                 let mut guard = unsafe { p.try_reserve_write() }.unwrap();
                 // SAFETY: `Payload` is `u64`, valid for any bytes.
-                unsafe { *guard.as_mut_ref() = 42 };
+                guard.as_mut_ref().write(42);
             }
             // `write` consumes the guard and publishes on drop too.
             // SAFETY: `write` initializes the reserved slot before publishing.
@@ -1496,8 +1490,7 @@ mod tests {
         let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
 
         assert!(consumer.try_reserve_read().is_none());
-        // SAFETY: `Payload` is `u64`, valid POD-like bytes.
-        unsafe { *guard.as_mut_ref() = 42 };
+        guard.as_mut_ref().write(42);
         drop(guard);
 
         // SAFETY: `Payload` is `u64`, valid POD-like bytes.

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -78,9 +78,12 @@ impl Layout {
         if capacity == 0 || capacity > u32::MAX as usize {
             return None;
         }
+        // `consumer_slots == 0` is allowed: producers then run free (no consumer
+        // can constrain the reserve limit), useful for measuring a producer in
+        // isolation. `producer_slots` must be at least one — a queue with no
+        // lanes can hold nothing.
         if config.producer_slots == 0
             || config.producer_slots > u32::MAX as usize
-            || config.consumer_slots == 0
             || config.consumer_slots > u32::MAX as usize
         {
             return None;
@@ -999,6 +1002,26 @@ mod tests {
             for value in 0..16u64 {
                 assert!(p.try_write(value).is_ok());
             }
+        }
+    }
+
+    #[test]
+    fn zero_consumer_slots_lets_producer_run_free() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 0,
+            });
+            // No consumer can ever constrain the lane, so writes never block.
+            for value in 0..16u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            // And no consumer can join when there are no consumer slots.
+            assert!(matches!(
+                p.join_as_consumer(),
+                Err(Error::ConsumerSlotsExhausted)
+            ));
         }
     }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,0 +1,7 @@
+//! Multi-producer / multi-consumer broadcast queue.
+//!
+//! Each producer owns a [`producer_lane::ProducerLane`]; every consumer reads
+//! every lane. The producer/consumer handles and the shared region wiring land
+//! in later commits.
+
+mod producer_lane;

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -38,8 +38,6 @@ use producer_lane::ProducerLane;
 
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqcast");
 
-/// Consumer-index ownership states for the global `consumer_state` table, read
-/// and written by the consumer side.
 const CONSUMER_FREE: u64 = 0;
 const CONSUMER_ACTIVE: u64 = 1;
 
@@ -143,7 +141,6 @@ impl Layout {
 }
 
 /// A handle onto the shared region: the header plus the section base pointers.
-/// Cloneable — every producer/consumer shares one mapping.
 struct SharedQueue<T> {
     region: Arc<Region>,
     header: NonNull<SharedQueueHeader>,

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -14,6 +14,16 @@
 //! lane or consumer index can be taken over with `recover` (resuming where the
 //! dead owner was) or returned to the pool with `force_release`.
 //!
+//! Payloads are treated as shared-memory bytes, not as ordinary Rust-owned
+//! values. In practice `T` should be POD-like: no process-local pointers, no
+//! references whose provenance matters in another process, no destructor that
+//! must run, and safe to duplicate by raw reads. This is stricter than a normal
+//! queue because every broadcast consumer can read the same cell.
+//!
+//! Recovery is an externally serialized operation. Do not race recovery or
+//! force-release with other recovery operations, with joins/drops for the same
+//! queue, or with a still-live owner of the index/lane being recovered.
+//!
 //! The region is a fixed header (magic/version, the global consumer-ownership
 //! table, and the blocked-consumer wake counter) followed by one lane block per
 //! producer.
@@ -424,7 +434,9 @@ impl<T> Producer<T> {
     /// - `file` must be initialized as a broadcast queue exactly once (by the
     ///   designated initializer), and not resized while any handle is joined.
     /// - All producers/consumers for `file` must use the same `T`; queued values
-    ///   must be valid to read/overwrite as shared-memory bytes in each process.
+    ///   must be POD-like shared-memory bytes: valid in every process that reads
+    ///   them, safe to overwrite without running a destructor, and safe for every
+    ///   consumer to duplicate by raw reads.
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
         // SAFETY: caller guarantees this mapping is initialized exactly once.
         let queue = unsafe { SharedQueue::create(file, &config) }?;
@@ -463,6 +475,9 @@ impl<T> Producer<T> {
     /// - All of [`Self::join`]'s requirements, plus: the producer that owned
     ///   `index` must be dead and no other live handle may use that lane — two
     ///   producers on one lane corrupts it.
+    /// - Recovery must be serialized externally; it must not race with other
+    ///   recovery/force-release operations or with producer/consumer joins or
+    ///   drops on the same queue.
     pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::join(file) }?;
@@ -485,6 +500,8 @@ impl<T> Producer<T> {
     /// # Safety
     /// - As [`Self::join`], plus: the producer that owned `index` must be dead and
     ///   no other live handle may use that lane.
+    /// - Force-release must be serialized externally, with the same restrictions
+    ///   as [`Self::recover`].
     pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::<T>::join(file) }?;
@@ -517,7 +534,9 @@ impl<T> Producer<T> {
     /// Publishes one value, or returns it on backpressure (the slowest consumer
     /// has not freed the cell that publishing would overwrite).
     pub fn try_write(&mut self, value: T) -> Result<(), T> {
-        match self.reserve_write() {
+        // SAFETY: on successful reservation, `value` is written before the guard
+        // is dropped and publishes the cell.
+        match unsafe { self.reserve_write() } {
             Some(guard) => {
                 guard.write(value);
                 Ok(())
@@ -526,11 +545,38 @@ impl<T> Producer<T> {
         }
     }
 
+    /// Writes items from a slice into this producer's lane.
+    ///
+    /// Returns `false` if there is not enough space.
+    pub fn try_write_slice(&mut self, items: &[T]) -> bool
+    where
+        T: Copy,
+    {
+        let Some(len) = NonZeroUsize::new(items.len()) else {
+            return true;
+        };
+
+        // SAFETY: if reservation succeeds, every reserved cell is written below.
+        let mut batch = match unsafe { self.reserve_write_batch(len) } {
+            Some(batch) => batch,
+            None => return false,
+        };
+
+        for (index, item) in items.iter().copied().enumerate() {
+            // SAFETY: `index` comes from enumerating exactly `len` items.
+            unsafe { batch.write(index, item) };
+        }
+        true
+    }
+
     /// Reserves a single cell for an in-place write, or `None` on backpressure.
-    /// The cell becomes visible when the returned guard is dropped; the caller
-    /// must write it first.
+    /// The cell becomes visible when the returned guard is dropped.
+    ///
+    /// # Safety
+    /// - The caller must initialize the reserved cell before the guard is
+    ///   dropped.
     #[must_use]
-    pub fn reserve_write(&mut self) -> Option<WriteGuard<'_, T>> {
+    pub unsafe fn reserve_write(&mut self) -> Option<WriteGuard<'_, T>> {
         let start = self.lane.reserve(NonZeroUsize::MIN)?;
         Some(WriteGuard {
             producer: self,
@@ -539,10 +585,13 @@ impl<T> Producer<T> {
     }
 
     /// Reserves `count` consecutive cells for in-place writes, or `None` on
-    /// backpressure. The cells become visible when the returned batch is dropped;
-    /// the caller must write all of them first.
+    /// backpressure. The cells become visible when the returned batch is dropped.
+    ///
+    /// # Safety
+    /// - The caller must initialize every reserved cell before the batch is
+    ///   dropped.
     #[must_use]
-    pub fn reserve_write_batch(&mut self, count: NonZeroUsize) -> Option<WriteBatch<'_, T>> {
+    pub unsafe fn reserve_write_batch(&mut self, count: NonZeroUsize) -> Option<WriteBatch<'_, T>> {
         let start = self.lane.reserve(count)?;
         Some(WriteBatch {
             producer: self,
@@ -672,7 +721,8 @@ impl<T> Consumer<T> {
     ///
     /// # Safety
     /// - Same as [`Producer::create`]: `file` initialized as a queue exactly once
-    ///   (the consumer may be the initializer), same `T` across all handles.
+    ///   (the consumer may be the initializer), same POD-like `T` across all
+    ///   handles.
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
         // SAFETY: caller guarantees this mapping is initialized exactly once.
         let queue = unsafe { SharedQueue::create(file, &config) }?;
@@ -739,6 +789,9 @@ impl<T> Consumer<T> {
     /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
     ///   `index` must be dead and no other live handle may use it — two consumers
     ///   sharing an index corrupts each other's cursor.
+    /// - Recovery must be serialized externally; it must not race with other
+    ///   recovery/force-release operations or with producer/consumer joins or
+    ///   drops on the same queue.
     pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::join(file) }?;
@@ -777,6 +830,8 @@ impl<T> Consumer<T> {
     /// # Safety
     /// - As [`Self::join`], plus: the consumer that owned `index` must be dead and
     ///   no other live handle may use it.
+    /// - Force-release must be serialized externally, with the same restrictions
+    ///   as [`Self::recover`].
     pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::<T>::join(file) }?;
@@ -1123,9 +1178,9 @@ mod tests {
             });
             let mut c = p.join_as_consumer().unwrap();
             {
-                let mut batch = p
-                    .reserve_write_batch(NonZeroUsize::new(3).unwrap())
-                    .unwrap();
+                // SAFETY: every reserved slot is initialized below.
+                let mut batch =
+                    unsafe { p.reserve_write_batch(NonZeroUsize::new(3).unwrap()) }.unwrap();
                 assert_eq!(batch.len(), 3);
                 for index in 0..3usize {
                     // SAFETY: index < len.
@@ -1136,6 +1191,26 @@ mod tests {
                 // SAFETY: `Payload` is `u64`, valid for any bytes.
                 assert_eq!(unsafe { c.try_read() }, Some(value));
             }
+        }
+    }
+
+    #[test]
+    fn try_write_slice_publishes_all_items() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+            assert!(p.try_write_slice(&[]));
+            assert!(p.try_write_slice(&[1, 2, 3]));
+
+            for value in 1..=3u64 {
+                // SAFETY: `Payload` is `u64`, valid POD-like bytes.
+                assert_eq!(unsafe { c.try_read() }, Some(value));
+            }
+            assert_eq!(unsafe { c.try_read() }, None);
         }
     }
 
@@ -1294,12 +1369,14 @@ mod tests {
 
             // A single write guard publishes its cell when dropped.
             {
-                let mut guard = p.reserve_write().unwrap();
+                // SAFETY: the reserved slot is initialized before `guard` is dropped.
+                let mut guard = unsafe { p.reserve_write() }.unwrap();
                 // SAFETY: `Payload` is `u64`, valid for any bytes.
                 unsafe { *guard.as_mut_ref() = 42 };
             }
             // `write` consumes the guard and publishes on drop too.
-            p.reserve_write().unwrap().write(43);
+            // SAFETY: `write` initializes the reserved slot before publishing.
+            unsafe { p.reserve_write() }.unwrap().write(43);
 
             // SAFETY: `Payload` is `u64`; `read` copies out, committing on drop.
             assert_eq!(unsafe { c.reserve_read().unwrap().read() }, 42);

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -550,7 +550,7 @@ impl<T> Producer<T> {
     ///   dropped.
     #[must_use]
     pub unsafe fn reserve_write(&mut self) -> Option<WriteGuard<'_, T>> {
-        let start = self.lane.reserve(NonZeroUsize::MIN)?;
+        let start = self.lane.try_reserve(NonZeroUsize::MIN)?;
         Some(WriteGuard {
             producer: self,
             start,
@@ -565,7 +565,7 @@ impl<T> Producer<T> {
     ///   dropped.
     #[must_use]
     pub unsafe fn reserve_write_batch(&mut self, count: NonZeroUsize) -> Option<WriteBatch<'_, T>> {
-        let start = self.lane.reserve(count)?;
+        let start = self.lane.try_reserve(count)?;
         Some(WriteBatch {
             producer: self,
             start,
@@ -1667,7 +1667,7 @@ mod tests {
         // the reservation runs ahead of the publication.
         let mut lane = queue.lane(0);
         assert!(lane.try_acquire());
-        lane.reserve(NonZeroUsize::new(3).unwrap());
+        lane.try_reserve(NonZeroUsize::new(3).unwrap());
         assert_eq!(lane.reserved(), 3);
         assert_eq!(lane.published(), 0);
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -17,10 +17,12 @@ use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, Ordering};
 use std::fs::File;
 use std::sync::Arc;
+use std::time::Duration;
 
-use crate::error::Error;
+use crate::error::{Error, WaitError};
+use crate::futex::{Waiters, SPIN_ATTEMPTS};
 use crate::shmem::Region;
-use crate::{normalized_capacity, VERSION};
+use crate::{normalized_capacity, CacheAlignedAtomicSize, VERSION};
 
 use producer_lane::ProducerLane;
 
@@ -42,8 +44,8 @@ pub struct BroadcastConfig {
 }
 
 /// Shared header at the start of the region. The producer-lane cursors and the
-/// per-consumer reserve limits live in the lane blocks; only consumer-index
-/// ownership is global (the `consumer_state` table after this header).
+/// per-consumer reserve limits live in the lane blocks; consumer-index ownership
+/// and the blocked-consumer wake state are global.
 #[repr(C)]
 struct SharedQueueHeader {
     magic: AtomicU64,
@@ -51,6 +53,11 @@ struct SharedQueueHeader {
     capacity: u32, // per-lane ring capacity (power of two)
     producer_slots: u32,
     consumer_slots: u32,
+    /// Count of consumers blocked waiting for any lane to publish.
+    waiters: Waiters,
+    /// Futex word for blocked consumers: bumped only when a publish wakes one
+    /// (the lane cursors carry the data; this only breaks a racing wait).
+    wake_seq: CacheAlignedAtomicSize,
 }
 
 /// Byte offsets and sizes of the region's sections (a construction-time helper;
@@ -186,6 +193,9 @@ impl<T> SharedQueue<T> {
         header.capacity = layout.capacity;
         header.producer_slots = layout.producer_slots as u32;
         header.consumer_slots = layout.consumer_slots as u32;
+        // Global wake state: no waiters, wake counter at zero.
+        header.waiters.initialize();
+        header.wake_seq.store(0, Ordering::Release);
 
         // Global consumer-ownership table: every index free.
         // SAFETY: the layout reserves `consumer_slots` AtomicU64s here.
@@ -267,6 +277,37 @@ impl<T> SharedQueue<T> {
     #[inline]
     fn consumer_slots(&self) -> usize {
         self.consumer_slots
+    }
+
+    #[inline]
+    fn header(&self) -> &SharedQueueHeader {
+        // SAFETY: the header sits at the region base and outlives this handle.
+        unsafe { self.header.as_ref() }
+    }
+
+    /// Bumps the wake counter and wakes blocked consumers, if any. Called after
+    /// a publish (the lane cursor is already advanced); a no-op on the hot path
+    /// when nothing is blocked.
+    fn wake(&self) {
+        let header = self.header();
+        header.waiters.bump_and_wake(&header.wake_seq);
+    }
+
+    /// Blocks until `check` succeeds or `timeout` elapses, sleeping on the global
+    /// wake counter (a publish on any lane bumps it). `check` reads the lane
+    /// cursors, which carry the actual data.
+    fn wait_for<R>(
+        &self,
+        timeout: Duration,
+        check: impl FnMut() -> Option<R>,
+    ) -> Result<R, WaitError> {
+        // `check` scans every lane, so scale the per-check baseline down by the
+        // lane count to keep total spin work comparable to a single-cursor queue.
+        let spins = (SPIN_ATTEMPTS / self.producer_slots).max(1);
+        let header = self.header();
+        header
+            .waiters
+            .wait_for(&header.wake_seq, spins, timeout, check)
     }
 
     /// The global ownership word for consumer index `index`.
@@ -489,6 +530,7 @@ impl<T> WriteGuard<'_, T> {
 impl<T> Drop for WriteGuard<'_, T> {
     fn drop(&mut self) {
         self.producer.lane.publish(NonZeroUsize::MIN);
+        self.producer.queue.wake();
     }
 }
 
@@ -536,6 +578,7 @@ impl<T> WriteBatch<'_, T> {
 impl<T> Drop for WriteBatch<'_, T> {
     fn drop(&mut self) {
         self.producer.lane.publish(self.count);
+        self.producer.queue.wake();
     }
 }
 
@@ -544,6 +587,8 @@ impl<T> Drop for WriteBatch<'_, T> {
 pub struct Consumer<T> {
     queue: SharedQueue<T>,
     index: usize,
+    /// One cached view per lane (avoids rebuilding it on every read).
+    lanes: Box<[ProducerLane<T>]>,
     /// Next sequence to read per lane (local cache of the published cursors).
     next_by_lane: Box<[usize]>,
     /// Lane to start the next round-robin scan from (rotates for fairness).
@@ -575,14 +620,19 @@ impl<T> Consumer<T> {
     fn from_queue(queue: SharedQueue<T>) -> Result<Self, Error> {
         let index = queue.acquire_consumer_index()?;
         let producer_slots = queue.producer_slots();
-        // Join each lane at its current reservation; cache the start positions.
+        // Cache one view per lane and join each at its current reservation,
+        // caching the start positions.
+        let mut lanes = Vec::with_capacity(producer_slots);
         let mut next_by_lane = Vec::with_capacity(producer_slots);
         for lane in 0..producer_slots {
-            next_by_lane.push(queue.lane(lane).join_consumer(index));
+            let lane = queue.lane(lane);
+            next_by_lane.push(lane.join_consumer(index));
+            lanes.push(lane);
         }
         Ok(Self {
             queue,
             index,
+            lanes: lanes.into_boxed_slice(),
             next_by_lane: next_by_lane.into_boxed_slice(),
             scan_start_lane: 0,
         })
@@ -596,7 +646,7 @@ impl<T> Consumer<T> {
         let mut lane = self.scan_start_lane;
         for _ in 0..producer_slots {
             let next = self.next_by_lane[lane];
-            if self.queue.lane(lane).published().wrapping_sub(next) > 0 {
+            if self.lanes[lane].published().wrapping_sub(next) > 0 {
                 return Some((lane, next));
             }
             // `lane < producer_slots`, so the wrap is a conditional subtract, not
@@ -616,7 +666,7 @@ impl<T> Consumer<T> {
     fn advance(&mut self, lane: usize, count: NonZeroUsize) {
         let next = self.next_by_lane[lane].wrapping_add(count.get());
         self.next_by_lane[lane] = next;
-        self.queue.lane(lane).set_consumer_cursor(self.index, next);
+        self.lanes[lane].set_consumer_cursor(self.index, next);
         // `lane < producer_slots`, so the wrap is a conditional subtract.
         let mut scan_start_lane = lane.wrapping_add(1);
         if scan_start_lane == self.queue.producer_slots() {
@@ -635,7 +685,7 @@ impl<T> Consumer<T> {
         // SAFETY: `sequence < publication`, so the cell is published (initialized);
         // this consumer's cursor still protects it from being overwritten until we
         // advance below. The copy happens before the cursor advances.
-        let value = unsafe { self.queue.lane(lane).payload_ptr(sequence).as_ptr().read() };
+        let value = unsafe { self.lanes[lane].payload_ptr(sequence).as_ptr().read() };
         self.advance(lane, NonZeroUsize::MIN);
         Some(value)
     }
@@ -643,12 +693,11 @@ impl<T> Consumer<T> {
     /// Reserves the next available value in place without copying, or `None` if
     /// every lane is caught up. The returned guard holds this consumer's cursor
     /// at the value's sequence, so the producer cannot overwrite it until the
-    /// guard is committed (dropping without committing leaves the cursor for a
-    /// re-read).
+    /// guard is dropped, which advances past it.
     #[must_use]
     pub fn reserve_read(&mut self) -> Option<ReadGuard<'_, T>> {
         let (lane, sequence) = self.next_readable()?;
-        let payload = self.queue.lane(lane).payload_ptr(sequence);
+        let payload = self.lanes[lane].payload_ptr(sequence);
         Some(ReadGuard {
             consumer: self,
             lane,
@@ -661,12 +710,12 @@ impl<T> Consumer<T> {
     /// lane, so its length is bounded by that lane's available run as well as by
     /// `max`. The returned guard holds this consumer's cursor at the batch start,
     /// so the producer cannot overwrite any of the batched cells until the guard
-    /// is committed (or dropped, which leaves the cursor for a re-read).
+    /// is dropped, which advances past the whole batch.
     #[must_use]
     pub fn reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
         let (lane, start) = self.next_readable()?;
         // `next_readable` guarantees at least one published value past `start`.
-        let available = self.queue.lane(lane).published().wrapping_sub(start);
+        let available = self.lanes[lane].published().wrapping_sub(start);
         let count = available.min(max.get());
         let count = NonZeroUsize::new(count).expect("readable lane has at least one value");
         Some(ReadBatch {
@@ -676,14 +725,57 @@ impl<T> Consumer<T> {
             count,
         })
     }
+
+    /// Blocks until any lane has an unread value or `timeout` elapses, then
+    /// returns a [`ReadGuard`] for it; `Err(Timeout)` if none arrived in time.
+    pub fn reserve_read_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<ReadGuard<'_, T>, WaitError> {
+        self.wait_until_readable(timeout)?;
+        Ok(self
+            .reserve_read()
+            .expect("a lane is readable after a successful wait"))
+    }
+
+    /// Blocks until any lane has unread values or `timeout` elapses, then returns
+    /// a [`ReadBatch`] of up to `max` of them; `Err(Timeout)` if none arrived.
+    pub fn reserve_read_batch_timeout(
+        &mut self,
+        max: NonZeroUsize,
+        timeout: Duration,
+    ) -> Result<ReadBatch<'_, T>, WaitError> {
+        self.wait_until_readable(timeout)?;
+        Ok(self
+            .reserve_read_batch(max)
+            .expect("a lane is readable after a successful wait"))
+    }
+
+    /// Blocks until any lane has an unread value or `timeout` elapses, then
+    /// copies it out; `Err(Timeout)` if none arrived in time.
+    ///
+    /// # Safety
+    /// - `T` must be valid to read from shared-memory bytes in this process.
+    pub unsafe fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
+        let guard = self.reserve_read_timeout(timeout)?;
+        // SAFETY: forwarded to the caller's contract.
+        Ok(unsafe { guard.read() })
+    }
+
+    /// Blocks until [`Self::next_readable`] would succeed, sleeping on the queue's
+    /// global wake counter (a publish on any lane wakes it).
+    fn wait_until_readable(&self, timeout: Duration) -> Result<(), WaitError> {
+        self.queue
+            .wait_for(timeout, || self.next_readable().map(|_| ()))
+    }
 }
 
 impl<T> Drop for Consumer<T> {
     fn drop(&mut self) {
         // Drop each lane's reserve limit first, then the global ownership, so no
         // limit lingers for an index another consumer could reclaim.
-        for lane in 0..self.queue.producer_slots() {
-            self.queue.lane(lane).release_consumer(self.index);
+        for lane in self.lanes.iter() {
+            lane.release_consumer(self.index);
         }
         self.queue.release_consumer_index(self.index);
     }
@@ -761,9 +853,7 @@ impl<T> ReadBatch<'_, T> {
     /// - `index < len`.
     pub unsafe fn as_ptr(&self, index: usize) -> *const T {
         debug_assert!(index < self.count.get());
-        self.consumer
-            .queue
-            .lane(self.lane)
+        self.consumer.lanes[self.lane]
             .payload_ptr(self.start.wrapping_add(index))
             .as_ptr()
     }
@@ -1128,6 +1218,88 @@ mod tests {
             // SAFETY: `Payload` is `u64`.
             assert_eq!(unsafe { c.try_read() }, Some(99));
             assert_eq!(unsafe { c.try_read() }, None);
+        }
+    }
+
+    #[test]
+    fn reserve_read_timeout_times_out_then_observes_publication() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 2,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+
+            // Nothing published on any lane yet: a zero timeout reports `Timeout`
+            // rather than blocking.
+            assert!(matches!(
+                c.reserve_read_timeout(Duration::ZERO),
+                Err(WaitError::Timeout)
+            ));
+
+            // A publish on any lane satisfies the (already-elapsed) wait.
+            assert!(p.try_write(42).is_ok());
+            let guard = c.reserve_read_timeout(Duration::ZERO).expect("readable");
+            // SAFETY: `Payload` is `u64`.
+            assert_eq!(unsafe { *guard.as_ref() }, 42);
+        }
+    }
+
+    /// Exercises the real `FUTEX_WAIT` syscall (not just the elapsed-deadline
+    /// short-circuit): with nothing published, a bounded wait blocks in the
+    /// kernel on the wake counter and returns `Timeout`.
+    #[cfg(not(miri))]
+    #[test]
+    fn reserve_read_timeout_blocks_in_futex_then_times_out() {
+        for create in producer_creators() {
+            let p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 2,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+            assert!(matches!(
+                c.reserve_read_timeout(Duration::from_millis(5)),
+                Err(WaitError::Timeout)
+            ));
+        }
+    }
+
+    #[test]
+    fn read_and_batch_timeout_observe_publication() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+
+            // SAFETY: `Payload` is `u64`.
+            assert!(matches!(
+                unsafe { c.read_timeout(Duration::ZERO) },
+                Err(WaitError::Timeout)
+            ));
+            assert!(matches!(
+                c.reserve_read_batch_timeout(NonZeroUsize::new(4).unwrap(), Duration::ZERO),
+                Err(WaitError::Timeout)
+            ));
+
+            for value in 0..2u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            // The batch sees both published values; dropping it commits them.
+            {
+                let batch = c
+                    .reserve_read_batch_timeout(NonZeroUsize::new(4).unwrap(), Duration::ZERO)
+                    .expect("readable");
+                assert_eq!(batch.len(), 2);
+            }
+            assert!(matches!(
+                c.reserve_read_batch_timeout(NonZeroUsize::new(4).unwrap(), Duration::ZERO),
+                Err(WaitError::Timeout)
+            ));
         }
     }
 }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -78,6 +78,36 @@ struct SharedQueueHeader {
     wake_seq: CacheAlignedAtomicSize,
 }
 
+impl SharedQueueHeader {
+    /// Initializes the shared queue header and publishes the region.
+    ///
+    /// # Safety
+    /// - `header` must be non-null, properly aligned, and large enough for
+    ///   [`SharedQueueHeader`].
+    /// - Access to `header` must be unique.
+    /// - The queue's non-header sections must already be initialized.
+    unsafe fn init(header: NonNull<Self>, layout: &Layout) {
+        // SAFETY: caller guarantees valid, uniquely-owned storage for the header.
+        unsafe {
+            header.as_ptr().write(Self {
+                magic: AtomicU64::new(0),
+                version: VERSION,
+                capacity: layout.capacity,
+                producer_slots: layout.producer_slots as u32,
+                consumer_slots: layout.consumer_slots as u32,
+                waiters: Waiters::default(),
+                wake_seq: CacheAlignedAtomicSize::default(),
+            });
+        }
+
+        // Publish initialization last.
+        // SAFETY: the header was initialized by the write above.
+        unsafe { header.as_ref() }
+            .magic
+            .store(MAGIC, Ordering::Release);
+    }
+}
+
 /// Byte offsets and sizes of the region's sections (a construction-time helper;
 /// `SharedQueue` keeps only the runtime scalars from it).
 struct Layout {
@@ -213,15 +243,6 @@ impl<T> SharedQueue<T> {
     /// - `region` must be at least `layout.total` bytes and initialized once.
     unsafe fn initialize(region: &Arc<Region>, layout: &Layout) {
         let base = region.addr();
-        // SAFETY: regions are page-aligned and large enough for the header.
-        let header = unsafe { &mut *base.cast::<SharedQueueHeader>().as_ptr() };
-        header.version = VERSION;
-        header.capacity = layout.capacity;
-        header.producer_slots = layout.producer_slots as u32;
-        header.consumer_slots = layout.consumer_slots as u32;
-        // Global wake state: no waiters, wake counter at zero.
-        header.waiters.initialize();
-        header.wake_seq.store(0, Ordering::Release);
 
         // Global consumer-ownership table: every index free.
         let consumer_state = unsafe { base.byte_add(layout.consumer_state_offset) };
@@ -238,8 +259,12 @@ impl<T> SharedQueue<T> {
             unsafe { ProducerLane::<T>::init(block, layout.consumer_slots) };
         }
 
-        // Publish initialization last.
-        header.magic.store(MAGIC, Ordering::Release);
+        // Header initialization publishes the queue, so it runs after every
+        // other region section is initialized.
+        let header = base.cast::<SharedQueueHeader>();
+        // SAFETY: region is page-aligned, large enough for the header, uniquely
+        // initialized here, and all non-header sections are initialized above.
+        unsafe { SharedQueueHeader::init(header, layout) };
     }
 
     fn from_region(region: Arc<Region>, layout: Layout) -> Self {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -619,7 +619,7 @@ impl<T> WriteGuard<'_, T> {
 
 impl<T> Drop for WriteGuard<'_, T> {
     fn drop(&mut self) {
-        self.producer.lane.publish(NonZeroUsize::MIN);
+        self.producer.lane.publish(self.start, NonZeroUsize::MIN);
         self.producer.queue.wake();
     }
 }
@@ -669,7 +669,7 @@ impl<T> WriteBatch<'_, T> {
 
 impl<T> Drop for WriteBatch<'_, T> {
     fn drop(&mut self) {
-        self.producer.lane.publish(self.count);
+        self.producer.lane.publish(self.start, self.count);
         self.producer.queue.wake();
     }
 }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -28,10 +28,11 @@
 //! table, and the blocked-consumer wake counter) followed by one lane block per
 //! producer.
 
+mod consumer_state;
 mod producer_lane;
 
 use core::marker::PhantomData;
-use core::mem::{align_of, size_of};
+use core::mem::size_of;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -44,12 +45,10 @@ use crate::futex::{Waiters, SPIN_ATTEMPTS};
 use crate::shmem::Region;
 use crate::{CacheAlignedAtomicSize, VERSION};
 
+use consumer_state::ConsumerState;
 use producer_lane::ProducerLane;
 
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqcast");
-
-const CONSUMER_FREE: u64 = 0;
-const CONSUMER_ACTIVE: u64 = 1;
 
 /// Runtime configuration for a broadcast queue.
 ///
@@ -116,8 +115,8 @@ impl Layout {
         let capacity = capacity as u32;
 
         let consumer_state_offset =
-            size_of::<SharedQueueHeader>().next_multiple_of(align_of::<AtomicU64>());
-        let consumer_state_bytes = config.consumer_slots.checked_mul(size_of::<AtomicU64>())?;
+            size_of::<SharedQueueHeader>().next_multiple_of(ConsumerState::block_align());
+        let consumer_state_bytes = ConsumerState::block_size(config.consumer_slots)?;
 
         let block_align = ProducerLane::<T>::block_align();
         let producer_blocks_offset = consumer_state_offset
@@ -161,12 +160,11 @@ impl Layout {
 struct SharedQueue<T> {
     region: Arc<Region>,
     header: NonNull<SharedQueueHeader>,
-    consumer_state: NonNull<AtomicU64>,
+    consumer_state: ConsumerState,
     producer_blocks: NonNull<u8>,
     // Runtime scalars (the layout offsets are construction-only, so not kept).
     capacity: u32,
     producer_slots: usize,
-    consumer_slots: usize,
     block_stride: usize,
     _marker: PhantomData<T>,
 }
@@ -225,20 +223,9 @@ impl<T> SharedQueue<T> {
         header.wake_seq.store(0, Ordering::Release);
 
         // Global consumer-ownership table: every index free.
+        let consumer_state = unsafe { base.byte_add(layout.consumer_state_offset) };
         // SAFETY: the layout reserves `consumer_slots` AtomicU64s here.
-        let consumer_state = unsafe {
-            base.byte_add(layout.consumer_state_offset)
-                .cast::<AtomicU64>()
-        };
-        for index in 0..layout.consumer_slots {
-            // SAFETY: `index < consumer_slots`.
-            unsafe {
-                consumer_state
-                    .add(index)
-                    .as_ptr()
-                    .write(AtomicU64::new(CONSUMER_FREE))
-            };
-        }
+        unsafe { ConsumerState::init(consumer_state, layout.consumer_slots) };
 
         // Producer-lane blocks.
         // SAFETY: the layout reserves `producer_slots` blocks of `block_stride`.
@@ -258,7 +245,12 @@ impl<T> SharedQueue<T> {
         let base = region.addr();
         let header = base.cast::<SharedQueueHeader>();
         // SAFETY: offsets lie within the region.
-        let consumer_state = unsafe { base.byte_add(layout.consumer_state_offset).cast() };
+        let consumer_state = unsafe {
+            ConsumerState::from_block(
+                base.byte_add(layout.consumer_state_offset),
+                layout.consumer_slots,
+            )
+        };
         // SAFETY: offsets lie within the region.
         let producer_blocks = unsafe { base.byte_add(layout.producer_blocks_offset) };
         Self {
@@ -268,7 +260,6 @@ impl<T> SharedQueue<T> {
             producer_blocks,
             capacity: layout.capacity,
             producer_slots: layout.producer_slots,
-            consumer_slots: layout.consumer_slots,
             block_stride: layout.block_stride,
             _marker: PhantomData,
         }
@@ -288,7 +279,7 @@ impl<T> SharedQueue<T> {
                 .byte_add(lane.wrapping_mul(self.block_stride))
         };
         // SAFETY: the block was initialized with these parameters.
-        unsafe { ProducerLane::from_block(block, self.capacity, self.consumer_slots) }
+        unsafe { ProducerLane::from_block(block, self.capacity, self.consumer_slots()) }
     }
 
     /// Claims a free producer lane, returning its index.
@@ -303,7 +294,7 @@ impl<T> SharedQueue<T> {
 
     #[inline]
     fn consumer_slots(&self) -> usize {
-        self.consumer_slots
+        self.consumer_state.len()
     }
 
     #[inline]
@@ -337,44 +328,20 @@ impl<T> SharedQueue<T> {
             .wait_for(&header.wake_seq, spins, timeout, check)
     }
 
-    /// The global ownership word for consumer index `index`.
-    #[inline]
-    fn consumer_state(&self, index: usize) -> &AtomicU64 {
-        debug_assert!(index < self.consumer_slots);
-        // SAFETY: `index < consumer_slots`; the slot was initialized.
-        unsafe { &*self.consumer_state.add(index).as_ptr() }
-    }
-
     /// Claims a free consumer index in the global ownership table.
     fn acquire_consumer_index(&self) -> Result<usize, Error> {
-        for index in 0..self.consumer_slots {
-            if self
-                .consumer_state(index)
-                .compare_exchange(
-                    CONSUMER_FREE,
-                    CONSUMER_ACTIVE,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_ok()
-            {
-                return Ok(index);
-            }
-        }
-        Err(Error::ConsumerSlotsExhausted)
+        self.consumer_state.acquire()
     }
 
     /// Releases a consumer index back to free.
     fn release_consumer_index(&self, index: usize) {
-        self.consumer_state(index)
-            .store(CONSUMER_FREE, Ordering::Release);
+        self.consumer_state.release(index);
     }
 
     /// Force-owns a consumer index whose previous owner died (no CAS). The
     /// caller guarantees that owner is dead and no live handle uses the index.
     fn recover_consumer_index(&self, index: usize) {
-        self.consumer_state(index)
-            .store(CONSUMER_ACTIVE, Ordering::Release);
+        self.consumer_state.recover(index);
     }
 
     /// Maps `file`, initializing it as a broadcast queue.
@@ -411,7 +378,6 @@ impl<T> Clone for SharedQueue<T> {
             producer_blocks: self.producer_blocks,
             capacity: self.capacity,
             producer_slots: self.producer_slots,
-            consumer_slots: self.consumer_slots,
             block_stride: self.block_stride,
             _marker: PhantomData,
         }
@@ -769,7 +735,7 @@ impl<T> Consumer<T> {
             .collect();
         let next_by_lane = lanes
             .iter()
-            .map(|lane| lane.join_consumer(index, from_backlog))
+            .map(|lane| Self::join_lane(lane, index, from_backlog))
             .collect();
         Ok(Self {
             queue,
@@ -817,7 +783,7 @@ impl<T> Consumer<T> {
             .collect();
         let next_by_lane = lanes
             .iter()
-            .map(|lane| lane.recover_consumer(index))
+            .map(|lane| Self::recover_lane(lane, index))
             .collect();
         Ok(Self {
             queue,
@@ -846,10 +812,20 @@ impl<T> Consumer<T> {
             return Err(Error::InvalidIndex);
         }
         for lane in 0..queue.producer_slots() {
-            queue.lane(lane).release_consumer(index);
+            queue.lane(lane).consumer_state().release(index);
         }
         queue.release_consumer_index(index);
         Ok(())
+    }
+
+    fn join_lane(lane: &ProducerLane<T>, index: usize, from_backlog: bool) -> usize {
+        let consumer_state = lane.consumer_state();
+        consumer_state.join(index, from_backlog, lane.published(), || lane.reserved())
+    }
+
+    fn recover_lane(lane: &ProducerLane<T>, index: usize) -> usize {
+        let consumer_state = lane.consumer_state();
+        consumer_state.recover(index, lane.published(), || lane.reserved())
     }
 
     /// Finds the next readable `(lane, sequence)`, scanning round-robin from
@@ -879,7 +855,9 @@ impl<T> Consumer<T> {
     fn advance(&mut self, lane: usize, count: NonZeroUsize) {
         let next = self.next_by_lane[lane].wrapping_add(count.get());
         self.next_by_lane[lane] = next;
-        self.lanes[lane].set_consumer_cursor(self.index, next);
+        self.lanes[lane]
+            .consumer_state()
+            .set_cursor(self.index, next);
         // `lane < producer_slots`, so the wrap is a conditional subtract.
         let mut scan_start_lane = lane.wrapping_add(1);
         if scan_start_lane == self.queue.producer_slots() {
@@ -988,7 +966,7 @@ impl<T> Drop for Consumer<T> {
         // Drop each lane's reserve limit first, then the global ownership, so no
         // limit lingers for an index another consumer could reclaim.
         for lane in self.lanes.iter() {
-            lane.release_consumer(self.index);
+            lane.consumer_state().release(self.index);
         }
         self.queue.release_consumer_index(self.index);
     }
@@ -1712,13 +1690,14 @@ mod tests {
         // position recorded (next-to-read = 1). Build that state directly (claim
         // the index, join, record the cursor) so nothing releases the slot.
         let index = queue.acquire_consumer_index().unwrap();
-        queue.lane(0).join_consumer(index, false);
+        let lane = queue.lane(0);
+        Consumer::join_lane(&lane, index, false);
 
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());
         }
-        queue.lane(0).set_consumer_cursor(index, 1);
+        lane.consumer_state().set_cursor(index, 1);
 
         // Recovery resumes at the recorded position: it reads the unread backlog
         // (items 1, 2), never re-reading item 0.
@@ -1742,12 +1721,13 @@ mod tests {
         // The only consumer index is claimed and the lane's limit recorded, then
         // its owner "crashes" (no release).
         let index = queue.acquire_consumer_index().unwrap();
-        queue.lane(0).join_consumer(index, false);
+        let lane = queue.lane(0);
+        Consumer::join_lane(&lane, index, false);
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());
         }
-        queue.lane(0).set_consumer_cursor(index, 1);
+        lane.consumer_state().set_cursor(index, 1);
 
         // A fresh join can't proceed — the index is still owned.
         assert!(matches!(
@@ -1758,7 +1738,7 @@ mod tests {
         // Force-release frees it (clear limits + free the index); a catch-up join
         // then reclaims it and reads the still-present backlog from the start.
         for lane in 0..queue.producer_slots() {
-            queue.lane(lane).release_consumer(index);
+            queue.lane(lane).consumer_state().release(index);
         }
         queue.release_consumer_index(index);
         let mut fresh = Consumer::from_queue(queue.clone(), true).unwrap();

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -91,7 +91,11 @@ struct Layout {
 }
 
 impl Layout {
-    fn new<T>(config: &BroadcastConfig) -> Option<Self> {
+    fn new<T>(config: &BroadcastConfig) -> Result<Self, Error> {
+        Self::checked_new::<T>(config).ok_or(Error::InvalidBufferSize)
+    }
+
+    fn checked_new<T>(config: &BroadcastConfig) -> Option<Self> {
         if config.capacity == 0 {
             return None;
         }
@@ -145,7 +149,7 @@ impl Layout {
         };
         // `capacity` is already a power of two, so the recomputed layout must
         // match the stored capacity exactly.
-        let layout = Layout::new::<T>(&config).ok_or(Error::InvalidBufferSize)?;
+        let layout = Layout::new::<T>(&config)?;
         if layout.capacity as usize != capacity || region_size < layout.total {
             return Err(Error::InvalidBufferSize);
         }
@@ -176,7 +180,7 @@ impl<T> SharedQueue<T> {
         region: &Arc<Region>,
         config: &BroadcastConfig,
     ) -> Result<Self, Error> {
-        let layout = Layout::new::<T>(config).ok_or(Error::InvalidBufferSize)?;
+        let layout = Layout::new::<T>(config)?;
         if region.size() < layout.total {
             return Err(Error::InvalidBufferSize);
         }
@@ -379,7 +383,7 @@ impl<T> SharedQueue<T> {
     /// - `file` must be initialized as a queue at most once (by the designated
     ///   initializer) and not resized while any handle is joined.
     unsafe fn create(file: &File, config: &BroadcastConfig) -> Result<Self, Error> {
-        let layout = Layout::new::<T>(config).ok_or(Error::InvalidBufferSize)?;
+        let layout = Layout::new::<T>(config)?;
         file.set_len(layout.total as u64)?;
         let region = Region::map_file(file, layout.total)?;
         // SAFETY: caller guarantees this mapping is initialized exactly once.
@@ -1277,7 +1281,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        assert!(Layout::new::<Payload>(&config).is_none());
+        assert!(Layout::new::<Payload>(&config).is_err());
     }
 
     #[test]
@@ -1287,7 +1291,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        assert!(Layout::new::<Payload>(&config).is_none());
+        assert!(Layout::new::<Payload>(&config).is_err());
     }
 
     #[test]

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -263,6 +263,68 @@ impl<T> SharedQueue<T> {
         }
         Err(Error::ProducerSlotsExhausted)
     }
+
+    #[inline]
+    fn consumer_slots(&self) -> usize {
+        self.consumer_slots
+    }
+
+    /// The global ownership word for consumer index `index`.
+    #[inline]
+    fn consumer_state(&self, index: usize) -> &AtomicU64 {
+        debug_assert!(index < self.consumer_slots);
+        // SAFETY: `index < consumer_slots`; the slot was initialized.
+        unsafe { &*self.consumer_state.add(index).as_ptr() }
+    }
+
+    /// Claims a free consumer index in the global ownership table.
+    fn acquire_consumer_index(&self) -> Result<usize, Error> {
+        for index in 0..self.consumer_slots {
+            if self
+                .consumer_state(index)
+                .compare_exchange(
+                    CONSUMER_FREE,
+                    CONSUMER_ACTIVE,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return Ok(index);
+            }
+        }
+        Err(Error::ConsumerSlotsExhausted)
+    }
+
+    /// Releases a consumer index back to free.
+    fn release_consumer_index(&self, index: usize) {
+        self.consumer_state(index)
+            .store(CONSUMER_FREE, Ordering::Release);
+    }
+
+    /// Maps `file`, initializing it as a broadcast queue.
+    ///
+    /// # Safety
+    /// - `file` must be initialized as a queue at most once (by the designated
+    ///   initializer) and not resized while any handle is joined.
+    unsafe fn create(file: &File, config: &BroadcastConfig) -> Result<Self, Error> {
+        let layout = Layout::new::<T>(config).ok_or(Error::InvalidBufferSize)?;
+        file.set_len(layout.total as u64)?;
+        let region = Region::map_file(file, layout.total)?;
+        // SAFETY: caller guarantees this mapping is initialized exactly once.
+        unsafe { Self::create_in_region(&region, config) }
+    }
+
+    /// Maps and validates an existing broadcast queue in `file`.
+    ///
+    /// # Safety
+    /// - `file` must refer to a live broadcast queue, not resized while joined.
+    unsafe fn join(file: &File) -> Result<Self, Error> {
+        let file_size = file.metadata()?.len() as usize;
+        let region = Region::map_file(file, file_size)?;
+        // SAFETY: validated against the stored header.
+        unsafe { Self::join_region(&region) }
+    }
 }
 
 impl<T> Clone for SharedQueue<T> {
@@ -305,11 +367,8 @@ impl<T> Producer<T> {
     /// - All producers/consumers for `file` must use the same `T`; queued values
     ///   must be valid to read/overwrite as shared-memory bytes in each process.
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
-        let layout = Layout::new::<T>(&config).ok_or(Error::InvalidBufferSize)?;
-        file.set_len(layout.total as u64)?;
-        let region = Region::map_file(file, layout.total)?;
         // SAFETY: caller guarantees this mapping is initialized exactly once.
-        let queue = unsafe { SharedQueue::create_in_region(&region, &config) }?;
+        let queue = unsafe { SharedQueue::create(file, &config) }?;
         Self::from_queue(queue)
     }
 
@@ -319,10 +378,8 @@ impl<T> Producer<T> {
     /// - `file` must refer to a live broadcast queue (not resized while joined),
     ///   with the same `T` as every other handle (see [`Self::create`]).
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
-        let file_size = file.metadata()?.len() as usize;
-        let region = Region::map_file(file, file_size)?;
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join_region(&region) }?;
+        let queue = unsafe { SharedQueue::join(file) }?;
         Self::from_queue(queue)
     }
 
@@ -337,16 +394,35 @@ impl<T> Producer<T> {
         Self::from_queue(self.queue.clone())
     }
 
+    /// Joins the same queue as a consumer (sharing the mapping). The consumer
+    /// starts at each lane's current reservation, so it only observes items
+    /// published after it joins.
+    pub fn join_as_consumer(&self) -> Result<Consumer<T>, Error> {
+        Consumer::from_queue(self.queue.clone())
+    }
+
     /// Publishes one value, or returns it on backpressure (the slowest consumer
     /// has not freed the cell that publishing would overwrite).
     pub fn try_write(&mut self, value: T) -> Result<(), T> {
-        let Some(start) = self.lane.reserve(NonZeroUsize::MIN) else {
-            return Err(value);
-        };
-        // SAFETY: the cell is reserved and not yet published; `T` is moved in.
-        unsafe { self.lane.payload_ptr(start).as_ptr().write(value) };
-        self.lane.publish(start, NonZeroUsize::MIN);
-        Ok(())
+        match self.reserve_write() {
+            Some(guard) => {
+                guard.write(value);
+                Ok(())
+            }
+            None => Err(value),
+        }
+    }
+
+    /// Reserves a single cell for an in-place write, or `None` on backpressure.
+    /// The cell becomes visible when the returned guard is dropped; the caller
+    /// must write it first.
+    #[must_use]
+    pub fn reserve_write(&mut self) -> Option<WriteGuard<'_, T>> {
+        let start = self.lane.reserve(NonZeroUsize::MIN)?;
+        Some(WriteGuard {
+            producer: self,
+            start,
+        })
     }
 
     /// Reserves `count` consecutive cells for in-place writes, or `None` on
@@ -372,6 +448,49 @@ impl<T> Drop for Producer<T> {
 // SAFETY: a producer is single-threaded (write ops take `&mut self`) but may be
 // moved between threads.
 unsafe impl<T: Send> Send for Producer<T> {}
+
+/// A reservation of one cell in a producer's lane. Write it via
+/// [`Self::write`]/[`Self::as_mut_ptr`], then drop the guard to publish it.
+#[must_use]
+pub struct WriteGuard<'a, T> {
+    producer: &'a mut Producer<T>,
+    start: usize,
+}
+
+impl<T> WriteGuard<'_, T> {
+    /// Pointer to the reserved cell.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.producer.lane.payload_ptr(self.start).as_ptr()
+    }
+
+    /// Mutable reference to the reserved cell.
+    ///
+    /// # Safety
+    /// - The cell is uninitialized; `T` must be valid for any bytes (the caller
+    ///   must not read it before fully initializing it).
+    pub unsafe fn as_mut_ref(&mut self) -> &mut T {
+        // SAFETY: forwarded; the cell is reserved for this producer.
+        unsafe { &mut *self.as_mut_ptr() }
+    }
+
+    /// Writes `value` into the reserved cell; the guard publishes it on drop.
+    pub fn write(self, value: T) {
+        // SAFETY: the cell is reserved and not yet published; `T` is moved in.
+        unsafe {
+            self.producer
+                .lane
+                .payload_ptr(self.start)
+                .as_ptr()
+                .write(value)
+        };
+    }
+}
+
+impl<T> Drop for WriteGuard<'_, T> {
+    fn drop(&mut self) {
+        self.producer.lane.publish(NonZeroUsize::MIN);
+    }
+}
 
 /// A reservation of `count` cells in a producer's lane. Write every cell via
 /// [`Self::write`]/[`Self::as_mut_ptr`], then drop the batch to publish them.
@@ -416,7 +535,266 @@ impl<T> WriteBatch<'_, T> {
 
 impl<T> Drop for WriteBatch<'_, T> {
     fn drop(&mut self) {
-        self.producer.lane.publish(self.start, self.count);
+        self.producer.lane.publish(self.count);
+    }
+}
+
+/// A consumer: owns one consumer index and reads every lane round-robin. Reads
+/// only items published after it joins. Single-threaded use (`&mut self`).
+pub struct Consumer<T> {
+    queue: SharedQueue<T>,
+    index: usize,
+    /// Next sequence to read per lane (local cache of the published cursors).
+    next_by_lane: Box<[usize]>,
+    /// Lane to start the next round-robin scan from (rotates for fairness).
+    scan_start_lane: usize,
+}
+
+impl<T> Consumer<T> {
+    /// Creates a broadcast queue in `file` and joins as a consumer.
+    ///
+    /// # Safety
+    /// - Same as [`Producer::create`]: `file` initialized as a queue exactly once
+    ///   (the consumer may be the initializer), same `T` across all handles.
+    pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
+        // SAFETY: caller guarantees this mapping is initialized exactly once.
+        let queue = unsafe { SharedQueue::create(file, &config) }?;
+        Self::from_queue(queue)
+    }
+
+    /// Joins an existing broadcast queue in `file` as a consumer.
+    ///
+    /// # Safety
+    /// - Same as [`Producer::join`]: live queue, same `T` across all handles.
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join(file) }?;
+        Self::from_queue(queue)
+    }
+
+    fn from_queue(queue: SharedQueue<T>) -> Result<Self, Error> {
+        let index = queue.acquire_consumer_index()?;
+        let producer_slots = queue.producer_slots();
+        // Join each lane at its current reservation; cache the start positions.
+        let mut next_by_lane = Vec::with_capacity(producer_slots);
+        for lane in 0..producer_slots {
+            next_by_lane.push(queue.lane(lane).join_consumer(index));
+        }
+        Ok(Self {
+            queue,
+            index,
+            next_by_lane: next_by_lane.into_boxed_slice(),
+            scan_start_lane: 0,
+        })
+    }
+
+    /// Finds the next readable `(lane, sequence)`, scanning round-robin from
+    /// `scan_start_lane`. A lane is readable when its publication is ahead of
+    /// this consumer's cursor.
+    fn next_readable(&self) -> Option<(usize, usize)> {
+        let producer_slots = self.queue.producer_slots();
+        let mut lane = self.scan_start_lane;
+        for _ in 0..producer_slots {
+            let next = self.next_by_lane[lane];
+            if self.queue.lane(lane).published().wrapping_sub(next) > 0 {
+                return Some((lane, next));
+            }
+            // `lane < producer_slots`, so the wrap is a conditional subtract, not
+            // a division.
+            lane = lane.wrapping_add(1);
+            if lane == producer_slots {
+                lane = 0;
+            }
+        }
+        None
+    }
+
+    /// Advances this consumer's cursor on `lane` by `count` consumed values,
+    /// publishing the progress and rotating the scan start. The consumer is the
+    /// sole reader of its own cursor (`&mut self`), so the cursor only moves here
+    /// and advancing is a plain increment.
+    fn advance(&mut self, lane: usize, count: NonZeroUsize) {
+        let next = self.next_by_lane[lane].wrapping_add(count.get());
+        self.next_by_lane[lane] = next;
+        self.queue.lane(lane).set_consumer_cursor(self.index, next);
+        // `lane < producer_slots`, so the wrap is a conditional subtract.
+        let mut scan_start_lane = lane.wrapping_add(1);
+        if scan_start_lane == self.queue.producer_slots() {
+            scan_start_lane = 0;
+        }
+        self.scan_start_lane = scan_start_lane;
+    }
+
+    /// Reads the next available value by copying it out, or `None` if every lane
+    /// is caught up.
+    ///
+    /// # Safety
+    /// - `T` must be valid to read from shared-memory bytes in this process.
+    pub unsafe fn try_read(&mut self) -> Option<T> {
+        let (lane, sequence) = self.next_readable()?;
+        // SAFETY: `sequence < publication`, so the cell is published (initialized);
+        // this consumer's cursor still protects it from being overwritten until we
+        // advance below. The copy happens before the cursor advances.
+        let value = unsafe { self.queue.lane(lane).payload_ptr(sequence).as_ptr().read() };
+        self.advance(lane, NonZeroUsize::MIN);
+        Some(value)
+    }
+
+    /// Reserves the next available value in place without copying, or `None` if
+    /// every lane is caught up. The returned guard holds this consumer's cursor
+    /// at the value's sequence, so the producer cannot overwrite it until the
+    /// guard is committed (dropping without committing leaves the cursor for a
+    /// re-read).
+    #[must_use]
+    pub fn reserve_read(&mut self) -> Option<ReadGuard<'_, T>> {
+        let (lane, sequence) = self.next_readable()?;
+        let payload = self.queue.lane(lane).payload_ptr(sequence);
+        Some(ReadGuard {
+            consumer: self,
+            lane,
+            payload,
+        })
+    }
+
+    /// Reserves up to `max` consecutive published values from the next readable
+    /// lane, or `None` if every lane is caught up. A batch reads from a single
+    /// lane, so its length is bounded by that lane's available run as well as by
+    /// `max`. The returned guard holds this consumer's cursor at the batch start,
+    /// so the producer cannot overwrite any of the batched cells until the guard
+    /// is committed (or dropped, which leaves the cursor for a re-read).
+    #[must_use]
+    pub fn reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
+        let (lane, start) = self.next_readable()?;
+        // `next_readable` guarantees at least one published value past `start`.
+        let available = self.queue.lane(lane).published().wrapping_sub(start);
+        let count = available.min(max.get());
+        let count = NonZeroUsize::new(count).expect("readable lane has at least one value");
+        Some(ReadBatch {
+            consumer: self,
+            lane,
+            start,
+            count,
+        })
+    }
+}
+
+impl<T> Drop for Consumer<T> {
+    fn drop(&mut self) {
+        // Drop each lane's reserve limit first, then the global ownership, so no
+        // limit lingers for an index another consumer could reclaim.
+        for lane in 0..self.queue.producer_slots() {
+            self.queue.lane(lane).release_consumer(self.index);
+        }
+        self.queue.release_consumer_index(self.index);
+    }
+}
+
+// SAFETY: a consumer is single-threaded (read ops take `&mut self`) but may be
+// moved between threads.
+unsafe impl<T: Send> Send for Consumer<T> {}
+
+/// An in-place borrow of one published value. The consumer's cursor stays at
+/// this value's sequence while the guard lives (so the producer cannot overwrite
+/// it); dropping the guard advances past it.
+#[must_use]
+pub struct ReadGuard<'a, T> {
+    consumer: &'a mut Consumer<T>,
+    lane: usize,
+    payload: NonNull<T>,
+}
+
+impl<T> ReadGuard<'_, T> {
+    /// Pointer to the borrowed value.
+    pub fn as_ptr(&self) -> *const T {
+        self.payload.as_ptr()
+    }
+
+    /// Reference to the borrowed value.
+    ///
+    /// # Safety
+    /// - `T` must be valid to reference as shared-memory bytes in this process.
+    pub unsafe fn as_ref(&self) -> &T {
+        // SAFETY: the cell is published and held by this consumer's cursor.
+        unsafe { self.payload.as_ref() }
+    }
+
+    /// Copies the value out; the guard advances past it on drop.
+    ///
+    /// # Safety
+    /// - `T` must be valid to read from shared-memory bytes in this process.
+    pub unsafe fn read(self) -> T {
+        // SAFETY: the cell is published and held by this consumer's cursor.
+        unsafe { self.payload.as_ptr().read() }
+    }
+}
+
+impl<T> Drop for ReadGuard<'_, T> {
+    fn drop(&mut self) {
+        self.consumer.advance(self.lane, NonZeroUsize::MIN);
+    }
+}
+
+/// An in-place borrow of `count` consecutive published values from one lane. The
+/// consumer's cursor stays at the batch start while the guard lives (so the
+/// producer cannot overwrite any of them); dropping the guard advances past the
+/// whole batch.
+#[must_use]
+pub struct ReadBatch<'a, T> {
+    consumer: &'a mut Consumer<T>,
+    lane: usize,
+    start: usize,
+    count: NonZeroUsize,
+}
+
+impl<T> ReadBatch<'_, T> {
+    pub fn len(&self) -> usize {
+        self.count.get()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Pointer to the value at `index`.
+    ///
+    /// # Safety
+    /// - `index < len`.
+    pub unsafe fn as_ptr(&self, index: usize) -> *const T {
+        debug_assert!(index < self.count.get());
+        self.consumer
+            .queue
+            .lane(self.lane)
+            .payload_ptr(self.start.wrapping_add(index))
+            .as_ptr()
+    }
+
+    /// Reference to the value at `index`.
+    ///
+    /// # Safety
+    /// - `index < len`; `T` must be valid to reference as shared-memory bytes in
+    ///   this process, and the reference must not be used after the guard is
+    ///   dropped.
+    pub unsafe fn as_ref(&self, index: usize) -> &T {
+        // SAFETY: forwarded; the cell is published and held by this consumer's
+        // cursor.
+        unsafe { &*self.as_ptr(index) }
+    }
+
+    /// Copies the value at `index` out.
+    ///
+    /// # Safety
+    /// - `index < len`; `T` must be valid to read from shared-memory bytes in
+    ///   this process.
+    pub unsafe fn read(&self, index: usize) -> T {
+        // SAFETY: forwarded; the cell is published and held by this consumer's
+        // cursor until the batch is dropped.
+        unsafe { self.as_ptr(index).read() }
+    }
+}
+
+impl<T> Drop for ReadBatch<'_, T> {
+    fn drop(&mut self) {
+        self.consumer.advance(self.lane, self.count);
     }
 }
 
@@ -457,13 +835,6 @@ mod tests {
         ]
     }
 
-    /// Reads a published payload from `lane` at `sequence` (test-only).
-    /// Reads a published payload from the producer's own lane (test-only).
-    fn read(producer: &Producer<Payload>, sequence: usize) -> Payload {
-        // SAFETY: `sequence` was published on this lane, so the cell is initialized.
-        unsafe { producer.lane.payload_ptr(sequence).as_ptr().read() }
-    }
-
     #[test]
     fn clones_until_lanes_exhausted() {
         for create in producer_creators() {
@@ -489,11 +860,13 @@ mod tests {
                 producer_slots: 1,
                 consumer_slots: 1,
             });
+            let mut c = p.join_as_consumer().unwrap();
             for value in 0..5u64 {
                 assert!(p.try_write(value * 10).is_ok());
             }
-            for sequence in 0..5usize {
-                assert_eq!(read(&p, sequence), sequence as u64 * 10);
+            for value in 0..5u64 {
+                // SAFETY: `Payload` is `u64`, valid for any bytes.
+                assert_eq!(unsafe { c.try_read() }, Some(value * 10));
             }
         }
     }
@@ -506,6 +879,7 @@ mod tests {
                 producer_slots: 1,
                 consumer_slots: 1,
             });
+            let mut c = p.join_as_consumer().unwrap();
             {
                 let mut batch = p
                     .reserve_write_batch(NonZeroUsize::new(3).unwrap())
@@ -516,8 +890,9 @@ mod tests {
                     unsafe { batch.write(index, (index as u64) + 1) };
                 }
             }
-            for sequence in 0..3usize {
-                assert_eq!(read(&p, sequence), sequence as u64 + 1);
+            for value in 1..=3u64 {
+                // SAFETY: `Payload` is `u64`, valid for any bytes.
+                assert_eq!(unsafe { c.try_read() }, Some(value));
             }
         }
     }
@@ -537,43 +912,222 @@ mod tests {
         }
     }
 
-    /// File-backed create then join a second producer (exercises `Producer::join`).
+    /// Only a file can be opened before it holds a valid queue (e.g. by another
+    /// process); a heap region is always initialized in-process before it is
+    /// joined, so there is no uninitialized heap case to reject.
     #[cfg(not(miri))]
     #[test]
-    fn file_backed_join_acquires_a_second_lane() {
-        let config = BroadcastConfig {
-            capacity: 4,
-            producer_slots: 2,
-            consumer_slots: 1,
-        };
-        let file = create_temp_shmem_file().expect("temp file");
-        // SAFETY: fresh file, initialized once by `create`.
-        let _p0 = unsafe { Producer::<Payload>::create(&file, config) }.unwrap();
-        // SAFETY: same live queue, same `T`.
-        let _p1 = unsafe { Producer::<Payload>::join(&file) }.unwrap();
-        // Both lanes are held now; a third join is refused.
-        // SAFETY: same live queue, same `T`.
-        let third = unsafe { Producer::<Payload>::join(&file) };
-        assert!(matches!(third, Err(Error::ProducerSlotsExhausted)));
-    }
-
-    #[test]
-    fn join_validates_magic_and_version() {
+    fn join_rejects_uninitialized_file() {
         let config = BroadcastConfig {
             capacity: 4,
             producer_slots: 1,
             consumer_slots: 1,
         };
         let size = Layout::new::<Payload>(&config).unwrap().total;
-        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
-        // SAFETY: fresh region, initialized once.
-        let _queue = unsafe { SharedQueue::<Payload>::create_in_region(&region, &config) }.unwrap();
-        // SAFETY: initialized above.
-        assert!(unsafe { SharedQueue::<Payload>::join_region(&region) }.is_ok());
-
-        let uninit = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
-        // SAFETY: uninitialized region → magic mismatch.
-        let err = unsafe { SharedQueue::<Payload>::join_region(&uninit) };
+        let file = create_temp_shmem_file().expect("temp file");
+        file.set_len(size as u64).expect("set_len");
+        // SAFETY: sized-but-zeroed file → magic mismatch.
+        let err = unsafe { SharedQueue::<Payload>::join(&file) };
         assert!(matches!(err, Err(Error::InvalidMagic)));
+    }
+
+    #[test]
+    fn every_consumer_observes_every_item_in_order() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 2,
+            });
+            // Both consumers join before anything is published, so they start at 0.
+            let mut c0 = p.join_as_consumer().unwrap();
+            let mut c1 = p.join_as_consumer().unwrap();
+            // A third consumer would exhaust the slots.
+            assert!(matches!(
+                p.join_as_consumer(),
+                Err(Error::ConsumerSlotsExhausted)
+            ));
+
+            for value in 0..5u64 {
+                assert!(p.try_write(value * 10).is_ok());
+            }
+            for value in 0..5u64 {
+                // SAFETY: `Payload` is `u64`, valid for any bytes.
+                assert_eq!(unsafe { c0.try_read() }, Some(value * 10));
+                assert_eq!(unsafe { c1.try_read() }, Some(value * 10));
+            }
+            // SAFETY: see above.
+            assert_eq!(unsafe { c0.try_read() }, None);
+            assert_eq!(unsafe { c1.try_read() }, None);
+
+            // A released consumer's index can be reclaimed.
+            drop(c1);
+            assert!(p.join_as_consumer().is_ok());
+        }
+    }
+
+    #[test]
+    fn slow_consumer_backpressures_producer() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+
+            // Fill the ring; the consumer has read nothing, so the producer blocks.
+            for value in 0..4u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            assert!(p.try_write(99).is_err());
+
+            // The consumer reads one; one cell frees up.
+            // SAFETY: `Payload` is `u64`.
+            assert_eq!(unsafe { c.try_read() }, Some(0));
+            assert!(p.try_write(99).is_ok());
+            assert!(p.try_write(100).is_err());
+        }
+    }
+
+    #[test]
+    fn read_guard_holds_cell_until_dropped() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+            assert!(p.try_write(10).is_ok());
+
+            let guard = c.reserve_read().expect("readable");
+            // SAFETY: the cell is published.
+            assert_eq!(unsafe { *guard.as_ref() }, 10);
+
+            // The producer can fill the rest of the ring but cannot overwrite the
+            // cell the guard still holds (sequence 0).
+            for value in 11..14u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            assert!(p.try_write(14).is_err());
+            // SAFETY: the guard still protects sequence 0.
+            assert_eq!(unsafe { *guard.as_ref() }, 10);
+
+            // Dropping the guard commits, advancing past the cell and freeing it.
+            drop(guard);
+            assert!(p.try_write(14).is_ok());
+        }
+    }
+
+    #[test]
+    fn write_guard_publishes_on_drop_and_read_guard_reads() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+
+            // A single write guard publishes its cell when dropped.
+            {
+                let mut guard = p.reserve_write().unwrap();
+                // SAFETY: `Payload` is `u64`, valid for any bytes.
+                unsafe { *guard.as_mut_ref() = 42 };
+            }
+            // `write` consumes the guard and publishes on drop too.
+            p.reserve_write().unwrap().write(43);
+
+            // SAFETY: `Payload` is `u64`; `read` copies out, committing on drop.
+            assert_eq!(unsafe { c.reserve_read().unwrap().read() }, 42);
+            assert_eq!(unsafe { c.reserve_read().unwrap().read() }, 43);
+            assert!(c.reserve_read().is_none());
+        }
+    }
+
+    #[test]
+    fn read_batch_is_bounded_and_commits_on_drop() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+            for value in 0..5u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+
+            // Bounded by `max` (3) below the available run (5); drop commits it.
+            {
+                let batch = c.reserve_read_batch(NonZeroUsize::new(3).unwrap()).unwrap();
+                assert_eq!(batch.len(), 3);
+                for index in 0..3 {
+                    // SAFETY: `index < len`; `Payload` is `u64`.
+                    assert_eq!(unsafe { batch.read(index) }, index as u64);
+                }
+            }
+            // Now bounded by the available run (2), not `max`.
+            {
+                let batch = c
+                    .reserve_read_batch(NonZeroUsize::new(10).unwrap())
+                    .unwrap();
+                assert_eq!(batch.len(), 2);
+                for index in 0..2 {
+                    // SAFETY: `index < len`; `Payload` is `u64`.
+                    assert_eq!(unsafe { *batch.as_ref(index) }, (index as u64) + 3);
+                }
+            }
+            assert!(c
+                .reserve_read_batch(NonZeroUsize::new(1).unwrap())
+                .is_none());
+        }
+    }
+
+    #[test]
+    fn read_batch_holds_cells_until_dropped() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.join_as_consumer().unwrap();
+            for value in 0..4u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+
+            // The batch holds the whole ring; the producer is fully blocked.
+            {
+                let batch = c.reserve_read_batch(NonZeroUsize::new(4).unwrap()).unwrap();
+                assert_eq!(batch.len(), 4);
+                assert!(p.try_write(99).is_err());
+            }
+            // Dropping the batch commits all four cells, freeing them.
+            for value in 99..103u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn consumer_joining_late_skips_earlier_items() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 8,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            for value in 0..3u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            // Joins at the current reservation (3), so it sees only later items.
+            let mut c = p.join_as_consumer().unwrap();
+            assert!(p.try_write(99).is_ok());
+            // SAFETY: `Payload` is `u64`.
+            assert_eq!(unsafe { c.try_read() }, Some(99));
+            assert_eq!(unsafe { c.try_read() }, None);
+        }
     }
 }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -865,10 +865,7 @@ impl<T> Consumer<T> {
 
     /// Reads the next available value by copying it out, or `None` if every lane
     /// is caught up.
-    ///
-    /// # Safety
-    /// - `T` must be valid to read from shared-memory bytes in this process.
-    pub unsafe fn try_read(&mut self) -> Option<T> {
+    pub fn try_read(&mut self) -> Option<T> {
         let (lane, sequence) = self.next_readable()?;
         // SAFETY: `sequence < publication`, so the cell is published (initialized);
         // this consumer's cursor still protects it from being overwritten until we
@@ -941,13 +938,9 @@ impl<T> Consumer<T> {
 
     /// Blocks until any lane has an unread value or `timeout` elapses, then
     /// copies it out; `Err(Timeout)` if none arrived in time.
-    ///
-    /// # Safety
-    /// - `T` must be valid to read from shared-memory bytes in this process.
-    pub unsafe fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
+    pub fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
         let guard = self.reserve_read_timeout(timeout)?;
-        // SAFETY: forwarded to the caller's contract.
-        Ok(unsafe { guard.read() })
+        Ok(guard.read())
     }
 
     /// Blocks until [`Self::next_readable`] would succeed, sleeping on the queue's
@@ -984,27 +977,17 @@ pub struct ReadGuard<'a, T> {
 }
 
 impl<T> ReadGuard<'_, T> {
-    /// Pointer to the borrowed value.
-    pub fn as_ptr(&self) -> *const T {
-        self.payload.as_ptr()
-    }
-
-    /// Reference to the borrowed value.
-    ///
-    /// # Safety
-    /// - `T` must be valid to reference as shared-memory bytes in this process.
-    pub unsafe fn as_ref(&self) -> &T {
-        // SAFETY: the cell is published and held by this consumer's cursor.
-        unsafe { self.payload.as_ref() }
-    }
-
     /// Copies the value out; the guard advances past it on drop.
-    ///
-    /// # Safety
-    /// - `T` must be valid to read from shared-memory bytes in this process.
-    pub unsafe fn read(self) -> T {
+    pub fn read(self) -> T {
         // SAFETY: the cell is published and held by this consumer's cursor.
         unsafe { self.payload.as_ptr().read() }
+    }
+}
+
+impl<T> AsRef<T> for ReadGuard<'_, T> {
+    fn as_ref(&self) -> &T {
+        // SAFETY: the cell is published and held by this consumer's cursor.
+        unsafe { self.payload.as_ref() }
     }
 }
 
@@ -1049,11 +1032,9 @@ impl<T> ReadBatch<'_, T> {
     /// Reference to the value at `index`.
     ///
     /// # Safety
-    /// - `index < len`; `T` must be valid to reference as shared-memory bytes in
-    ///   this process, and the reference must not be used after the guard is
-    ///   dropped.
+    /// - `index < len`
     pub unsafe fn as_ref(&self, index: usize) -> &T {
-        // SAFETY: forwarded; the cell is published and held by this consumer's
+        // SAFETY: the cell is published and held by this consumer's
         // cursor.
         unsafe { &*self.as_ptr(index) }
     }
@@ -1061,8 +1042,7 @@ impl<T> ReadBatch<'_, T> {
     /// Copies the value at `index` out.
     ///
     /// # Safety
-    /// - `index < len`; `T` must be valid to read from shared-memory bytes in
-    ///   this process.
+    /// - `index < len`
     pub unsafe fn read(&self, index: usize) -> T {
         // SAFETY: forwarded; the cell is published and held by this consumer's
         // cursor until the batch is dropped.
@@ -1143,8 +1123,7 @@ mod tests {
                 assert!(p.try_write(value * 10).is_ok());
             }
             for value in 0..5u64 {
-                // SAFETY: `Payload` is `u64`, valid for any bytes.
-                assert_eq!(unsafe { c.try_read() }, Some(value * 10));
+                assert_eq!(c.try_read(), Some(value * 10));
             }
         }
     }
@@ -1169,8 +1148,7 @@ mod tests {
                 }
             }
             for value in 1..=3u64 {
-                // SAFETY: `Payload` is `u64`, valid for any bytes.
-                assert_eq!(unsafe { c.try_read() }, Some(value));
+                assert_eq!(c.try_read(), Some(value));
             }
         }
     }
@@ -1188,10 +1166,9 @@ mod tests {
             assert!(p.try_write_slice(&[1, 2, 3]));
 
             for value in 1..=3u64 {
-                // SAFETY: `Payload` is `u64`, valid POD-like bytes.
-                assert_eq!(unsafe { c.try_read() }, Some(value));
+                assert_eq!(c.try_read(), Some(value));
             }
-            assert_eq!(unsafe { c.try_read() }, None);
+            assert_eq!(c.try_read(), None);
         }
     }
 
@@ -1290,13 +1267,11 @@ mod tests {
                 assert!(p.try_write(value * 10).is_ok());
             }
             for value in 0..5u64 {
-                // SAFETY: `Payload` is `u64`, valid for any bytes.
-                assert_eq!(unsafe { c0.try_read() }, Some(value * 10));
-                assert_eq!(unsafe { c1.try_read() }, Some(value * 10));
+                assert_eq!(c0.try_read(), Some(value * 10));
+                assert_eq!(c1.try_read(), Some(value * 10));
             }
-            // SAFETY: see above.
-            assert_eq!(unsafe { c0.try_read() }, None);
-            assert_eq!(unsafe { c1.try_read() }, None);
+            assert_eq!(c0.try_read(), None);
+            assert_eq!(c1.try_read(), None);
 
             // A released consumer's index can be reclaimed.
             drop(c1);
@@ -1321,8 +1296,7 @@ mod tests {
             assert!(p.try_write(99).is_err());
 
             // The consumer reads one; one cell frees up.
-            // SAFETY: `Payload` is `u64`.
-            assert_eq!(unsafe { c.try_read() }, Some(0));
+            assert_eq!(c.try_read(), Some(0));
             assert!(p.try_write(99).is_ok());
             assert!(p.try_write(100).is_err());
         }
@@ -1340,8 +1314,7 @@ mod tests {
             assert!(p.try_write(10).is_ok());
 
             let guard = c.try_reserve_read().expect("readable");
-            // SAFETY: the cell is published.
-            assert_eq!(unsafe { *guard.as_ref() }, 10);
+            assert_eq!(*guard.as_ref(), 10);
 
             // The producer can fill the rest of the ring but cannot overwrite the
             // cell the guard still holds (sequence 0).
@@ -1349,8 +1322,7 @@ mod tests {
                 assert!(p.try_write(value).is_ok());
             }
             assert!(p.try_write(14).is_err());
-            // SAFETY: the guard still protects sequence 0.
-            assert_eq!(unsafe { *guard.as_ref() }, 10);
+            assert_eq!(*guard.as_ref(), 10);
 
             // Dropping the guard commits, advancing past the cell and freeing it.
             drop(guard);
@@ -1372,16 +1344,14 @@ mod tests {
             {
                 // SAFETY: the reserved slot is initialized before `guard` is dropped.
                 let mut guard = unsafe { p.try_reserve_write() }.unwrap();
-                // SAFETY: `Payload` is `u64`, valid for any bytes.
                 guard.as_mut_ref().write(42);
             }
             // `write` consumes the guard and publishes on drop too.
             // SAFETY: `write` initializes the reserved slot before publishing.
             unsafe { p.try_reserve_write() }.unwrap().write(43);
 
-            // SAFETY: `Payload` is `u64`; `read` copies out, committing on drop.
-            assert_eq!(unsafe { c.try_reserve_read().unwrap().read() }, 42);
-            assert_eq!(unsafe { c.try_reserve_read().unwrap().read() }, 43);
+            assert_eq!(c.try_reserve_read().unwrap().read(), 42);
+            assert_eq!(c.try_reserve_read().unwrap().read(), 43);
             assert!(c.try_reserve_read().is_none());
         }
     }
@@ -1469,9 +1439,8 @@ mod tests {
             // Joins at the current publication (3), so it sees only later items.
             let mut c = p.join_as_consumer().unwrap();
             assert!(p.try_write(99).is_ok());
-            // SAFETY: `Payload` is `u64`.
-            assert_eq!(unsafe { c.try_read() }, Some(99));
-            assert_eq!(unsafe { c.try_read() }, None);
+            assert_eq!(c.try_read(), Some(99));
+            assert_eq!(c.try_read(), None);
         }
     }
 
@@ -1493,9 +1462,8 @@ mod tests {
         guard.as_mut_ref().write(42);
         drop(guard);
 
-        // SAFETY: `Payload` is `u64`, valid POD-like bytes.
-        assert_eq!(unsafe { consumer.try_read() }, Some(42));
-        assert_eq!(unsafe { consumer.try_read() }, None);
+        assert_eq!(consumer.try_read(), Some(42));
+        assert_eq!(consumer.try_read(), None);
     }
 
     #[test]
@@ -1515,12 +1483,11 @@ mod tests {
             // so it reads data published before it joined, then keeps up.
             let mut c = p.join_as_consumer_from_backlog().unwrap();
             for value in 0..3u64 {
-                // SAFETY: `Payload` is `u64`.
-                assert_eq!(unsafe { c.try_read() }, Some(value));
+                assert_eq!(c.try_read(), Some(value));
             }
             assert!(p.try_write(99).is_ok());
-            assert_eq!(unsafe { c.try_read() }, Some(99));
-            assert_eq!(unsafe { c.try_read() }, None);
+            assert_eq!(c.try_read(), Some(99));
+            assert_eq!(c.try_read(), None);
         }
     }
 
@@ -1544,8 +1511,7 @@ mod tests {
             // A publish on any lane satisfies the (already-elapsed) wait.
             assert!(p.try_write(42).is_ok());
             let guard = c.reserve_read_timeout(Duration::ZERO).expect("readable");
-            // SAFETY: `Payload` is `u64`.
-            assert_eq!(unsafe { *guard.as_ref() }, 42);
+            assert_eq!(*guard.as_ref(), 42);
         }
     }
 
@@ -1579,9 +1545,8 @@ mod tests {
             });
             let mut c = p.join_as_consumer().unwrap();
 
-            // SAFETY: `Payload` is `u64`.
             assert!(matches!(
-                unsafe { c.read_timeout(Duration::ZERO) },
+                c.read_timeout(Duration::ZERO),
                 Err(WaitError::Timeout)
             ));
             assert!(matches!(
@@ -1648,10 +1613,9 @@ mod tests {
 
         // The consumer (joined before the crash) sees every item in order.
         for value in 1..=3u64 {
-            // SAFETY: `Payload` is `u64`.
-            assert_eq!(unsafe { consumer.try_read() }, Some(value));
+            assert_eq!(consumer.try_read(), Some(value));
         }
-        assert_eq!(unsafe { consumer.try_read() }, None);
+        assert_eq!(consumer.try_read(), None);
     }
 
     #[test]
@@ -1703,10 +1667,9 @@ mod tests {
         // (items 1, 2), never re-reading item 0.
         let mut recovered = Consumer::recover_in_queue(queue.clone(), index).unwrap();
         assert_eq!(recovered.index(), index);
-        // SAFETY: `Payload` is `u64`.
-        assert_eq!(unsafe { recovered.try_read() }, Some(1));
-        assert_eq!(unsafe { recovered.try_read() }, Some(2));
-        assert_eq!(unsafe { recovered.try_read() }, None);
+        assert_eq!(recovered.try_read(), Some(1));
+        assert_eq!(recovered.try_read(), Some(2));
+        assert_eq!(recovered.try_read(), None);
     }
 
     #[test]
@@ -1744,10 +1707,9 @@ mod tests {
         let mut fresh = Consumer::from_queue(queue.clone(), true).unwrap();
         assert_eq!(fresh.index(), index);
         for value in 0..3u64 {
-            // SAFETY: `Payload` is `u64`.
-            assert_eq!(unsafe { fresh.try_read() }, Some(value));
+            assert_eq!(fresh.try_read(), Some(value));
         }
-        assert_eq!(unsafe { fresh.try_read() }, None);
+        assert_eq!(fresh.try_read(), None);
     }
 
     #[test]

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,12 +1,22 @@
-//! Multi-producer / multi-consumer broadcast queue.
+//! Multi-producer / multi-consumer broadcast queue in shared memory.
 //!
-//! Each producer owns a [`producer_lane::ProducerLane`]; every consumer reads
-//! every lane. This module wires the shared region (header + global consumer
-//! ownership + producer-lane blocks) and the [`Producer`] handle.
-
-// Some of this (e.g. the global consumer-ownership table, used by the consumer
-// side) has no non-test callers, so dead-code warnings are silenced.
-#![allow(dead_code)]
+//! Each producer owns its own ring (a `ProducerLane`); every consumer reads
+//! every lane, so each published item reaches all consumers. Backpressure is
+//! lossless — a producer cannot overwrite a cell until every consumer has read
+//! it.
+//!
+//! [`Producer`] writes via by-value [`Producer::try_write`], an in-place
+//! [`WriteGuard`], or a [`WriteBatch`]; [`Consumer`] reads via
+//! [`Consumer::try_read`], a [`ReadGuard`], or a [`ReadBatch`], with blocking
+//! `*_timeout` variants that park on the queue's futex when idle. A consumer
+//! joins at the current frontier, or with the `*_from_backlog` variants up to one
+//! ring behind it to also read data published before it joined. After a crash, a
+//! lane or consumer index can be taken over with `recover` (resuming where the
+//! dead owner was) or returned to the pool with `force_release`.
+//!
+//! The region is a fixed header (magic/version, the global consumer-ownership
+//! table, and the blocked-consumer wake counter) followed by one lane block per
+//! producer.
 
 mod producer_lane;
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -891,7 +891,10 @@ impl<T> Consumer<T> {
 
     /// Reads the next available value by copying it out, or `None` if every lane
     /// is caught up.
-    pub fn try_read(&mut self) -> Option<T> {
+    pub fn try_read(&mut self) -> Option<T>
+    where
+        T: Copy,
+    {
         let (lane, sequence) = self.next_readable()?;
         // SAFETY: `sequence < publication`, so the cell is published (initialized);
         // this consumer's cursor still protects it from being overwritten until we
@@ -964,7 +967,10 @@ impl<T> Consumer<T> {
 
     /// Blocks until any lane has an unread value or `timeout` elapses, then
     /// copies it out; `Err(Timeout)` if none arrived in time.
-    pub fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
+    pub fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError>
+    where
+        T: Copy,
+    {
         let guard = self.reserve_read_timeout(timeout)?;
         Ok(guard.read())
     }
@@ -1004,7 +1010,10 @@ pub struct ReadGuard<'a, T> {
 
 impl<T> ReadGuard<'_, T> {
     /// Copies the value out; the guard advances past it on drop.
-    pub fn read(self) -> T {
+    pub fn read(self) -> T
+    where
+        T: Copy,
+    {
         // SAFETY: the cell is published and held by this consumer's cursor.
         unsafe { self.payload.as_ptr().read() }
     }
@@ -1069,7 +1078,10 @@ impl<T> ReadBatch<'_, T> {
     ///
     /// # Safety
     /// - `index < len`
-    pub unsafe fn read(&self, index: usize) -> T {
+    pub unsafe fn read(&self, index: usize) -> T
+    where
+        T: Copy,
+    {
         // SAFETY: forwarded; the cell is published and held by this consumer's
         // cursor until the batch is dropped.
         unsafe { self.as_ptr(index).read() }

--- a/src/broadcast/consumer_state.rs
+++ b/src/broadcast/consumer_state.rs
@@ -1,0 +1,404 @@
+//! Consumer state for a broadcast queue.
+//!
+//! This module owns the global consumer-index ownership table and the per-lane
+//! reserve-limit slots that publish each consumer's read progress.
+
+use core::mem::{align_of, size_of, MaybeUninit};
+use core::ptr::NonNull;
+use core::slice;
+use core::sync::atomic::{fence, AtomicU64, AtomicUsize, Ordering};
+
+use crate::error::Error;
+use crate::CacheAlignedAtomicSize;
+
+const CONSUMER_FREE: u64 = 0;
+const CONSUMER_ACTIVE: u64 = 1;
+
+/// Value stored in a lane consumer slot that no consumer owns.
+///
+/// A real reserve limit never reaches `usize::MAX` — that would take millennia
+/// at any real publish rate — so this is an unambiguous "no constraint"
+/// sentinel: it sits at the top, so it drops out of the producer's `min` and
+/// never gates a reserve.
+const UNCLAIMED: usize = usize::MAX;
+
+/// Global consumer-index ownership table.
+///
+/// The table is a contiguous `[AtomicU64; consumer_slots]` block. It only tracks
+/// whether a consumer index is owned.
+#[derive(Clone, Copy)]
+pub(crate) struct ConsumerState {
+    slots: NonNull<AtomicU64>,
+    slot_count: usize,
+}
+
+impl ConsumerState {
+    pub(crate) fn block_size(slot_count: usize) -> Option<usize> {
+        slot_count.checked_mul(size_of::<AtomicU64>())
+    }
+
+    pub(crate) const fn block_align() -> usize {
+        align_of::<AtomicU64>()
+    }
+
+    /// Initializes a consumer ownership table with every index free.
+    ///
+    /// # Safety
+    /// - `block` must point at a [`Self::block_size`] region for `slot_count`
+    ///   slots and be initialized at most once.
+    pub(crate) unsafe fn init(block: NonNull<u8>, slot_count: usize) {
+        // SAFETY: layout reserves `slot_count` AtomicU64s here; init runs once
+        // with no other handle joined, so &mut is exclusive.
+        let slots: &mut [MaybeUninit<AtomicU64>] = unsafe {
+            slice::from_raw_parts_mut(block.cast::<MaybeUninit<AtomicU64>>().as_ptr(), slot_count)
+        };
+        for slot in slots {
+            slot.write(AtomicU64::new(CONSUMER_FREE));
+        }
+    }
+
+    /// Builds a view over an initialized consumer ownership table.
+    ///
+    /// # Safety
+    /// - `block` must reference a table initialized by [`Self::init`] with the
+    ///   same `slot_count`, alive for the view's use.
+    pub(crate) unsafe fn from_block(block: NonNull<u8>, slot_count: usize) -> Self {
+        Self {
+            slots: block.cast(),
+            slot_count,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.slot_count
+    }
+
+    /// Claims a free consumer index in the global ownership table.
+    pub(crate) fn acquire(&self) -> Result<usize, Error> {
+        for index in 0..self.slot_count {
+            if self
+                .slot(index)
+                .compare_exchange(
+                    CONSUMER_FREE,
+                    CONSUMER_ACTIVE,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return Ok(index);
+            }
+        }
+        Err(Error::ConsumerSlotsExhausted)
+    }
+
+    /// Releases a consumer index back to free.
+    pub(crate) fn release(&self, index: usize) {
+        self.slot(index).store(CONSUMER_FREE, Ordering::Release);
+    }
+
+    /// Force-owns a consumer index whose previous owner died (no CAS). The
+    /// caller guarantees that owner is dead and no live handle uses the index.
+    pub(crate) fn recover(&self, index: usize) {
+        self.slot(index).store(CONSUMER_ACTIVE, Ordering::Release);
+    }
+
+    /// The global ownership word for consumer index `index`.
+    #[inline]
+    fn slot(&self, index: usize) -> &AtomicU64 {
+        debug_assert!(index < self.slot_count);
+        // SAFETY: `index < slot_count`; the slot was initialized.
+        unsafe { &*self.slots.add(index).as_ptr() }
+    }
+}
+
+/// Per-lane consumer reserve-limit slots.
+///
+/// A slot does **not** store the consumer's raw read cursor. It stores that
+/// consumer's **reserve limit**: `next_to_read + capacity`, i.e. the lowest
+/// sequence the producer may NOT yet reserve to avoid overwriting an active
+/// read. An unowned slot holds [`UNCLAIMED`].
+#[derive(Clone, Copy)]
+pub(crate) struct LaneConsumerState {
+    limits: NonNull<CacheAlignedAtomicSize>,
+    slot_count: usize,
+    capacity: usize,
+}
+
+impl LaneConsumerState {
+    pub(crate) fn block_size(slot_count: usize) -> Option<usize> {
+        slot_count.checked_mul(size_of::<CacheAlignedAtomicSize>())
+    }
+
+    pub(crate) const fn block_align() -> usize {
+        align_of::<CacheAlignedAtomicSize>()
+    }
+
+    /// Initializes a lane's consumer reserve-limit slots as unowned.
+    ///
+    /// # Safety
+    /// - `block` must point at a [`Self::block_size`] region for `slot_count`
+    ///   slots and be initialized at most once.
+    pub(crate) unsafe fn init(block: NonNull<u8>, slot_count: usize) {
+        // SAFETY: layout reserves `slot_count` aligned slots here; init runs
+        // once with no other handle joined, so &mut is exclusive.
+        let slots: &mut [MaybeUninit<CacheAlignedAtomicSize>] = unsafe {
+            slice::from_raw_parts_mut(
+                block.cast::<MaybeUninit<CacheAlignedAtomicSize>>().as_ptr(),
+                slot_count,
+            )
+        };
+        for slot in slots {
+            slot.write(CacheAlignedAtomicSize {
+                inner: AtomicUsize::new(UNCLAIMED),
+            });
+        }
+    }
+
+    /// Builds a view over initialized per-lane consumer slots.
+    ///
+    /// # Safety
+    /// - `block` must reference slots initialized by [`Self::init`] with the
+    ///   same `slot_count`, alive for the view's use.
+    pub(crate) unsafe fn from_block(
+        block: NonNull<u8>,
+        slot_count: usize,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            limits: block.cast(),
+            slot_count,
+            capacity,
+        }
+    }
+
+    /// The binding reserve limit across consumers: the lowest sequence the
+    /// producer may NOT yet reserve. Each slot holds `next_to_read + capacity`;
+    /// unowned slots hold [`UNCLAIMED`] and so drop out of the `min`. With every
+    /// slot unowned the result is [`UNCLAIMED`] (no constraint).
+    pub(crate) fn reserve_limit(&self) -> usize {
+        self.limits()
+            .iter()
+            .map(|limit| limit.load(Ordering::Acquire))
+            .min()
+            .unwrap_or(UNCLAIMED)
+    }
+
+    /// Joins `consumer_index` to this lane and returns the sequence it starts
+    /// reading from.
+    ///
+    /// The caller must already own `consumer_index` through the broadcast's
+    /// global consumer-ownership state, so this slot has a single writer (the
+    /// owning consumer): no CAS is needed — a release store publishes the limit.
+    ///
+    /// The start is normally the lane's **current publication**: the next value
+    /// to become visible after this join. With `from_backlog`, the start is
+    /// instead up to one ring behind the publication (the oldest published item
+    /// still guaranteed to be in the ring, floored at the first sequence), so a
+    /// consumer on a slow queue can read data published before it joined. If the
+    /// producer has already lapped that point, the handshake below fast-forwards
+    /// to the reservation frontier — you cannot read cells already being
+    /// recycled.
+    ///
+    /// The limit is published with a single release store, so the slot never
+    /// passes through [`UNCLAIMED`]. This also makes the call usable for
+    /// recovery: re-joining a dead owner's index overwrites its stale limit
+    /// directly, never dropping this consumer's backpressure mid-claim.
+    pub(crate) fn join(
+        &self,
+        consumer_index: usize,
+        from_backlog: bool,
+        published: usize,
+        read_reserved: impl FnOnce() -> usize,
+    ) -> usize {
+        let start = if from_backlog {
+            // Up to one ring behind the frontier (floored at the first
+            // sequence): the oldest item still guaranteed to be in the ring.
+            published.saturating_sub(self.capacity)
+        } else {
+            published
+        };
+        let limit = start.wrapping_add(self.capacity);
+        debug_assert!(limit != UNCLAIMED);
+        self.limit(consumer_index).store(limit, Ordering::Release);
+
+        // Consumer half of the join handshake: order publishing this limit
+        // before re-reading the producer reservation. This pairs with the
+        // producer's matching fence before it reads the reserve limit, so one
+        // side observes the other's advance.
+        fence(Ordering::SeqCst);
+
+        let reserved = read_reserved();
+        if reserved > limit {
+            self.limit(consumer_index)
+                .store(reserved.wrapping_add(self.capacity), Ordering::Release);
+            return reserved;
+        }
+        start
+    }
+
+    /// Publishes consumer `consumer_index`'s progress: its next-to-read sequence
+    /// `next_to_read`. The slot stores the reserve limit `next_to_read +
+    /// capacity` — the lowest sequence the producer may not yet overwrite for
+    /// this consumer.
+    pub(crate) fn set_cursor(&self, consumer_index: usize, next_to_read: usize) {
+        let limit = next_to_read.wrapping_add(self.capacity);
+        debug_assert!(limit != UNCLAIMED);
+        self.limit(consumer_index).store(limit, Ordering::Release);
+    }
+
+    /// Releases consumer slot `consumer_index` back to unowned (the reserve
+    /// limit then ignores it).
+    pub(crate) fn release(&self, consumer_index: usize) {
+        self.limit(consumer_index)
+            .store(UNCLAIMED, Ordering::Release);
+    }
+
+    /// Reconstructs a recovering consumer's next-to-read on this lane from its
+    /// surviving reserve limit (`next_to_read + capacity`), so it resumes where
+    /// the dead owner left off — those unread cells are still pinned by the
+    /// limit. This only reads the slot, so this consumer's backpressure is never
+    /// dropped. If the slot was never claimed, start fresh at the frontier.
+    pub(crate) fn recover(
+        &self,
+        consumer_index: usize,
+        published: usize,
+        read_reserved: impl FnOnce() -> usize,
+    ) -> usize {
+        let limit = self.limit(consumer_index).load(Ordering::Acquire);
+        if limit == UNCLAIMED {
+            self.join(consumer_index, false, published, read_reserved)
+        } else {
+            limit.wrapping_sub(self.capacity)
+        }
+    }
+
+    #[inline]
+    fn limits(&self) -> &[CacheAlignedAtomicSize] {
+        // SAFETY: layout reserves `slot_count` aligned slots here.
+        unsafe { slice::from_raw_parts(self.limits.as_ptr(), self.slot_count) }
+    }
+
+    /// The slot holding consumer `consumer_index`'s reserve limit
+    /// (`next_to_read + capacity`, or [`UNCLAIMED`]).
+    #[inline]
+    fn limit(&self, consumer_index: usize) -> &CacheAlignedAtomicSize {
+        debug_assert!(consumer_index < self.slot_count);
+        // SAFETY: `consumer_index < slot_count`; the slot was initialized.
+        unsafe { &*self.limits.add(consumer_index).as_ptr() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shmem::Region;
+    use std::num::NonZeroUsize;
+
+    fn consumer_state(slot_count: usize) -> (std::sync::Arc<Region>, ConsumerState) {
+        let size = ConsumerState::block_size(slot_count).unwrap().max(1);
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
+        // SAFETY: freshly allocated block, initialized once.
+        unsafe { ConsumerState::init(region.addr(), slot_count) };
+        // SAFETY: just initialized with this slot count.
+        let state = unsafe { ConsumerState::from_block(region.addr(), slot_count) };
+        (region, state)
+    }
+
+    fn lane_consumer_state(
+        slot_count: usize,
+        capacity: usize,
+    ) -> (std::sync::Arc<Region>, LaneConsumerState) {
+        let size = LaneConsumerState::block_size(slot_count).unwrap().max(1);
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
+        // SAFETY: freshly allocated block, initialized once.
+        unsafe { LaneConsumerState::init(region.addr(), slot_count) };
+        // SAFETY: just initialized with this slot count.
+        let state = unsafe { LaneConsumerState::from_block(region.addr(), slot_count, capacity) };
+        (region, state)
+    }
+
+    #[test]
+    fn consumer_state_acquires_releases_and_recovers_indices() {
+        let (_region, state) = consumer_state(2);
+
+        assert_eq!(state.len(), 2);
+        assert_eq!(state.acquire().unwrap(), 0);
+        assert_eq!(state.acquire().unwrap(), 1);
+        assert!(matches!(
+            state.acquire(),
+            Err(Error::ConsumerSlotsExhausted)
+        ));
+
+        state.release(0);
+        assert_eq!(state.acquire().unwrap(), 0);
+
+        state.release(1);
+        state.recover(1);
+        assert!(matches!(
+            state.acquire(),
+            Err(Error::ConsumerSlotsExhausted)
+        ));
+    }
+
+    #[test]
+    fn consumer_state_zero_slots_are_exhausted() {
+        let (_region, state) = consumer_state(0);
+
+        assert_eq!(state.len(), 0);
+        assert!(matches!(
+            state.acquire(),
+            Err(Error::ConsumerSlotsExhausted)
+        ));
+    }
+
+    #[test]
+    fn lane_consumer_state_tracks_minimum_reserve_limit() {
+        let (_region, state) = lane_consumer_state(2, 4);
+
+        assert_eq!(state.reserve_limit(), UNCLAIMED);
+
+        assert_eq!(state.join(0, false, 10, || 10), 10);
+        assert_eq!(state.reserve_limit(), 14);
+
+        state.set_cursor(0, 12);
+        assert_eq!(state.reserve_limit(), 16);
+
+        assert_eq!(state.join(1, false, 10, || 10), 10);
+        assert_eq!(state.reserve_limit(), 14);
+
+        state.release(1);
+        assert_eq!(state.reserve_limit(), 16);
+
+        state.release(0);
+        assert_eq!(state.reserve_limit(), UNCLAIMED);
+    }
+
+    #[test]
+    fn lane_consumer_state_backlog_join_fast_forwards_when_lapped() {
+        let (_region, state) = lane_consumer_state(1, 4);
+
+        assert_eq!(state.join(0, true, 10, || 13), 13);
+        assert_eq!(state.reserve_limit(), 17);
+    }
+
+    #[test]
+    fn lane_consumer_state_recover_resumes_claimed_slot() {
+        let (_region, state) = lane_consumer_state(1, 4);
+
+        state.set_cursor(0, 7);
+        assert_eq!(
+            state.recover(0, 99, || panic!("claimed slot should not rejoin")),
+            7
+        );
+        assert_eq!(state.reserve_limit(), 11);
+    }
+
+    #[test]
+    fn lane_consumer_state_recover_unclaimed_slot_joins_frontier() {
+        let (_region, state) = lane_consumer_state(1, 4);
+
+        assert_eq!(state.recover(0, 12, || 12), 12);
+        assert_eq!(state.reserve_limit(), 16);
+    }
+}

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -1,7 +1,6 @@
 //! One producer's lane: a self-contained shared-memory block holding the lane's
 //! ownership state, its reserve/publication cursors, the per-consumer reserve
-//! limits, and the ring of payloads. See [`ProducerLane`]. (The blocked-consumer
-//! wake state is global, in the queue header, not per-lane.)
+//! limits, and the ring of payloads. See [`ProducerLane`].
 
 use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
@@ -34,31 +33,23 @@ struct LaneHeader {
     producer_publication: CacheAlignedAtomicSize,
 }
 
-/// A single producer's lane, viewed over one shared-memory block.
+/// A single producer's lane.
 ///
-/// The block holds everything for the lane: ownership state, the
-/// reserve/publication cursors, one consumer slot per consumer (its read
-/// progress, doubling as its hazard), and the ring of `T`. The owning producer
-/// mutates the ring and cursors (`&mut self`); consumers read published payloads
-/// and publish their own progress (`&self`).
+/// The lane holds: ownership state, the reserve/publication cursors, one
+/// consumer slot per consumer (its read progress, doubling as its hazard),
+/// and the ring of `T`. The owning producer mutates the ring and cursors
+/// (`&mut self`); consumers read published payloads and publish their own
+/// progress (`&self`).
 ///
 /// ## Consumer slot = reserve limit (`next_to_read + capacity`)
 ///
 /// A consumer slot does **not** store the consumer's raw read cursor. It stores
 /// that consumer's **reserve limit**: `next_to_read + capacity`, i.e. the lowest
-/// sequence the producer may NOT yet reserve on this consumer's behalf — writing
-/// it would recycle the ring cell still holding `next_to_read`. An unowned slot
-/// holds [`UNCLAIMED`].
-///
-/// Storing the limit (rather than the raw cursor and adding `capacity` at the
-/// gate) makes the producer's backpressure check a plain
-/// `reserve_end > min(limits)`: no `+ capacity` in the hot path, and the
-/// `UNCLAIMED` sentinel needs no saturation because it already sits at the top
-/// of the `min`. The `+ capacity` is paid once, off the hot path, whenever a
-/// consumer advances its cursor.
+/// sequence the producer may NOT yet reserve to avoid overwriting an active read.
+/// An unowned slot holds [`UNCLAIMED`].
 ///
 /// Block layout: `LaneHeader`, then `[CacheAlignedAtomicSize; consumer_slots]`
-/// limits (one per cache line), then `[T; capacity]` (capacity is a power of two).
+/// limits (one per cache line), then `[T; capacity]`.
 pub(crate) struct ProducerLane<T> {
     block: NonNull<u8>,
     mask: usize, // capacity - 1
@@ -294,14 +285,7 @@ impl<T> ProducerLane<T> {
     }
 
     /// Publishes the next `count` reserved sequences, making them visible to
-    /// consumers. Call after the cells are written. A lane has a single producer,
-    /// so the publication cursor only advances here and always sits at the start
-    /// of the just-reserved batch; advancing it by `count` publishes exactly that
-    /// batch.
-    ///
-    /// Release-orders the ring writes before the publication a consumer reads
-    /// with Acquire. Waking blocked consumers is the queue's job (the wake state
-    /// is global, not per-lane), done after this returns.
+    /// consumers. Call after the cells are written.
     pub(crate) fn publish(&mut self, count: NonZeroUsize) {
         self.header()
             .producer_publication

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -2,7 +2,6 @@
 //! ownership state, its reserve/publication cursors, the per-consumer reserve
 //! limits, and the ring of payloads. See [`ProducerLane`].
 
-use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
@@ -53,12 +52,12 @@ struct LaneHeader {
 /// Block layout: `LaneHeader`, then `[CacheAlignedAtomicSize; consumer_slots]`
 /// limits (one per cache line), then `[T; capacity]`.
 pub(crate) struct ProducerLane<T> {
-    block: NonNull<u8>,
+    header: NonNull<LaneHeader>,
+    consumers: NonNull<CacheAlignedAtomicSize>,
+    ring: NonNull<T>,
+
     mask: usize, // capacity - 1
     consumer_slots: usize,
-    consumers_offset: usize,
-    ring_offset: usize,
-    _marker: PhantomData<T>,
 }
 
 #[inline]
@@ -143,13 +142,24 @@ impl<T> ProducerLane<T> {
         consumer_slots: usize,
     ) -> Self {
         debug_assert!(capacity.is_power_of_two());
+
+        let header = block.cast();
+        // SAFETY: `block` is an initialized region - it must be large enough
+        //         for consumers to fit (if init succeeded).
+        let consumers = unsafe { block.byte_add(consumers_offset()) }.cast();
+        // SAFETY: `block` is an initialized region - it must be large enough
+        //         for ring data to fit (if init succeeded).
+        let ring = unsafe {
+            block.byte_add(ring_offset::<T>(consumer_slots).expect("validated_lane layout"))
+        }
+        .cast();
+
         Self {
-            block,
+            header,
+            consumers,
+            ring,
             mask: (capacity as usize).wrapping_sub(1),
             consumer_slots,
-            consumers_offset: consumers_offset(),
-            ring_offset: ring_offset::<T>(consumer_slots).expect("validated lane layout"),
-            _marker: PhantomData,
         }
     }
 
@@ -160,8 +170,8 @@ impl<T> ProducerLane<T> {
 
     #[inline]
     fn header(&self) -> &LaneHeader {
-        // SAFETY: the block begins with an initialized `LaneHeader` for its lifetime.
-        unsafe { &*self.block.cast::<LaneHeader>().as_ptr() }
+        // SAFETY: The lane has an initialized header that lives for the lane's lifetime.
+        unsafe { self.header.as_ref() }
     }
 
     /// The slot holding consumer `consumer_index`'s reserve limit
@@ -170,14 +180,7 @@ impl<T> ProducerLane<T> {
     fn consumer_limit(&self, consumer_index: usize) -> &CacheAlignedAtomicSize {
         debug_assert!(consumer_index < self.consumer_slots);
         // SAFETY: `consumer_index < consumer_slots`; the slot was initialized.
-        unsafe {
-            &*self
-                .block
-                .byte_add(self.consumers_offset)
-                .cast::<CacheAlignedAtomicSize>()
-                .add(consumer_index)
-                .as_ptr()
-        }
+        unsafe { &*self.consumers.add(consumer_index).as_ptr() }
     }
 
     /// Pointer to the ring cell holding `sequence` — used by the producer to
@@ -185,12 +188,7 @@ impl<T> ProducerLane<T> {
     #[inline]
     pub(crate) fn payload_ptr(&self, sequence: usize) -> NonNull<T> {
         // SAFETY: `sequence & mask < capacity`; the ring has `capacity` cells.
-        unsafe {
-            self.block
-                .byte_add(self.ring_offset)
-                .cast::<T>()
-                .add(sequence & self.mask)
-        }
+        unsafe { self.ring.add(sequence & self.mask) }
     }
 
     /// Claims the lane for a producer. Returns `false` if already owned.

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -174,6 +174,12 @@ impl<T> ProducerLane<T> {
         unsafe { self.header.as_ref() }
     }
 
+    #[inline]
+    fn consumers(&self) -> &[CacheAlignedAtomicSize] {
+        // SAFETY: layout reserves `consumer_slots` aligned slots here
+        unsafe { slice::from_raw_parts(self.consumers.as_ptr(), self.consumer_slots) }
+    }
+
     /// The slot holding consumer `consumer_index`'s reserve limit
     /// (`next_to_read + capacity`, or [`UNCLAIMED`]).
     #[inline]
@@ -244,14 +250,11 @@ impl<T> ProducerLane<T> {
     /// unowned slots hold [`UNCLAIMED`] and so drop out of the `min`. With every
     /// slot unowned the result is [`UNCLAIMED`] (no constraint).
     fn reserve_limit(&self) -> usize {
-        let mut limit = UNCLAIMED;
-        for consumer_index in 0..self.consumer_slots {
-            let consumer_limit = self.consumer_limit(consumer_index).load(Ordering::Acquire);
-            if consumer_limit < limit {
-                limit = consumer_limit;
-            }
-        }
-        limit
+        self.consumers()
+            .iter()
+            .map(|c| c.load(Ordering::Acquire))
+            .min()
+            .unwrap_or(UNCLAIMED)
     }
 
     /// Reserves `count` consecutive sequences for writing, returning the first.

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -267,6 +267,10 @@ impl<T> ProducerLane<T> {
     /// so the publication cursor only advances here and always sits at the start
     /// of the just-reserved batch; advancing it by `count` publishes exactly that
     /// batch.
+    ///
+    /// Release-orders the ring writes before the publication a consumer reads
+    /// with Acquire. Waking blocked consumers is the queue's job (the wake state
+    /// is global, not per-lane), done after this returns.
     pub(crate) fn publish(&mut self, count: NonZeroUsize) {
         self.header()
             .producer_publication

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -262,12 +262,15 @@ impl<T> ProducerLane<T> {
         Some(start)
     }
 
-    /// Publishes the `count` sequences reserved at `start`, making them visible
-    /// to consumers. Call in reservation order, after the cells are written.
-    pub(crate) fn publish(&mut self, start: usize, count: NonZeroUsize) {
+    /// Publishes the next `count` reserved sequences, making them visible to
+    /// consumers. Call after the cells are written. A lane has a single producer,
+    /// so the publication cursor only advances here and always sits at the start
+    /// of the just-reserved batch; advancing it by `count` publishes exactly that
+    /// batch.
+    pub(crate) fn publish(&mut self, count: NonZeroUsize) {
         self.header()
             .producer_publication
-            .store(start.wrapping_add(count.get()), Ordering::Release);
+            .fetch_add(count.get(), Ordering::Release);
     }
 
     /// Joins consumer `consumer_index` to this lane and returns the sequence it
@@ -380,7 +383,7 @@ mod tests {
         };
         // SAFETY: the cell is reserved and not yet published.
         unsafe { lane.payload_ptr(start).as_ptr().write(value) };
-        lane.publish(start, one);
+        lane.publish(one);
         true
     }
 
@@ -424,7 +427,7 @@ mod tests {
         // Reserved but not yet visible.
         assert_eq!(lane.reserved(), 3);
         assert_eq!(lane.published(), 0);
-        lane.publish(start, count);
+        lane.publish(count);
         assert_eq!(lane.published(), 3);
         for offset in 0..3usize {
             assert_eq!(read(&lane, offset), offset as u64 + 1);

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -65,18 +65,18 @@ const fn consumers_offset() -> usize {
 }
 
 #[inline]
-fn ring_offset<T>(consumer_slots: usize) -> usize {
+fn ring_offset<T>(consumer_slots: usize) -> Option<usize> {
     consumers_offset()
-        .wrapping_add(consumer_slots.wrapping_mul(size_of::<CacheAlignedAtomicSize>()))
-        .next_multiple_of(align_of::<T>())
+        .checked_add(consumer_slots.checked_mul(size_of::<CacheAlignedAtomicSize>())?)?
+        .checked_next_multiple_of(align_of::<T>())
 }
 
 impl<T> ProducerLane<T> {
     /// Bytes needed for one lane block of `capacity` payload cells and
     /// `consumer_slots` consumer slots.
-    pub(crate) fn block_size(capacity: u32, consumer_slots: usize) -> usize {
-        ring_offset::<T>(consumer_slots)
-            .wrapping_add((capacity as usize).wrapping_mul(size_of::<T>()))
+    pub(crate) fn block_size(capacity: u32, consumer_slots: usize) -> Option<usize> {
+        ring_offset::<T>(consumer_slots)?
+            .checked_add((capacity as usize).checked_mul(size_of::<T>())?)
     }
 
     /// Required alignment of a lane block: the `LaneHeader`'s alignment.
@@ -147,7 +147,7 @@ impl<T> ProducerLane<T> {
             mask: (capacity as usize).wrapping_sub(1),
             consumer_slots,
             consumers_offset: consumers_offset(),
-            ring_offset: ring_offset::<T>(consumer_slots),
+            ring_offset: ring_offset::<T>(consumer_slots).expect("validated lane layout"),
             _marker: PhantomData,
         }
     }
@@ -299,20 +299,20 @@ impl<T> ProducerLane<T> {
     /// global consumer-ownership state, so this slot has a single writer (the
     /// owning consumer): no CAS is needed — a release store publishes the limit.
     ///
-    /// The start is normally the lane's **current reservation**: the freshest
-    /// sequence the producer has not yet written, so its cell cannot already be
-    /// overwritten and there is a full ring of margin before the producer could
-    /// lap it. With `from_backlog`, the start is instead up to one ring behind the
-    /// reservation (the oldest still-available item, floored at the first
-    /// sequence), so a consumer on a slow queue can read data published before it
-    /// joined. If the producer has already lapped that point, the handshake below
-    /// fast-forwards to the frontier — you cannot read cells already being recycled.
+    /// The start is normally the lane's **current publication**: the next value
+    /// to become visible after this join. With `from_backlog`, the start is
+    /// instead up to one ring behind the publication (the oldest published item
+    /// still guaranteed to be in the ring, floored at the first sequence), so a
+    /// consumer on a slow queue can read data published before it joined. If the
+    /// producer has already lapped that point, the handshake below fast-forwards
+    /// to the reservation frontier — you cannot read cells already being
+    /// recycled.
     ///
     /// The slot stores the **reserve limit** `start + capacity` (see the type
-    /// docs). Reading the reservation and publishing the limit are not atomic,
+    /// docs). Reading the publication and publishing the limit are not atomic,
     /// so the producer can lap the start cell in the gap; the limit pins the
-    /// producer once visible, so re-reading the reservation detects such a lap
-    /// and fast-forwards to the now-pinned frontier.
+    /// producer once visible, so reading the reservation detects such a lap and
+    /// fast-forwards to the now-pinned frontier.
     ///
     /// That lap detection is a StoreLoad handshake against the producer's
     /// `reserve`: a `SeqCst` fence here (between publishing the limit and
@@ -329,13 +329,13 @@ impl<T> ProducerLane<T> {
         let slot = self.consumer_limit(consumer_index);
 
         let start = {
-            let reserved = self.reserved();
+            let published = self.published();
             if from_backlog {
                 // Up to one ring behind the frontier (floored at the first
                 // sequence): the oldest item still guaranteed to be in the ring.
-                reserved.saturating_sub(capacity)
+                published.saturating_sub(capacity)
             } else {
-                reserved
+                published
             }
         };
         let limit = start.wrapping_add(capacity);
@@ -410,7 +410,7 @@ mod tests {
         capacity: u32,
         consumer_slots: usize,
     ) -> (std::sync::Arc<Region>, ProducerLane<Payload>) {
-        let size = ProducerLane::<Payload>::block_size(capacity, consumer_slots);
+        let size = ProducerLane::<Payload>::block_size(capacity, consumer_slots).unwrap();
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
         // SAFETY: freshly allocated block, initialized once.
         unsafe { ProducerLane::<Payload>::init(region.addr(), consumer_slots) };
@@ -534,14 +534,14 @@ mod tests {
     }
 
     #[test]
-    fn join_starts_at_current_reservation() {
+    fn join_starts_at_current_publication() {
         let (_region, mut lane) = lane(8, 1);
         assert!(lane.try_acquire());
-        // Publish 3 with no consumer (free overwrite), advancing the reservation.
+        // Publish 3 with no consumer (free overwrite), advancing the publication.
         for value in 0..3u64 {
             assert!(publish_value(&mut lane, value));
         }
-        // A consumer joining now starts at the reservation, not 0.
+        // A consumer joining now starts at the publication, not 0.
         assert_eq!(lane.join_consumer(0, false), 3);
     }
 

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -2,25 +2,17 @@
 //! ownership state, its reserve/publication cursors, the per-consumer reserve
 //! limits, and the ring of payloads. See [`ProducerLane`].
 
-use core::mem::MaybeUninit;
 use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
-use core::slice;
-use core::sync::atomic::{fence, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{fence, AtomicU64, Ordering};
 
 use crate::CacheAlignedAtomicSize;
 
+use super::consumer_state::LaneConsumerState;
+
 const LANE_FREE: u64 = 0;
 const LANE_ACTIVE: u64 = 1;
-
-/// Value stored in a consumer slot that no consumer owns.
-///
-/// A real reserve limit (see the consumer-slot docs below) never reaches
-/// `usize::MAX` — that would take millennia at any real publish rate — so this
-/// is an unambiguous "no constraint" sentinel: it sits at the top, so it drops
-/// out of the producer's `min` and never gates a reserve.
-const UNCLAIMED: usize = usize::MAX;
 
 /// Fixed-size head of a producer-lane block.
 #[repr(C)]
@@ -36,39 +28,30 @@ struct LaneHeader {
 
 /// A single producer's lane.
 ///
-/// The lane holds: ownership state, the reserve/publication cursors, one
-/// consumer slot per consumer (its read progress, doubling as its hazard),
-/// and the ring of `T`. The owning producer mutates the ring and cursors
-/// (`&mut self`); consumers read published payloads and publish their own
-/// progress (`&self`).
-///
-/// ## Consumer slot = reserve limit (`next_to_read + capacity`)
-///
-/// A consumer slot does **not** store the consumer's raw read cursor. It stores
-/// that consumer's **reserve limit**: `next_to_read + capacity`, i.e. the lowest
-/// sequence the producer may NOT yet reserve to avoid overwriting an active read.
-/// An unowned slot holds [`UNCLAIMED`].
+/// The lane holds ownership state, the reserve/publication cursors, the
+/// per-lane consumer reserve-limit state, and the ring of `T`. The owning
+/// producer mutates the ring and producer cursors (`&mut self`); consumers read
+/// published payloads and publish their own progress through [`LaneConsumerState`].
 ///
 /// Block layout: `LaneHeader`, then `[CacheAlignedAtomicSize; consumer_slots]`
 /// limits (one per cache line), then `[T; capacity]`.
 pub(crate) struct ProducerLane<T> {
     header: NonNull<LaneHeader>,
-    consumers: NonNull<CacheAlignedAtomicSize>,
+    consumer_state: LaneConsumerState,
     ring: NonNull<T>,
 
     mask: usize, // capacity - 1
-    consumer_slots: usize,
 }
 
 #[inline]
-const fn consumers_offset() -> usize {
-    size_of::<LaneHeader>().next_multiple_of(align_of::<CacheAlignedAtomicSize>())
+const fn consumer_state_offset() -> usize {
+    size_of::<LaneHeader>().next_multiple_of(LaneConsumerState::block_align())
 }
 
 #[inline]
 fn ring_offset<T>(consumer_slots: usize) -> Option<usize> {
-    consumers_offset()
-        .checked_add(consumer_slots.checked_mul(size_of::<CacheAlignedAtomicSize>())?)?
+    consumer_state_offset()
+        .checked_add(LaneConsumerState::block_size(consumer_slots)?)?
         .checked_next_multiple_of(align_of::<T>())
 }
 
@@ -113,22 +96,10 @@ impl<T> ProducerLane<T> {
                 producer_publication: CacheAlignedAtomicSize::default(),
             });
         }
-        // SAFETY: layout reserves `consumer_slots` aligned slots here; init runs
-        // once with no other handle joined, so &mut is exclusive.
-        let slots: &mut [MaybeUninit<CacheAlignedAtomicSize>] = unsafe {
-            slice::from_raw_parts_mut(
-                block
-                    .byte_add(consumers_offset())
-                    .cast::<MaybeUninit<CacheAlignedAtomicSize>>()
-                    .as_ptr(),
-                consumer_slots,
-            )
-        };
-        for slot in slots {
-            slot.write(CacheAlignedAtomicSize {
-                inner: AtomicUsize::new(UNCLAIMED),
-            });
-        }
+        // SAFETY: layout reserves `consumer_slots` aligned slots here.
+        let consumer_state = unsafe { block.byte_add(consumer_state_offset()) };
+        // SAFETY: freshly initialized lane block; consumer slots are initialized once.
+        unsafe { LaneConsumerState::init(consumer_state, consumer_slots) };
     }
 
     /// Builds a lane view over an initialized block.
@@ -145,8 +116,14 @@ impl<T> ProducerLane<T> {
 
         let header = block.cast();
         // SAFETY: `block` is an initialized region - it must be large enough
-        //         for consumers to fit (if init succeeded).
-        let consumers = unsafe { block.byte_add(consumers_offset()) }.cast();
+        //         for consumer state to fit (if init succeeded).
+        let consumer_state = unsafe {
+            LaneConsumerState::from_block(
+                block.byte_add(consumer_state_offset()),
+                consumer_slots,
+                capacity as usize,
+            )
+        };
         // SAFETY: `block` is an initialized region - it must be large enough
         //         for ring data to fit (if init succeeded).
         let ring = unsafe {
@@ -156,10 +133,9 @@ impl<T> ProducerLane<T> {
 
         Self {
             header,
-            consumers,
+            consumer_state,
             ring,
             mask: (capacity as usize).wrapping_sub(1),
-            consumer_slots,
         }
     }
 
@@ -175,18 +151,8 @@ impl<T> ProducerLane<T> {
     }
 
     #[inline]
-    fn consumers(&self) -> &[CacheAlignedAtomicSize] {
-        // SAFETY: layout reserves `consumer_slots` aligned slots here
-        unsafe { slice::from_raw_parts(self.consumers.as_ptr(), self.consumer_slots) }
-    }
-
-    /// The slot holding consumer `consumer_index`'s reserve limit
-    /// (`next_to_read + capacity`, or [`UNCLAIMED`]).
-    #[inline]
-    fn consumer_limit(&self, consumer_index: usize) -> &CacheAlignedAtomicSize {
-        debug_assert!(consumer_index < self.consumer_slots);
-        // SAFETY: `consumer_index < consumer_slots`; the slot was initialized.
-        unsafe { &*self.consumers.add(consumer_index).as_ptr() }
+    pub(crate) fn consumer_state(&self) -> LaneConsumerState {
+        self.consumer_state
     }
 
     /// Pointer to the ring cell holding `sequence` — used by the producer to
@@ -245,18 +211,6 @@ impl<T> ProducerLane<T> {
         self.header().state.store(LANE_FREE, Ordering::Release);
     }
 
-    /// The binding reserve limit across consumers: the lowest sequence the
-    /// producer may NOT yet reserve. Each slot holds `next_to_read + capacity`;
-    /// unowned slots hold [`UNCLAIMED`] and so drop out of the `min`. With every
-    /// slot unowned the result is [`UNCLAIMED`] (no constraint).
-    fn reserve_limit(&self) -> usize {
-        self.consumers()
-            .iter()
-            .map(|c| c.load(Ordering::Acquire))
-            .min()
-            .unwrap_or(UNCLAIMED)
-    }
-
     /// Reserves `count` consecutive sequences for writing, returning the first.
     /// `None` on backpressure: the batch would overwrite a cell an active
     /// consumer has not yet read, or it exceeds the ring capacity.
@@ -269,14 +223,13 @@ impl<T> ProducerLane<T> {
         let start = self.header().producer_reservation.load(Ordering::Acquire);
         // Producer half of the join handshake: order the previous reserve's
         // `producer_reservation` store before this reserve's limit loads, so a
-        // racing `join_consumer` either sees our advance or we see its limit
-        // (cf. `futex::Waiters`).
+        // racing consumer join either sees our advance or we see its limit.
         fence(Ordering::SeqCst);
         // Each slot already stores `next_to_read + capacity`, so the gate is a
         // plain comparison: rejecting once the batch would reach a sequence a
-        // consumer still needs. `UNCLAIMED` sits at the top, so unowned slots
-        // (and the all-unowned case) never gate.
-        if start.wrapping_add(count.get()) > self.reserve_limit() {
+        // consumer still needs. Unowned slots sit at the top, so they never
+        // gate.
+        if start.wrapping_add(count.get()) > self.consumer_state.reserve_limit() {
             return None;
         }
         // Claim before the writes; consumers only read `< producer_publication`.
@@ -292,100 +245,6 @@ impl<T> ProducerLane<T> {
         self.header()
             .producer_publication
             .fetch_add(count.get(), Ordering::Release);
-    }
-
-    /// Joins consumer `consumer_index` to this lane and returns the sequence it
-    /// starts reading from.
-    ///
-    /// The caller must already own `consumer_index` through the broadcast's
-    /// global consumer-ownership state, so this slot has a single writer (the
-    /// owning consumer): no CAS is needed — a release store publishes the limit.
-    ///
-    /// The start is normally the lane's **current publication**: the next value
-    /// to become visible after this join. With `from_backlog`, the start is
-    /// instead up to one ring behind the publication (the oldest published item
-    /// still guaranteed to be in the ring, floored at the first sequence), so a
-    /// consumer on a slow queue can read data published before it joined. If the
-    /// producer has already lapped that point, the handshake below fast-forwards
-    /// to the reservation frontier — you cannot read cells already being
-    /// recycled.
-    ///
-    /// The slot stores the **reserve limit** `start + capacity` (see the type
-    /// docs). Reading the publication and publishing the limit are not atomic,
-    /// so the producer can lap the start cell in the gap; the limit pins the
-    /// producer once visible, so reading the reservation detects such a lap and
-    /// fast-forwards to the now-pinned frontier.
-    ///
-    /// That lap detection is a StoreLoad handshake against the producer's
-    /// `reserve`: a `SeqCst` fence here (between publishing the limit and
-    /// re-reading the reservation) pairs with the matching fence in `reserve`,
-    /// so the producer either sees our limit (and stops) or we see its advance
-    /// (and fast-forward) — at least one (cf. `futex::Waiters`).
-    ///
-    /// The limit is published with a single release store, so the slot never
-    /// passes through [`UNCLAIMED`]. This also makes the call usable for
-    /// recovery: re-joining a dead owner's index overwrites its stale limit
-    /// directly, never dropping this consumer's backpressure mid-claim.
-    pub(crate) fn join_consumer(&self, consumer_index: usize, from_backlog: bool) -> usize {
-        let capacity = self.capacity();
-        let slot = self.consumer_limit(consumer_index);
-
-        let start = {
-            let published = self.published();
-            if from_backlog {
-                // Up to one ring behind the frontier (floored at the first
-                // sequence): the oldest item still guaranteed to be in the ring.
-                published.saturating_sub(capacity)
-            } else {
-                published
-            }
-        };
-        let limit = start.wrapping_add(capacity);
-        debug_assert!(limit != UNCLAIMED);
-        slot.store(limit, Ordering::Release);
-
-        // Consumer half of the join handshake (see the doc above).
-        fence(Ordering::SeqCst);
-
-        let reserved = self.reserved();
-        if reserved > limit {
-            slot.store(reserved.wrapping_add(capacity), Ordering::Release);
-            return reserved;
-        }
-        start
-    }
-
-    /// Publishes consumer `consumer_index`'s progress: its next-to-read sequence
-    /// `next_to_read`. The slot stores the reserve limit `next_to_read +
-    /// capacity` (see the type docs) — the lowest sequence the producer may not
-    /// yet overwrite for this consumer.
-    pub(crate) fn set_consumer_cursor(&self, consumer_index: usize, next_to_read: usize) {
-        let limit = next_to_read.wrapping_add(self.capacity());
-        debug_assert!(limit != UNCLAIMED);
-        self.consumer_limit(consumer_index)
-            .store(limit, Ordering::Release);
-    }
-
-    /// Releases consumer slot `consumer_index` back to unowned (the reserve
-    /// limit then ignores it).
-    pub(crate) fn release_consumer(&self, consumer_index: usize) {
-        self.consumer_limit(consumer_index)
-            .store(UNCLAIMED, Ordering::Release);
-    }
-
-    /// Reconstructs a recovering consumer's next-to-read on this lane from its
-    /// surviving reserve limit (`next_to_read + capacity`), so it resumes where
-    /// the dead owner left off — those unread cells are still pinned by the
-    /// limit. This only reads the slot, so this consumer's backpressure is never
-    /// dropped. If the slot was never claimed (the owner died before joining this
-    /// lane), start fresh at the frontier.
-    pub(crate) fn recover_consumer(&self, consumer_index: usize) -> usize {
-        let limit = self.consumer_limit(consumer_index).load(Ordering::Acquire);
-        if limit == UNCLAIMED {
-            self.join_consumer(consumer_index, false)
-        } else {
-            limit.wrapping_sub(self.capacity())
-        }
     }
 
     #[inline]
@@ -425,6 +284,17 @@ mod tests {
     fn read(lane: &ProducerLane<Payload>, sequence: usize) -> Payload {
         // SAFETY: `sequence` was published, so its cell is initialized.
         unsafe { lane.payload_ptr(sequence).as_ptr().read() }
+    }
+
+    fn join_consumer(
+        lane: &ProducerLane<Payload>,
+        consumer_index: usize,
+        from_backlog: bool,
+    ) -> usize {
+        let consumer_state = lane.consumer_state();
+        consumer_state.join(consumer_index, from_backlog, lane.published(), || {
+            lane.reserved()
+        })
     }
 
     /// Reserves, writes, and publishes one value; `false` on backpressure.
@@ -514,7 +384,7 @@ mod tests {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
         // Join consumer 0; nothing published yet, so it starts at sequence 0.
-        assert_eq!(lane.join_consumer(0, false), 0);
+        assert_eq!(join_consumer(&lane, 0, false), 0);
 
         // Fill the ring; the consumer has read nothing, so the next reserve laps.
         for value in 0..4u64 {
@@ -523,7 +393,7 @@ mod tests {
         assert!(!publish_value(&mut lane, 99));
 
         // Consumer consumes sequences 0 and 1; two cells free up.
-        lane.set_consumer_cursor(0, 2);
+        lane.consumer_state().set_cursor(0, 2);
         assert!(publish_value(&mut lane, 100));
         assert!(publish_value(&mut lane, 101));
         // Now full again relative to the watermark (cursor 2, capacity 4).
@@ -536,29 +406,17 @@ mod tests {
     }
 
     #[test]
-    fn join_starts_at_current_publication() {
-        let (_region, mut lane) = lane(8, 1);
-        assert!(lane.try_acquire());
-        // Publish 3 with no consumer (free overwrite), advancing the publication.
-        for value in 0..3u64 {
-            assert!(publish_value(&mut lane, value));
-        }
-        // A consumer joining now starts at the publication, not 0.
-        assert_eq!(lane.join_consumer(0, false), 3);
-    }
-
-    #[test]
     fn released_consumer_no_longer_constrains() {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
-        assert_eq!(lane.join_consumer(0, false), 0);
+        assert_eq!(join_consumer(&lane, 0, false), 0);
         for value in 0..4u64 {
             assert!(publish_value(&mut lane, value));
         }
         assert!(!publish_value(&mut lane, 99));
 
         // Releasing the slot removes the constraint.
-        lane.release_consumer(0);
+        lane.consumer_state().release(0);
         assert!(publish_value(&mut lane, 99));
     }
 }

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -164,6 +164,7 @@ impl<T> ProducerLane<T> {
     }
 
     /// Claims the lane for a producer. Returns `false` if already owned.
+    #[must_use]
     pub(crate) fn try_acquire(&self) -> bool {
         self.header()
             .state

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -241,12 +241,12 @@ impl<T> ProducerLane<T> {
         Some(start)
     }
 
-    /// Publishes the next `count` reserved sequences, making them visible to
-    /// consumers. Call after the cells are written.
-    pub(crate) fn publish(&mut self, count: NonZeroUsize) {
+    /// Publishes `start..start + count`, making it visible to consumers. Call
+    /// after the cells are written.
+    pub(crate) fn publish(&mut self, start: usize, count: NonZeroUsize) {
         self.header()
             .producer_publication
-            .fetch_add(count.get(), Ordering::Release);
+            .store(start.wrapping_add(count.get()), Ordering::Release);
     }
 
     #[inline]
@@ -307,7 +307,7 @@ mod tests {
         };
         // SAFETY: the cell is reserved and not yet published.
         unsafe { lane.payload_ptr(start).as_ptr().write(value) };
-        lane.publish(one);
+        lane.publish(start, one);
         true
     }
 
@@ -351,7 +351,7 @@ mod tests {
         // Reserved but not yet visible.
         assert_eq!(lane.reserved(), 3);
         assert_eq!(lane.published(), 0);
-        lane.publish(count);
+        lane.publish(start, count);
         assert_eq!(lane.published(), 3);
         for offset in 0..3usize {
             assert_eq!(read(&lane, offset), offset as u64 + 1);

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -1,0 +1,492 @@
+// The broadcast handles that drive these lanes (Producer/Consumer) land in later
+// commits, so much of this API has no non-test callers yet.
+#![allow(dead_code)]
+
+use core::marker::PhantomData;
+use core::mem::{align_of, size_of};
+use core::num::NonZeroUsize;
+use core::ptr::NonNull;
+use core::sync::atomic::{fence, AtomicU64, AtomicUsize, Ordering};
+
+use crate::CacheAlignedAtomicSize;
+
+const LANE_FREE: u64 = 0;
+const LANE_ACTIVE: u64 = 1;
+
+/// Value stored in a consumer slot that no consumer owns.
+///
+/// A real reserve limit (see the consumer-slot docs below) never reaches
+/// `usize::MAX` — that would take millennia at any real publish rate — so this
+/// is an unambiguous "no constraint" sentinel: it sits at the top, so it drops
+/// out of the producer's `min` and never gates a reserve.
+const UNCLAIMED: usize = usize::MAX;
+
+/// Fixed-size head of a producer-lane block.
+#[repr(C)]
+struct LaneHeader {
+    /// Lane ownership: `LANE_FREE` or `LANE_ACTIVE`.
+    state: AtomicU64,
+    /// Claimed-up-to sequence: advanced before a ring cell is written.
+    producer_reservation: CacheAlignedAtomicSize,
+    /// Visible-up-to sequence: advanced after a ring cell is written; consumers
+    /// read sequences `< producer_publication`.
+    producer_publication: CacheAlignedAtomicSize,
+}
+
+/// A single producer's lane, viewed over one shared-memory block.
+///
+/// The block holds everything for the lane: ownership state, the
+/// reserve/publication cursors, one consumer slot per consumer (its read
+/// progress, doubling as its hazard), and the ring of `T`. The owning producer
+/// mutates the ring and cursors (`&mut self`); consumers read published payloads
+/// and publish their own progress (`&self`).
+///
+/// ## Consumer slot = reserve limit (`next_to_read + capacity`)
+///
+/// A consumer slot does **not** store the consumer's raw read cursor. It stores
+/// that consumer's **reserve limit**: `next_to_read + capacity`, i.e. the lowest
+/// sequence the producer may NOT yet reserve on this consumer's behalf — writing
+/// it would recycle the ring cell still holding `next_to_read`. An unowned slot
+/// holds [`UNCLAIMED`].
+///
+/// Storing the limit (rather than the raw cursor and adding `capacity` at the
+/// gate) makes the producer's backpressure check a plain
+/// `reserve_end > min(limits)`: no `+ capacity` in the hot path, and the
+/// `UNCLAIMED` sentinel needs no saturation because it already sits at the top
+/// of the `min`. The `+ capacity` is paid once, off the hot path, whenever a
+/// consumer advances its cursor.
+///
+/// Block layout: `LaneHeader`, then `[CacheAlignedAtomicSize; consumer_slots]`
+/// limits (one per cache line), then `[T; capacity]` (capacity is a power of two).
+pub(crate) struct ProducerLane<T> {
+    block: NonNull<u8>,
+    mask: usize, // capacity - 1
+    consumer_slots: usize,
+    consumers_offset: usize,
+    ring_offset: usize,
+    _marker: PhantomData<T>,
+}
+
+#[inline]
+const fn consumers_offset() -> usize {
+    size_of::<LaneHeader>().next_multiple_of(align_of::<CacheAlignedAtomicSize>())
+}
+
+#[inline]
+fn ring_offset<T>(consumer_slots: usize) -> usize {
+    consumers_offset()
+        .wrapping_add(consumer_slots.wrapping_mul(size_of::<CacheAlignedAtomicSize>()))
+        .next_multiple_of(align_of::<T>())
+}
+
+impl<T> ProducerLane<T> {
+    /// Bytes needed for one lane block of `capacity` payload cells and
+    /// `consumer_slots` consumer slots.
+    pub(crate) fn block_size(capacity: u32, consumer_slots: usize) -> usize {
+        ring_offset::<T>(consumer_slots)
+            .wrapping_add((capacity as usize).wrapping_mul(size_of::<T>()))
+    }
+
+    /// Initializes a lane block: ownership/cursors zeroed, every consumer slot
+    /// free. The ring is left uninitialized (each cell is written before it is
+    /// published, and read only after).
+    ///
+    /// # Safety
+    /// - `block` must point at a [`Self::block_size`] region for `(capacity,
+    ///   consumer_slots)` and be initialized at most once.
+    pub(crate) unsafe fn init(block: NonNull<u8>, consumer_slots: usize) {
+        // SAFETY: `block` begins with a `LaneHeader`.
+        unsafe {
+            block.cast::<LaneHeader>().as_ptr().write(LaneHeader {
+                state: AtomicU64::new(LANE_FREE),
+                producer_reservation: CacheAlignedAtomicSize::default(),
+                producer_publication: CacheAlignedAtomicSize::default(),
+            });
+        }
+        // SAFETY: `consumers_offset` reserves `consumer_slots` cursors.
+        let consumers = unsafe {
+            block
+                .byte_add(consumers_offset())
+                .cast::<CacheAlignedAtomicSize>()
+        };
+        for consumer_index in 0..consumer_slots {
+            // SAFETY: `consumer_index < consumer_slots`. Unowned slots start at the sentinel.
+            unsafe {
+                consumers
+                    .add(consumer_index)
+                    .as_ptr()
+                    .write(CacheAlignedAtomicSize {
+                        inner: AtomicUsize::new(UNCLAIMED),
+                    });
+            }
+        }
+    }
+
+    /// Builds a lane view over an initialized block.
+    ///
+    /// # Safety
+    /// - `block` must reference a block initialized by [`Self::init`] with the
+    ///   same `consumer_slots`, sized for `capacity`, alive for the view's use.
+    pub(crate) unsafe fn from_block(
+        block: NonNull<u8>,
+        capacity: u32,
+        consumer_slots: usize,
+    ) -> Self {
+        debug_assert!(capacity.is_power_of_two());
+        Self {
+            block,
+            mask: (capacity as usize).wrapping_sub(1),
+            consumer_slots,
+            consumers_offset: consumers_offset(),
+            ring_offset: ring_offset::<T>(consumer_slots),
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.mask.wrapping_add(1)
+    }
+
+    #[inline]
+    fn header(&self) -> &LaneHeader {
+        // SAFETY: the block begins with an initialized `LaneHeader` for its lifetime.
+        unsafe { &*self.block.cast::<LaneHeader>().as_ptr() }
+    }
+
+    /// The slot holding consumer `consumer_index`'s reserve limit
+    /// (`next_to_read + capacity`, or [`UNCLAIMED`]).
+    #[inline]
+    fn consumer_limit(&self, consumer_index: usize) -> &CacheAlignedAtomicSize {
+        debug_assert!(consumer_index < self.consumer_slots);
+        // SAFETY: `consumer_index < consumer_slots`; the slot was initialized.
+        unsafe {
+            &*self
+                .block
+                .byte_add(self.consumers_offset)
+                .cast::<CacheAlignedAtomicSize>()
+                .add(consumer_index)
+                .as_ptr()
+        }
+    }
+
+    /// Pointer to the ring cell holding `sequence` — used by the producer to
+    /// write a reserved cell and by consumers to read a published one.
+    #[inline]
+    pub(crate) fn payload_ptr(&self, sequence: usize) -> NonNull<T> {
+        // SAFETY: `sequence & mask < capacity`; the ring has `capacity` cells.
+        unsafe {
+            self.block
+                .byte_add(self.ring_offset)
+                .cast::<T>()
+                .add(sequence & self.mask)
+        }
+    }
+
+    /// Claims the lane for a producer. Returns `false` if already owned.
+    pub(crate) fn try_acquire(&self) -> bool {
+        self.header()
+            .state
+            .compare_exchange(LANE_FREE, LANE_ACTIVE, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Releases the lane back to free.
+    pub(crate) fn release(&self) {
+        let _ = self.header().state.compare_exchange(
+            LANE_ACTIVE,
+            LANE_FREE,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    /// The binding reserve limit across consumers: the lowest sequence the
+    /// producer may NOT yet reserve. Each slot holds `next_to_read + capacity`;
+    /// unowned slots hold [`UNCLAIMED`] and so drop out of the `min`. With every
+    /// slot unowned the result is [`UNCLAIMED`] (no constraint).
+    fn reserve_limit(&self) -> usize {
+        let mut limit = UNCLAIMED;
+        for consumer_index in 0..self.consumer_slots {
+            let consumer_limit = self.consumer_limit(consumer_index).load(Ordering::Acquire);
+            if consumer_limit < limit {
+                limit = consumer_limit;
+            }
+        }
+        limit
+    }
+
+    /// Reserves `count` consecutive sequences for writing, returning the first.
+    /// `None` on backpressure: the batch would overwrite a cell an active
+    /// consumer has not yet read, or it exceeds the ring capacity.
+    ///
+    /// Write each reserved cell via [`Self::payload_ptr`], then [`Self::publish`].
+    pub(crate) fn reserve(&mut self, count: NonZeroUsize) -> Option<usize> {
+        if count.get() > self.capacity() {
+            return None;
+        }
+        let start = self.header().producer_reservation.load(Ordering::Acquire);
+        // Producer half of the join handshake: order the previous reserve's
+        // `producer_reservation` store before this reserve's limit loads, so a
+        // racing `join_consumer` either sees our advance or we see its limit
+        // (cf. `futex::Waiters`).
+        fence(Ordering::SeqCst);
+        // Each slot already stores `next_to_read + capacity`, so the gate is a
+        // plain comparison: rejecting once the batch would reach a sequence a
+        // consumer still needs. `UNCLAIMED` sits at the top, so unowned slots
+        // (and the all-unowned case) never gate.
+        if start.wrapping_add(count.get()) > self.reserve_limit() {
+            return None;
+        }
+        // Claim before the writes; consumers only read `< producer_publication`.
+        self.header()
+            .producer_reservation
+            .store(start.wrapping_add(count.get()), Ordering::Release);
+        Some(start)
+    }
+
+    /// Publishes the `count` sequences reserved at `start`, making them visible
+    /// to consumers. Call in reservation order, after the cells are written.
+    pub(crate) fn publish(&mut self, start: usize, count: NonZeroUsize) {
+        self.header()
+            .producer_publication
+            .store(start.wrapping_add(count.get()), Ordering::Release);
+    }
+
+    /// Joins consumer `consumer_index` to this lane and returns the sequence it
+    /// starts reading from.
+    ///
+    /// The caller must already own `consumer_index` through the broadcast's
+    /// global consumer-ownership state, so this slot has a single writer (the
+    /// owning consumer): no CAS is needed — a release store publishes the limit.
+    ///
+    /// The start is the lane's **current reservation**, not a caller-supplied
+    /// value: it is the freshest sequence the producer has not yet written, so
+    /// its cell cannot already be overwritten and there is a full ring of margin
+    /// before the producer could lap it. Starting earlier could land on a cell
+    /// the producer is still writing (reserved but unpublished) or has recycled.
+    ///
+    /// The slot stores the **reserve limit** `start + capacity` (see the type
+    /// docs). Reading the reservation and publishing the limit are not atomic,
+    /// so the producer can lap the start cell in the gap; the limit pins the
+    /// producer once visible, so re-reading the reservation detects such a lap
+    /// and fast-forwards to the now-pinned frontier.
+    ///
+    /// That lap detection is a StoreLoad handshake against the producer's
+    /// `reserve`: a `SeqCst` fence here (between publishing the limit and
+    /// re-reading the reservation) pairs with the matching fence in `reserve`,
+    /// so the producer either sees our limit (and stops) or we see its advance
+    /// (and fast-forward) — at least one (cf. `futex::Waiters`).
+    pub(crate) fn join_consumer(&self, consumer_index: usize) -> usize {
+        let capacity = self.capacity();
+        let slot = self.consumer_limit(consumer_index);
+        debug_assert_eq!(slot.load(Ordering::Relaxed), UNCLAIMED);
+
+        let start = self.reserved();
+        let limit = start.wrapping_add(capacity);
+        debug_assert!(limit != UNCLAIMED);
+        slot.store(limit, Ordering::Release);
+
+        // Consumer half of the join handshake (see the doc above).
+        fence(Ordering::SeqCst);
+
+        let reserved = self.reserved();
+        if reserved > limit {
+            slot.store(reserved.wrapping_add(capacity), Ordering::Release);
+            return reserved;
+        }
+        start
+    }
+
+    /// Publishes consumer `consumer_index`'s progress: its next-to-read sequence
+    /// `next_to_read`. The slot stores the reserve limit `next_to_read +
+    /// capacity` (see the type docs) — the lowest sequence the producer may not
+    /// yet overwrite for this consumer.
+    pub(crate) fn set_consumer_cursor(&self, consumer_index: usize, next_to_read: usize) {
+        let limit = next_to_read.wrapping_add(self.capacity());
+        debug_assert!(limit != UNCLAIMED);
+        self.consumer_limit(consumer_index)
+            .store(limit, Ordering::Release);
+    }
+
+    /// Releases consumer slot `consumer_index` back to unowned (the reserve
+    /// limit then ignores it).
+    pub(crate) fn release_consumer(&self, consumer_index: usize) {
+        self.consumer_limit(consumer_index)
+            .store(UNCLAIMED, Ordering::Release);
+    }
+
+    #[inline]
+    pub(crate) fn published(&self) -> usize {
+        self.header().producer_publication.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    pub(crate) fn reserved(&self) -> usize {
+        self.header().producer_reservation.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shmem::Region;
+    use std::num::NonZeroUsize;
+
+    type Payload = u64;
+
+    /// Allocates and initializes a standalone lane block.
+    fn lane(
+        capacity: u32,
+        consumer_slots: usize,
+    ) -> (std::sync::Arc<Region>, ProducerLane<Payload>) {
+        let size = ProducerLane::<Payload>::block_size(capacity, consumer_slots);
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
+        // SAFETY: freshly allocated block, initialized once.
+        unsafe { ProducerLane::<Payload>::init(region.addr(), consumer_slots) };
+        // SAFETY: just initialized with these parameters.
+        let lane =
+            unsafe { ProducerLane::<Payload>::from_block(region.addr(), capacity, consumer_slots) };
+        (region, lane)
+    }
+
+    fn read(lane: &ProducerLane<Payload>, sequence: usize) -> Payload {
+        // SAFETY: `sequence` was published, so its cell is initialized.
+        unsafe { lane.payload_ptr(sequence).as_ptr().read() }
+    }
+
+    /// Reserves, writes, and publishes one value; `false` on backpressure.
+    fn publish_value(lane: &mut ProducerLane<Payload>, value: Payload) -> bool {
+        let one = NonZeroUsize::new(1).unwrap();
+        let Some(start) = lane.reserve(one) else {
+            return false;
+        };
+        // SAFETY: the cell is reserved and not yet published.
+        unsafe { lane.payload_ptr(start).as_ptr().write(value) };
+        lane.publish(start, one);
+        true
+    }
+
+    #[test]
+    fn lane_ownership_is_exclusive() {
+        let (_region, lane) = lane(4, 1);
+        assert!(lane.try_acquire());
+        assert!(!lane.try_acquire());
+        lane.release();
+        assert!(lane.try_acquire());
+    }
+
+    #[test]
+    fn publishes_and_advances_cursors() {
+        let (_region, mut lane) = lane(4, 1);
+        assert!(lane.try_acquire());
+        for value in 0..4u64 {
+            assert!(publish_value(&mut lane, value * 10));
+        }
+        assert_eq!(lane.published(), 4);
+        assert_eq!(lane.reserved(), 4);
+        for seq in 0..4usize {
+            assert_eq!(read(&lane, seq), seq as u64 * 10);
+        }
+    }
+
+    #[test]
+    fn reserves_and_publishes_a_batch() {
+        let (_region, mut lane) = lane(8, 1);
+        assert!(lane.try_acquire());
+        let count = NonZeroUsize::new(3).unwrap();
+        let start = lane.reserve(count).expect("reserve");
+        for offset in 0..count.get() {
+            // SAFETY: each cell in the batch is reserved and unpublished.
+            unsafe {
+                lane.payload_ptr(start.wrapping_add(offset))
+                    .as_ptr()
+                    .write((offset as u64) + 1)
+            };
+        }
+        // Reserved but not yet visible.
+        assert_eq!(lane.reserved(), 3);
+        assert_eq!(lane.published(), 0);
+        lane.publish(start, count);
+        assert_eq!(lane.published(), 3);
+        for offset in 0..3usize {
+            assert_eq!(read(&lane, offset), offset as u64 + 1);
+        }
+    }
+
+    #[test]
+    fn reserve_rejects_count_above_capacity() {
+        let (_region, mut lane) = lane(4, 1);
+        assert!(lane.try_acquire());
+        assert!(lane.reserve(NonZeroUsize::new(5).unwrap()).is_none());
+    }
+
+    #[test]
+    fn no_active_consumers_allows_free_overwrite() {
+        let (_region, mut lane) = lane(4, 1);
+        assert!(lane.try_acquire());
+        // Publish well past one revolution; with no active consumer there is
+        // nothing to protect, so every reserve succeeds.
+        for value in 0..16u64 {
+            assert!(publish_value(&mut lane, value));
+        }
+        assert_eq!(lane.published(), 16);
+        // The ring holds the most recent generation (sequences 12..16).
+        for seq in 12..16usize {
+            assert_eq!(read(&lane, seq), seq as u64);
+        }
+    }
+
+    #[test]
+    fn backpressure_when_consumer_lags() {
+        let (_region, mut lane) = lane(4, 1);
+        assert!(lane.try_acquire());
+        // Join consumer 0; nothing published yet, so it starts at sequence 0.
+        assert_eq!(lane.join_consumer(0), 0);
+
+        // Fill the ring; the consumer has read nothing, so the next reserve laps.
+        for value in 0..4u64 {
+            assert!(publish_value(&mut lane, value));
+        }
+        assert!(!publish_value(&mut lane, 99));
+
+        // Consumer consumes sequences 0 and 1; two cells free up.
+        lane.set_consumer_cursor(0, 2);
+        assert!(publish_value(&mut lane, 100));
+        assert!(publish_value(&mut lane, 101));
+        // Now full again relative to the watermark (cursor 2, capacity 4).
+        assert!(!publish_value(&mut lane, 102));
+
+        // The recycled cells hold the new payloads.
+        assert_eq!(read(&lane, 4), 100);
+        assert_eq!(read(&lane, 5), 101);
+        assert_eq!(lane.published(), 6);
+    }
+
+    #[test]
+    fn join_starts_at_current_reservation() {
+        let (_region, mut lane) = lane(8, 1);
+        assert!(lane.try_acquire());
+        // Publish 3 with no consumer (free overwrite), advancing the reservation.
+        for value in 0..3u64 {
+            assert!(publish_value(&mut lane, value));
+        }
+        // A consumer joining now starts at the reservation, not 0.
+        assert_eq!(lane.join_consumer(0), 3);
+    }
+
+    #[test]
+    fn released_consumer_no_longer_constrains() {
+        let (_region, mut lane) = lane(4, 1);
+        assert!(lane.try_acquire());
+        assert_eq!(lane.join_consumer(0), 0);
+        for value in 0..4u64 {
+            assert!(publish_value(&mut lane, value));
+        }
+        assert!(!publish_value(&mut lane, 99));
+
+        // Releasing the slot removes the constraint.
+        lane.release_consumer(0);
+        assert!(publish_value(&mut lane, 99));
+    }
+}

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -1,5 +1,5 @@
-// The broadcast handles that drive these lanes (Producer/Consumer) land in later
-// commits, so much of this API has no non-test callers yet.
+// Some of this lane API is only used by the broadcast's consumer side, so it has
+// no non-test callers here; dead-code warnings are silenced.
 #![allow(dead_code)]
 
 use core::marker::PhantomData;
@@ -85,6 +85,23 @@ impl<T> ProducerLane<T> {
     pub(crate) fn block_size(capacity: u32, consumer_slots: usize) -> usize {
         ring_offset::<T>(consumer_slots)
             .wrapping_add((capacity as usize).wrapping_mul(size_of::<T>()))
+    }
+
+    /// Required alignment of a lane block: the `LaneHeader`'s alignment.
+    ///
+    /// The block starts with the `LaneHeader`; the trailing `[T]` ring is aligned
+    /// by its offset within the block (`ring_offset` is a multiple of
+    /// `align_of::<T>()`), so the block itself only needs the header's alignment —
+    /// as long as `T`'s alignment divides it, which holds for any normal payload
+    /// (alignment ≤ 64). Asserted so an over-aligned `T` is a clear compile error.
+    pub(crate) const fn block_align() -> usize {
+        const {
+            assert!(
+                align_of::<T>() <= align_of::<LaneHeader>(),
+                "payload alignment exceeds the lane header alignment",
+            );
+        }
+        align_of::<LaneHeader>()
     }
 
     /// Initializes a lane block: ownership/cursors zeroed, every consumer slot

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -3,9 +3,11 @@
 //! limits, and the ring of payloads. See [`ProducerLane`].
 
 use core::marker::PhantomData;
+use core::mem::MaybeUninit;
 use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
+use core::slice;
 use core::sync::atomic::{fence, AtomicU64, AtomicUsize, Ordering};
 
 use crate::CacheAlignedAtomicSize;
@@ -112,22 +114,21 @@ impl<T> ProducerLane<T> {
                 producer_publication: CacheAlignedAtomicSize::default(),
             });
         }
-        // SAFETY: `consumers_offset` reserves `consumer_slots` cursors.
-        let consumers = unsafe {
-            block
-                .byte_add(consumers_offset())
-                .cast::<CacheAlignedAtomicSize>()
+        // SAFETY: layout reserves `consumer_slots` aligned slots here; init runs
+        // once with no other handle joined, so &mut is exclusive.
+        let slots: &mut [MaybeUninit<CacheAlignedAtomicSize>] = unsafe {
+            slice::from_raw_parts_mut(
+                block
+                    .byte_add(consumers_offset())
+                    .cast::<MaybeUninit<CacheAlignedAtomicSize>>()
+                    .as_ptr(),
+                consumer_slots,
+            )
         };
-        for consumer_index in 0..consumer_slots {
-            // SAFETY: `consumer_index < consumer_slots`. Unowned slots start at the sentinel.
-            unsafe {
-                consumers
-                    .add(consumer_index)
-                    .as_ptr()
-                    .write(CacheAlignedAtomicSize {
-                        inner: AtomicUsize::new(UNCLAIMED),
-                    });
-            }
+        for slot in slots {
+            slot.write(CacheAlignedAtomicSize {
+                inner: AtomicUsize::new(UNCLAIMED),
+            });
         }
     }
 

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -218,6 +218,36 @@ impl<T> ProducerLane<T> {
         );
     }
 
+    /// Rewinds the reservation back to the publication. A dead producer may have
+    /// reserved cells it never published; those were never visible to a consumer,
+    /// so they are safely discarded, restoring the `reservation == publication`
+    /// invariant the next owner continues from.
+    fn rewind_reservation(&self) {
+        let header = self.header();
+        let published = header.producer_publication.load(Ordering::Acquire);
+        header
+            .producer_reservation
+            .store(published, Ordering::Release);
+    }
+
+    /// Force-claims a lane whose previous producer died and rewinds its
+    /// reservation, so the recovered producer resumes publishing from the last
+    /// published sequence.
+    ///
+    /// The caller must guarantee (via the global ownership contract) that the
+    /// previous owner is dead and no other producer holds this lane.
+    pub(crate) fn recover(&self) {
+        self.header().state.store(LANE_ACTIVE, Ordering::Release);
+        self.rewind_reservation();
+    }
+
+    /// Force-releases a dead producer's lane back to free (rewinding its
+    /// reservation first) so the normal acquire path can reclaim it.
+    pub(crate) fn force_release(&self) {
+        self.rewind_reservation();
+        self.header().state.store(LANE_FREE, Ordering::Release);
+    }
+
     /// The binding reserve limit across consumers: the lowest sequence the
     /// producer may NOT yet reserve. Each slot holds `next_to_read + capacity`;
     /// unowned slots hold [`UNCLAIMED`] and so drop out of the `min`. With every
@@ -284,11 +314,14 @@ impl<T> ProducerLane<T> {
     /// global consumer-ownership state, so this slot has a single writer (the
     /// owning consumer): no CAS is needed — a release store publishes the limit.
     ///
-    /// The start is the lane's **current reservation**, not a caller-supplied
-    /// value: it is the freshest sequence the producer has not yet written, so
-    /// its cell cannot already be overwritten and there is a full ring of margin
-    /// before the producer could lap it. Starting earlier could land on a cell
-    /// the producer is still writing (reserved but unpublished) or has recycled.
+    /// The start is normally the lane's **current reservation**: the freshest
+    /// sequence the producer has not yet written, so its cell cannot already be
+    /// overwritten and there is a full ring of margin before the producer could
+    /// lap it. With `from_backlog`, the start is instead up to one ring behind the
+    /// reservation (the oldest still-available item, floored at the first
+    /// sequence), so a consumer on a slow queue can read data published before it
+    /// joined. If the producer has already lapped that point, the handshake below
+    /// fast-forwards to the frontier — you cannot read cells already being recycled.
     ///
     /// The slot stores the **reserve limit** `start + capacity` (see the type
     /// docs). Reading the reservation and publishing the limit are not atomic,
@@ -301,12 +334,25 @@ impl<T> ProducerLane<T> {
     /// re-reading the reservation) pairs with the matching fence in `reserve`,
     /// so the producer either sees our limit (and stops) or we see its advance
     /// (and fast-forward) — at least one (cf. `futex::Waiters`).
-    pub(crate) fn join_consumer(&self, consumer_index: usize) -> usize {
+    ///
+    /// The limit is published with a single release store, so the slot never
+    /// passes through [`UNCLAIMED`]. This also makes the call usable for
+    /// recovery: re-joining a dead owner's index overwrites its stale limit
+    /// directly, never dropping this consumer's backpressure mid-claim.
+    pub(crate) fn join_consumer(&self, consumer_index: usize, from_backlog: bool) -> usize {
         let capacity = self.capacity();
         let slot = self.consumer_limit(consumer_index);
-        debug_assert_eq!(slot.load(Ordering::Relaxed), UNCLAIMED);
 
-        let start = self.reserved();
+        let start = {
+            let reserved = self.reserved();
+            if from_backlog {
+                // Up to one ring behind the frontier (floored at the first
+                // sequence): the oldest item still guaranteed to be in the ring.
+                reserved.saturating_sub(capacity)
+            } else {
+                reserved
+            }
+        };
         let limit = start.wrapping_add(capacity);
         debug_assert!(limit != UNCLAIMED);
         slot.store(limit, Ordering::Release);
@@ -338,6 +384,21 @@ impl<T> ProducerLane<T> {
     pub(crate) fn release_consumer(&self, consumer_index: usize) {
         self.consumer_limit(consumer_index)
             .store(UNCLAIMED, Ordering::Release);
+    }
+
+    /// Reconstructs a recovering consumer's next-to-read on this lane from its
+    /// surviving reserve limit (`next_to_read + capacity`), so it resumes where
+    /// the dead owner left off — those unread cells are still pinned by the
+    /// limit. This only reads the slot, so this consumer's backpressure is never
+    /// dropped. If the slot was never claimed (the owner died before joining this
+    /// lane), start fresh at the frontier.
+    pub(crate) fn recover_consumer(&self, consumer_index: usize) -> usize {
+        let limit = self.consumer_limit(consumer_index).load(Ordering::Acquire);
+        if limit == UNCLAIMED {
+            self.join_consumer(consumer_index, false)
+        } else {
+            limit.wrapping_sub(self.capacity())
+        }
     }
 
     #[inline]
@@ -466,7 +527,7 @@ mod tests {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
         // Join consumer 0; nothing published yet, so it starts at sequence 0.
-        assert_eq!(lane.join_consumer(0), 0);
+        assert_eq!(lane.join_consumer(0, false), 0);
 
         // Fill the ring; the consumer has read nothing, so the next reserve laps.
         for value in 0..4u64 {
@@ -496,14 +557,14 @@ mod tests {
             assert!(publish_value(&mut lane, value));
         }
         // A consumer joining now starts at the reservation, not 0.
-        assert_eq!(lane.join_consumer(0), 3);
+        assert_eq!(lane.join_consumer(0, false), 3);
     }
 
     #[test]
     fn released_consumer_no_longer_constrains() {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
-        assert_eq!(lane.join_consumer(0), 0);
+        assert_eq!(lane.join_consumer(0, false), 0);
         for value in 0..4u64 {
             assert!(publish_value(&mut lane, value));
         }

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -214,9 +214,11 @@ impl<T> ProducerLane<T> {
     /// Reserves `count` consecutive sequences for writing, returning the first.
     /// `None` on backpressure: the batch would overwrite a cell an active
     /// consumer has not yet read, or it exceeds the ring capacity.
+    /// On success this returns Some(seqnum) - with seqnum being
+    /// the starting sequence number of the reservation.
     ///
     /// Write each reserved cell via [`Self::payload_ptr`], then [`Self::publish`].
-    pub(crate) fn reserve(&mut self, count: NonZeroUsize) -> Option<usize> {
+    pub(crate) fn try_reserve(&mut self, count: NonZeroUsize) -> Option<usize> {
         if count.get() > self.capacity() {
             return None;
         }
@@ -300,7 +302,7 @@ mod tests {
     /// Reserves, writes, and publishes one value; `false` on backpressure.
     fn publish_value(lane: &mut ProducerLane<Payload>, value: Payload) -> bool {
         let one = NonZeroUsize::new(1).unwrap();
-        let Some(start) = lane.reserve(one) else {
+        let Some(start) = lane.try_reserve(one) else {
             return false;
         };
         // SAFETY: the cell is reserved and not yet published.
@@ -337,7 +339,7 @@ mod tests {
         let (_region, mut lane) = lane(8, 1);
         assert!(lane.try_acquire());
         let count = NonZeroUsize::new(3).unwrap();
-        let start = lane.reserve(count).expect("reserve");
+        let start = lane.try_reserve(count).expect("reserve");
         for offset in 0..count.get() {
             // SAFETY: each cell in the batch is reserved and unpublished.
             unsafe {
@@ -360,7 +362,7 @@ mod tests {
     fn reserve_rejects_count_above_capacity() {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
-        assert!(lane.reserve(NonZeroUsize::new(5).unwrap()).is_none());
+        assert!(lane.try_reserve(NonZeroUsize::new(5).unwrap()).is_none());
     }
 
     #[test]

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -1,6 +1,7 @@
-// Some of this lane API is only used by the broadcast's consumer side, so it has
-// no non-test callers here; dead-code warnings are silenced.
-#![allow(dead_code)]
+//! One producer's lane: a self-contained shared-memory block holding the lane's
+//! ownership state, its reserve/publication cursors, the per-consumer reserve
+//! limits, and the ring of payloads. See [`ProducerLane`]. (The blocked-consumer
+//! wake state is global, in the queue header, not per-lane.)
 
 use core::marker::PhantomData;
 use core::mem::{align_of, size_of};

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     Allocation(std::alloc::Layout),
     Io(std::io::Error),
     Mmap(std::io::Error),
+    ProducerSlotsExhausted,
+    ConsumerSlotsExhausted,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +46,8 @@ impl Display for Error {
             ),
             Self::Io(err) => write!(f, "io; err={err}"),
             Self::Mmap(err) => write!(f, "mmap; err={err}"),
+            Self::ProducerSlotsExhausted => write!(f, "producer slots exhausted"),
+            Self::ConsumerSlotsExhausted => write!(f, "consumer slots exhausted"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,14 +3,22 @@ use std::fmt::Display;
 #[derive(Debug)]
 pub enum Error {
     InvalidMagic,
-    InvalidVersion { expected: u32, actual: u32 },
+    InvalidVersion {
+        expected: u32,
+        actual: u32,
+    },
     InvalidBufferSize,
-    InvalidRegionAlignment { minimum: usize, actual: usize },
+    InvalidRegionAlignment {
+        minimum: usize,
+        actual: usize,
+    },
     Allocation(std::alloc::Layout),
     Io(std::io::Error),
     Mmap(std::io::Error),
     ProducerSlotsExhausted,
     ConsumerSlotsExhausted,
+    /// A recovery index was out of range for the queue's slot count.
+    InvalidIndex,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +56,7 @@ impl Display for Error {
             Self::Mmap(err) => write!(f, "mmap; err={err}"),
             Self::ProducerSlotsExhausted => write!(f, "producer slots exhausted"),
             Self::ConsumerSlotsExhausted => write!(f, "consumer slots exhausted"),
+            Self::InvalidIndex => write!(f, "invalid index"),
         }
     }
 }

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,29 +1,34 @@
 //! Futex-backed waiting for the shared-memory queues.
 //!
-//! The futex word is the queue's own 64-bit publication cursor: every publish
-//! advances it, so there is no separate sequence word a waiter could miss.
+//! The futex word is a 64-bit atomic whose low 32 bits change on (or just
+//! before) every wake. For the single-cursor queues it is the publication
+//! cursor itself — every publish advances it. A multi-cursor queue (the
+//! broadcast, which has one cursor per lane) instead points waiters at a
+//! dedicated wake counter that a publish bumps only when a waiter is present
+//! (see [`Waiters::bump_and_wake`]); there the caller's `check` is what gates
+//! on real data, and the counter exists only to break a racing `FUTEX_WAIT`.
 //!
 //! # Why no wake is lost
 //!
-//! The producer publishes the cursor (Release), then in [`Waiters::wake`]
-//! issues a SeqCst fence and loads `waiters`, skipping the wake syscall if
-//! it is zero. A waiter increments `waiters`, issues a SeqCst fence (in
-//! `register`), then rechecks for data before sleeping. SeqCst fences are
-//! totally ordered, and a load after the later fence must see a store made
-//! before the earlier one. So either the producer's load sees the waiter
-//! and wakes it, or the waiter's recheck sees the publication (or
-//! `FUTEX_WAIT` bounces with `EAGAIN`) and it never sleeps. Without the
-//! fences both loads can be stale and a wake can be lost.
+//! The producer advances the futex word (Release), then issues a SeqCst fence
+//! and loads `waiters`, skipping the wake syscall if it is zero. A waiter
+//! increments `waiters`, issues a SeqCst fence (in `register`), then rechecks
+//! for data before sleeping. SeqCst fences are totally ordered, and a load
+//! after the later fence must see a store made before the earlier one. So
+//! either the producer's load sees the waiter and wakes it, or the waiter's
+//! recheck sees the new data (or `FUTEX_WAIT` bounces with `EAGAIN`) and it
+//! never sleeps. Without the fences both loads can be stale and a wake can be
+//! lost.
 //!
 //! # The futex word
 //!
-//! Userspace accesses the cursor only as a 64-bit atomic; the kernel's
-//! 32-bit `FUTEX_WAIT` compare reads its low half (byte offset 0 on
-//! little-endian, 4 on big-endian), which is 4-byte aligned and cannot tear.
-//! Never materialize an `&AtomicU32` into the cursor in Rust code — only a
-//! raw pointer passed to the syscall. If the cursor advances by an exact
-//! multiple of 2^32 between snapshot and compare the wait oversleeps; that
-//! is bounded by the timeout and astronomically unlikely.
+//! Userspace accesses the word only as a 64-bit atomic; the kernel's 32-bit
+//! `FUTEX_WAIT` compare reads its low half (byte offset 0 on little-endian, 4
+//! on big-endian), which is 4-byte aligned and cannot tear. Never materialize
+//! an `&AtomicU32` into it in Rust code — only a raw pointer passed to the
+//! syscall. If the word advances by an exact multiple of 2^32 between snapshot
+//! and compare the wait oversleeps; that is bounded by the timeout and
+//! astronomically unlikely.
 
 use crate::{error::WaitError, CacheAlignedAtomicSize};
 use core::{
@@ -47,6 +52,7 @@ fn remaining_until(deadline: Instant) -> Result<Duration, WaitError> {
         .ok_or(WaitError::Timeout)
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub(crate) struct Waiters {
     /// Approximate count of waiters registered against the queue's
@@ -65,9 +71,15 @@ impl Waiters {
     /// `cursor` is the queue's publication cursor used as the futex word
     /// while sleeping; an advance of `cursor` must imply that `check` can
     /// observe new data.
+    ///
+    /// `spins` is how many times to re-`check` before the first sleep. A caller
+    /// whose `check` is itself expensive (e.g. it scans many lanes) should pass
+    /// a smaller count so the total spin work stays bounded; see
+    /// [`SPIN_ATTEMPTS`] for the baseline used by a unit-cost check.
     pub(crate) fn wait_for<T>(
         &self,
         cursor: &AtomicUsize,
+        spins: usize,
         timeout: Duration,
         mut check: impl FnMut() -> Option<T>,
     ) -> Result<T, WaitError> {
@@ -81,7 +93,7 @@ impl Waiters {
 
         // Spin only before the first sleep; once this thread has blocked it
         // is on the slow path and goes straight back to waiting.
-        for _ in 0..SPIN_ATTEMPTS {
+        for _ in 0..spins {
             spin_loop();
             if let Some(value) = check() {
                 return Ok(value);
@@ -163,13 +175,38 @@ impl Waiters {
         let count = waiters.min(count).min(MAX_WAKE_COUNT) as u32;
         imp::wake(cursor, count);
     }
+
+    /// Bumps `word` and wakes all registered waiters — but only if any are
+    /// registered, so a queue with no blocked waiter never writes the shared
+    /// `word` on its hot path.
+    ///
+    /// Unlike [`Self::wake`], the bump is conditional and done here: `word` is a
+    /// dedicated wake counter that the caller does **not** otherwise advance, so
+    /// this increment is what breaks a racing waiter's `FUTEX_WAIT`. Callers must
+    /// have published the real data (the lane cursors a waiter rechecks) with a
+    /// Release store before calling; the fence here pairs that with a registering
+    /// waiter (see module docs).
+    pub(crate) fn bump_and_wake(&self, word: &AtomicUsize) {
+        fence(Ordering::SeqCst);
+        let waiters = self.waiters.load(Ordering::Relaxed);
+        if waiters == 0 {
+            return;
+        }
+
+        // Change the futex word so a waiter that snapshotted it but has not yet
+        // slept bounces out of `FUTEX_WAIT` with `EAGAIN`.
+        word.fetch_add(1, Ordering::Relaxed);
+        let count = waiters.min(MAX_WAKE_COUNT) as u32;
+        imp::wake(word, count);
+    }
 }
 
 const MAX_WAKE_COUNT: usize = i32::MAX as usize;
 
-/// Extra `check` attempts before a waiter's first sleep in
-/// [`Waiters::wait_for`].
-const SPIN_ATTEMPTS: usize = 2048;
+/// Baseline `check` attempts before a waiter's first sleep in
+/// [`Waiters::wait_for`], for a unit-cost `check`. Callers with a costlier
+/// `check` scale this down so the total spin work stays comparable.
+pub(crate) const SPIN_ATTEMPTS: usize = 2048;
 
 #[cfg(target_os = "linux")]
 mod imp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::AtomicUsize;
 // NB: To simplify casting we only support 64bit or wider systems.
 const _: () = assert!(size_of::<usize>() >= size_of::<u64>());
 
+mod broadcast;
 pub mod error;
 mod futex;
 pub mod mpmc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use core::sync::atomic::AtomicUsize;
 // NB: To simplify casting we only support 64bit or wider systems.
 const _: () = assert!(size_of::<usize>() >= size_of::<u64>());
 
-mod broadcast;
+pub mod broadcast;
 pub mod error;
 mod futex;
 pub mod mpmc;

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::{Error, WaitError},
-    futex::Waiters,
+    futex::{Waiters, SPIN_ATTEMPTS},
     normalized_capacity,
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
@@ -333,7 +333,7 @@ impl<T> Consumer<T> {
         let header = unsafe { self.queue.header.as_ref() };
         header
             .waiters
-            .wait_for(&header.producer_publication, timeout, check)
+            .wait_for(&header.producer_publication, SPIN_ATTEMPTS, timeout, check)
     }
 
     /// Makes reserved-but-not-released reads left behind by a previous

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{Error, WaitError},
-    futex::Waiters,
+    futex::{Waiters, SPIN_ATTEMPTS},
     normalized_capacity,
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
@@ -322,14 +322,16 @@ impl<T> Consumer<T> {
         let header = self.queue.header;
         // SAFETY: `header` points to this consumer's live shared queue header.
         let header = unsafe { header.as_ref() };
-        header.waiters.wait_for(&header.write, timeout, || {
-            self.queue.load_write();
-            if !self.queue.is_empty() {
-                Some(())
-            } else {
-                None
-            }
-        })
+        header
+            .waiters
+            .wait_for(&header.write, SPIN_ATTEMPTS, timeout, || {
+                self.queue.load_write();
+                if !self.queue.is_empty() {
+                    Some(())
+                } else {
+                    None
+                }
+            })
     }
 
     /// Blocks until a committed item can be reserved for reading or `timeout`
@@ -355,10 +357,12 @@ impl<T> Consumer<T> {
         let header = self.queue.header;
         // SAFETY: `header` points to this consumer's live shared queue header.
         let header = unsafe { header.as_ref() };
-        header.waiters.wait_for(&header.write, timeout, || {
-            self.queue.load_write();
-            self.try_read_ptr()
-        })
+        header
+            .waiters
+            .wait_for(&header.write, SPIN_ATTEMPTS, timeout, || {
+                self.queue.load_write();
+                self.try_read_ptr()
+            })
     }
 }
 


### PR DESCRIPTION
### Problem
- It is useful to publish events to many consumers that see all events

### Solution
- Add a broadcast queue

### Design
Broadcast at a high-level supports MPMC but is explicitly not totally ordered. Producers are prevented from pushing if the channel is full i.e. backpressured. Consumers may read events from *different* producers out of order.

Each producer has its' own lane which is independent from all other producers' lanes.
Consumers update their highest read value, and producers are simply blocked from overwriting past the minimum of all consumers.
Producers interact with eachother only when consumers are waiting - in this case there is a shared futex for the entire queue.

Consumers round-robin between producer lanes. If there is no available data on any lane, they may wait on a futex.



