### PR TITLE
Add in-process heap-backed queue pair APIs for SPSC and MPMC

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@
 [![Rust CI](https://github.com/anza-xyz/shaq/actions/workflows/ci.yml/badge.svg)](https://github.com/anza-xyz/shaq/actions/workflows/ci.yml)
 
 shaq is a **SHAred Queue**: a simple shared-memory SPSC (Single Producer Single Consumer) and MPMC (Multi Producer Multi Consumer) FIFO queue.
-It is designed for efficient inter-thread or inter-process communication using a lock-free, memory-mapped queue.
+It is designed for efficient inter-thread or inter-process communication using lock-free queues.
+
+`shaq` now supports two backing modes:
+
+- File-backed shared memory via `create` / `join`, for inter-process communication.
+- In-process heap-backed queues via `spsc::pair` and `mpmc::pair`, for channel-style usage without file backing.

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     InvalidVersion { expected: u32, actual: u32 },
     InvalidBufferSize,
     InvalidRegionAlignment { minimum: usize, actual: usize },
+    Allocation(std::alloc::Layout),
     Io(std::io::Error),
     Mmap(std::io::Error),
 }
@@ -28,6 +29,12 @@ impl Display for Error {
             Self::InvalidRegionAlignment { minimum, actual } => write!(
                 f,
                 "invalid region alignment; minimum={minimum}; actual={actual}"
+            ),
+            Self::Allocation(layout) => write!(
+                f,
+                "allocation; size={}; align={}",
+                layout.size(),
+                layout.align()
             ),
             Self::Io(err) => write!(f, "io; err={err}"),
             Self::Mmap(err) => write!(f, "mmap; err={err}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use core::sync::atomic::AtomicUsize;
 
 // NB: To simplify casting we only support 64bit or wider systems.

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -24,7 +24,10 @@ impl<T> Producer<T> {
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        let (region, header) = SharedQueueHeader::create::<T>(file, file_size)?;
+        // SAFETY: caller guarantees this file is uniquely created as a
+        // producer, so initializing the queue header for this mapping happens
+        // exactly once.
+        let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
         unsafe { Self::from_header(region, header) }
@@ -171,7 +174,10 @@ impl<T> Consumer<T> {
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        let (region, header) = SharedQueueHeader::create::<T>(file, file_size)?;
+        // SAFETY: caller guarantees this file is uniquely created as a
+        // consumer, so initializing the queue header for this mapping happens
+        // exactly once.
+        let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
         unsafe { Self::from_header(region, header) }
@@ -497,15 +503,29 @@ struct SharedQueueHeader {
 }
 
 impl SharedQueueHeader {
-    fn create<T>(file: &File, size: usize) -> Result<(Arc<Region>, NonNull<Self>), Error> {
+    /// Creates and initializes a new shared queue header in `file`.
+    ///
+    /// # Safety
+    /// - The mapping created for `file` must be used to initialize at most one
+    ///   queue header.
+    /// - The returned `region` must not be passed to any other queue-header
+    ///   initialization routine.
+    unsafe fn create<T>(file: &File, size: usize) -> Result<(Arc<Region>, NonNull<Self>), Error> {
         file.set_len(size as u64)?;
 
         let region = Region::map_file(file, size)?;
-        let header = Self::create_in_region::<T>(&region)?;
+        // SAFETY: caller guarantees this mapping is initialized exactly once.
+        let header = unsafe { Self::create_in_region::<T>(&region) }?;
         Ok((region, header))
     }
 
-    fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
+    /// Initializes a shared queue header in `region`.
+    ///
+    /// # Safety
+    /// - `region` must be uniquely used for queue-header initialization.
+    /// - This function must be called at most once for a given region.
+    /// - `region` must not already contain an initialized queue header.
+    unsafe fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
         let header = region.addr().cast::<Self>();
         // SAFETY: The header is non-null and aligned properly.

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -4,6 +4,7 @@ use crate::{error::Error, normalized_capacity, shmem::Region, CacheAlignedAtomic
 use core::{marker::PhantomData, ptr::NonNull, sync::atomic::Ordering};
 use std::{
     fs::File,
+    num::NonZeroUsize,
     sync::{atomic::AtomicU64, Arc},
 };
 
@@ -299,7 +300,7 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 /// having their destructors run.
 pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
-    let region = Region::alloc(region_size)?;
+    let region = Region::alloc(NonZeroUsize::new(region_size).ok_or(Error::InvalidBufferSize)?)?;
     // SAFETY: `region` is freshly allocated and used only for this queue.
     let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
     let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -276,6 +276,21 @@ pub const fn minimum_file_size<T>(capacity: usize) -> usize {
     buffer_offset + normalized_capacity(capacity) * core::mem::size_of::<T>()
 }
 
+/// Calculates the minimum region size required for a queue with given capacity.
+pub const fn minimum_region_size<T>(capacity: usize) -> usize {
+    minimum_file_size::<T>(capacity)
+}
+
+/// Creates a new in-process MPMC queue pair backed by a heap allocation.
+pub fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
+    let region_size = minimum_region_size::<T>(capacity);
+    let region = Region::alloc(region_size)?;
+    let header = SharedQueueHeader::create_in_region::<T>(&region)?;
+    let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;
+    let consumer = unsafe { Consumer::from_header(region, header) }?;
+    Ok((producer, consumer))
+}
+
 struct SharedQueue<T> {
     header: NonNull<SharedQueueHeader>,
     buffer: NonNull<T>,
@@ -1049,5 +1064,48 @@ mod tests {
 
         producer2.try_write(42).unwrap();
         assert_eq!(consumer.try_read(), Some(42));
+    }
+
+    #[test]
+    fn test_pair_creates_in_process_queue() {
+        let (producer, consumer) = pair::<u64>(64).expect("pair failed");
+
+        for value in [10, 20, 30, 40] {
+            producer.try_write(value).expect("write failed");
+        }
+
+        for value in [10, 20, 30, 40] {
+            assert_eq!(consumer.try_read(), Some(value));
+        }
+        assert_eq!(consumer.try_read(), None);
+    }
+
+    #[test]
+    fn test_pair_clone_roles() {
+        let (producer, consumer) = pair::<u64>(64).expect("pair failed");
+        let producer2 = producer.clone();
+        let consumer2 = consumer.clone();
+
+        producer.try_write(1).expect("write failed");
+        producer2.try_write(2).expect("write failed");
+
+        let mut values = Vec::new();
+        loop {
+            let mut progressed = false;
+            if let Some(value) = consumer.try_read() {
+                values.push(value);
+                progressed = true;
+            }
+            if let Some(value) = consumer2.try_read() {
+                values.push(value);
+                progressed = true;
+            }
+            if !progressed {
+                break;
+            }
+        }
+
+        values.sort_unstable();
+        assert_eq!(values, vec![1, 2]);
     }
 }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -19,14 +19,17 @@ impl<T> Producer<T> {
     /// the given size.
     ///
     /// # Safety
-    /// - The provided file must be uniquely created as a Producer.
+    /// - The file must be created and initialized exactly once.
+    /// - Initialization may be performed by either a [`Producer`] or a
+    ///   [`Consumer`], but that process or thread must be designated
+    ///   externally as the sole initializer.
     /// - The queue does not validate `T` across processes.
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this file is uniquely created as a
-        // producer, so initializing the queue header for this mapping happens
-        // exactly once.
+        // SAFETY: caller guarantees this process or thread is the externally
+        // designated sole initializer, so initializing the queue header for
+        // this mapping happens exactly once.
         let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -169,14 +172,17 @@ impl<T> Consumer<T> {
     /// the given size.
     ///
     /// # Safety
-    /// - The provided file must be uniquely created as a Consumer.
+    /// - The file must be created and initialized exactly once.
+    /// - Initialization may be performed by either a [`Producer`] or a
+    ///   [`Consumer`], but that process or thread must be designated
+    ///   externally as the sole initializer.
     /// - The queue does not validate `T` across processes.
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this file is uniquely created as a consumer,
-        // meaning no prior `create` call has mapped this file, so the queue
-        // header for this mapping is initialized exactly once.
+        // SAFETY: caller guarantees this process or thread is the externally
+        // designated sole initializer, so initializing the queue header for
+        // this mapping happens exactly once.
         let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -282,7 +282,14 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 }
 
 /// Creates a new in-process MPMC queue pair backed by a heap allocation.
-pub fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
+///
+/// # Safety
+/// - The queue does not validate `T`.
+/// - If a thread may read, dereference, mutate, or drop a queued value, that
+///   operation must be valid for that value in that thread.
+/// - Values left buffered when the queue is dropped may be leaked instead of
+///   having their destructors run.
+pub unsafe fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(region_size)?;
     let header = SharedQueueHeader::create_in_region::<T>(&region)?;
@@ -1068,7 +1075,7 @@ mod tests {
 
     #[test]
     fn test_pair_creates_in_process_queue() {
-        let (producer, consumer) = pair::<u64>(64).expect("pair failed");
+        let (producer, consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
 
         for value in [10, 20, 30, 40] {
             producer.try_write(value).expect("write failed");
@@ -1082,7 +1089,7 @@ mod tests {
 
     #[test]
     fn test_pair_clone_roles() {
-        let (producer, consumer) = pair::<u64>(64).expect("pair failed");
+        let (producer, consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
         let producer2 = producer.clone();
         let consumer2 = consumer.clone();
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -298,7 +298,8 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 pub unsafe fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(region_size)?;
-    let header = SharedQueueHeader::create_in_region::<T>(&region)?;
+    // SAFETY: `region` is freshly allocated and used only for this queue.
+    let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
     let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;
     let consumer = unsafe { Consumer::from_header(region, header) }?;
     Ok((producer, consumer))

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -174,9 +174,9 @@ impl<T> Consumer<T> {
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this file is uniquely created as a
-        // consumer, so initializing the queue header for this mapping happens
-        // exactly once.
+        // SAFETY: caller guarantees this file is uniquely created as a consumer,
+        // meaning no prior `create` call has mapped this file, so the queue
+        // header for this mapping is initialized exactly once.
         let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -522,9 +522,7 @@ impl SharedQueueHeader {
     /// Initializes a shared queue header in `region`.
     ///
     /// # Safety
-    /// - `region` must be uniquely used for queue-header initialization.
-    /// - This function must be called at most once for a given region.
-    /// - `region` must not already contain an initialized queue header.
+    /// - This function must be called at most once for a given `region`.
     unsafe fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
         let header = region.addr().cast::<Self>();
@@ -532,6 +530,8 @@ impl SharedQueueHeader {
         //         Alignment is guaranteed because mmap ensures that the
         //         memory is aligned to the page size, which is sufficient for the
         //         alignment of `SharedQueueHeader`.
+        //         Access is exclusive because the caller guarantees this region
+        //         is initialized at most once.
         unsafe { Self::initialize(header, buffer_size_in_items) };
         Ok(header)
     }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1,8 +1,6 @@
 //! DPDK-style bounded MPMC ring queue
 
-use crate::{
-    error::Error, normalized_capacity, shmem::MappedRegion, CacheAlignedAtomicSize, VERSION,
-};
+use crate::{error::Error, normalized_capacity, shmem::Region, CacheAlignedAtomicSize, VERSION};
 use core::{marker::PhantomData, ptr::NonNull, sync::atomic::Ordering};
 use std::{
     fs::File,
@@ -58,7 +56,7 @@ impl<T> Producer<T> {
     /// - `header` must be non-null and properly aligned.
     /// - allocation backing `region` must be of sufficient size.
     unsafe fn from_header(
-        region: Arc<MappedRegion>,
+        region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -205,7 +203,7 @@ impl<T> Consumer<T> {
     /// - `header` must be non-null and properly aligned.
     /// - allocation backing `region` must be of sufficient size.
     unsafe fn from_header(
-        region: Arc<MappedRegion>,
+        region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -285,7 +283,7 @@ struct SharedQueue<T> {
 
     // NB: Region must be declared last so it is dropped last ensuring `header` and
     // `buffer` remain valid for their entire lifetime.
-    region: Arc<MappedRegion>,
+    region: Arc<Region>,
 }
 
 impl<T> Clone for SharedQueue<T> {
@@ -402,7 +400,7 @@ impl<T> SharedQueue<T> {
     /// - `region` must back the allocation at `header`.
     /// - `header` must be non-null and properly aligned.
     unsafe fn from_header(
-        region: Arc<MappedRegion>,
+        region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Self, Error> {
         let header_ref = unsafe { header.as_ref() };
@@ -410,7 +408,7 @@ impl<T> SharedQueue<T> {
         let buffer_size_in_items = buffer_mask.wrapping_add(1);
         if !buffer_size_in_items.is_power_of_two()
             || buffer_size_in_items == 0
-            || SharedQueueHeader::calculate_buffer_size_in_items::<T>(region.file_size())?
+            || SharedQueueHeader::calculate_buffer_size_in_items::<T>(region.size())?
                 != buffer_size_in_items
         {
             return Err(Error::InvalidBufferSize);
@@ -477,18 +475,23 @@ struct SharedQueueHeader {
 }
 
 impl SharedQueueHeader {
-    fn create<T>(file: &File, size: usize) -> Result<(Arc<MappedRegion>, NonNull<Self>), Error> {
+    fn create<T>(file: &File, size: usize) -> Result<(Arc<Region>, NonNull<Self>), Error> {
         file.set_len(size as u64)?;
 
-        let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(size)?;
-        let region = MappedRegion::new(file, size)?;
+        let region = Region::map_file(file, size)?;
+        let header = Self::create_in_region::<T>(&region)?;
+        Ok((region, header))
+    }
+
+    fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
+        let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
         let header = region.addr().cast::<Self>();
         // SAFETY: The header is non-null and aligned properly.
         //         Alignment is guaranteed because mmap ensures that the
         //         memory is aligned to the page size, which is sufficient for the
         //         alignment of `SharedQueueHeader`.
         unsafe { Self::initialize(header, buffer_size_in_items) };
-        Ok((region, header))
+        Ok(header)
     }
 
     const fn buffer_offset<T>() -> usize {
@@ -554,9 +557,14 @@ impl SharedQueueHeader {
         header.magic.store(MAGIC, Ordering::Release);
     }
 
-    fn join<T>(file: &File) -> Result<(Arc<MappedRegion>, NonNull<Self>), Error> {
+    fn join<T>(file: &File) -> Result<(Arc<Region>, NonNull<Self>), Error> {
         let file_size = file.metadata()?.len() as usize;
-        let region = MappedRegion::new(file, file_size)?;
+        let region = Region::map_file(file, file_size)?;
+        let header = Self::join_region::<T>(&region)?;
+        Ok((region, header))
+    }
+
+    fn join_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let header = region.addr().cast::<Self>();
         {
             // SAFETY: The header is non-null and aligned properly.
@@ -574,12 +582,12 @@ impl SharedQueueHeader {
                 });
             }
             let buffer_size_in_items = (header.buffer_mask as usize).wrapping_add(1);
-            if buffer_size_in_items != Self::calculate_buffer_size_in_items::<T>(file_size)? {
+            if buffer_size_in_items != Self::calculate_buffer_size_in_items::<T>(region.size())? {
                 return Err(Error::InvalidBufferSize);
             }
         }
 
-        Ok((region, header))
+        Ok(header)
     }
 
     /// # Safety

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -295,13 +295,9 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 
 /// Creates a new in-process MPMC queue pair backed by a heap allocation.
 ///
-/// # Safety
-/// - The queue does not validate `T`.
-/// - If a thread may read, dereference, mutate, or drop a queued value, that
-///   operation must be valid for that value in that thread.
-/// - Values left buffered when the queue is dropped may be leaked instead of
-///   having their destructors run.
-pub unsafe fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
+/// Values left buffered when the queue is dropped may be leaked instead of
+/// having their destructors run.
+pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(region_size)?;
     // SAFETY: `region` is freshly allocated and used only for this queue.
@@ -1102,7 +1098,7 @@ mod tests {
 
     #[test]
     fn test_pair_creates_in_process_queue() {
-        let (producer, consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
+        let (producer, consumer) = pair::<u64>(64).expect("pair failed");
 
         for value in [10, 20, 30, 40] {
             producer.try_write(value).expect("write failed");
@@ -1116,7 +1112,7 @@ mod tests {
 
     #[test]
     fn test_pair_clone_roles() {
-        let (producer, consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
+        let (producer, consumer) = pair::<u64>(64).expect("pair failed");
         let producer2 = producer.clone();
         let consumer2 = consumer.clone();
 

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -20,6 +20,24 @@ impl Region {
         }))
     }
 
+    pub(crate) fn alloc(size: usize) -> Result<Arc<Self>, Error> {
+        let layout = std::alloc::Layout::from_size_align(size, MINIMUM_REGION_ALIGNMENT)
+            .map_err(|_| Error::InvalidBufferSize)?;
+        let addr = {
+            // SAFETY: layout is valid and non-zero.
+            let addr = unsafe { std::alloc::alloc_zeroed(layout) };
+            NonNull::new(addr).ok_or(Error::Allocation(layout))?
+        };
+
+        assert_eq!(addr.as_ptr().align_offset(MINIMUM_REGION_ALIGNMENT), 0);
+
+        Ok(Arc::new(Self {
+            addr,
+            size,
+            backing: RegionBacking::Heap(layout),
+        }))
+    }
+
     pub(crate) fn addr(&self) -> NonNull<u8> {
         self.addr
     }
@@ -36,12 +54,17 @@ impl Drop for Region {
                 // SAFETY: addr and size were produced by a successful map_file call.
                 unsafe { unmap_file(self.addr, self.size) };
             }
+            RegionBacking::Heap(layout) => {
+                // SAFETY: addr was allocated with this exact layout in `alloc`.
+                unsafe { std::alloc::dealloc(self.addr.as_ptr(), layout) };
+            }
         }
     }
 }
 
 enum RegionBacking {
     MappedFile,
+    Heap(std::alloc::Layout),
 }
 
 // SAFETY: The mapped memory is shared (MAP_SHARED / file-backed) and access
@@ -60,6 +83,13 @@ fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
 
     Ok(())
 }
+
+#[cfg(not(test))]
+#[allow(dead_code)]
+const _: () = {
+    let _ = Region::alloc;
+    let _ = RegionBacking::Heap;
+};
 
 /// Maps a file into memory.
 #[cfg(unix)]
@@ -203,5 +233,31 @@ mod tests {
                 .align_offset(MINIMUM_REGION_ALIGNMENT),
             0
         );
+    }
+
+    #[test]
+    fn test_alloc_region_is_4096_aligned() {
+        let region = Region::alloc(MINIMUM_REGION_ALIGNMENT * 2).expect("allocation failed");
+        assert_eq!(
+            region
+                .addr()
+                .as_ptr()
+                .align_offset(MINIMUM_REGION_ALIGNMENT),
+            0
+        );
+        assert_eq!(region.size(), MINIMUM_REGION_ALIGNMENT * 2);
+    }
+
+    #[test]
+    fn test_alloc_region_accepts_non_4096_multiple() {
+        let region = Region::alloc(MINIMUM_REGION_ALIGNMENT + 1).expect("allocation failed");
+        assert_eq!(
+            region
+                .addr()
+                .as_ptr()
+                .align_offset(MINIMUM_REGION_ALIGNMENT),
+            0
+        );
+        assert_eq!(region.size(), MINIMUM_REGION_ALIGNMENT + 1);
     }
 }

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -3,18 +3,20 @@ use std::{fs::File, ptr::NonNull, sync::Arc};
 
 pub(crate) const MINIMUM_REGION_ALIGNMENT: usize = 4096;
 
-pub(crate) struct MappedRegion {
+pub(crate) struct Region {
     addr: NonNull<u8>,
-    file_size: usize,
+    size: usize,
+    backing: RegionBacking,
 }
 
-impl MappedRegion {
-    pub(crate) fn new(file: &File, size: usize) -> Result<Arc<Self>, Error> {
+impl Region {
+    pub(crate) fn map_file(file: &File, size: usize) -> Result<Arc<Self>, Error> {
         let addr = map_file(file, size)?;
         validate_region_alignment(addr)?;
         Ok(Arc::new(Self {
             addr,
-            file_size: size,
+            size,
+            backing: RegionBacking::MappedFile,
         }))
     }
 
@@ -22,22 +24,30 @@ impl MappedRegion {
         self.addr
     }
 
-    pub(crate) fn file_size(&self) -> usize {
-        self.file_size
+    pub(crate) fn size(&self) -> usize {
+        self.size
     }
 }
 
-impl Drop for MappedRegion {
+impl Drop for Region {
     fn drop(&mut self) {
-        // SAFETY: addr and file_size were produced by a successful map_file call.
-        unsafe { unmap_file(self.addr, self.file_size) };
+        match self.backing {
+            RegionBacking::MappedFile => {
+                // SAFETY: addr and size were produced by a successful map_file call.
+                unsafe { unmap_file(self.addr, self.size) };
+            }
+        }
     }
+}
+
+enum RegionBacking {
+    MappedFile,
 }
 
 // SAFETY: The mapped memory is shared (MAP_SHARED / file-backed) and access
 // is synchronized by the queue protocol built on top of it.
-unsafe impl Send for MappedRegion {}
-unsafe impl Sync for MappedRegion {}
+unsafe impl Send for Region {}
+unsafe impl Sync for Region {}
 
 fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
     let actual = addr.as_ptr().align_offset(MINIMUM_REGION_ALIGNMENT);
@@ -180,12 +190,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_mapped_region_is_minimum_region_aligned() {
+    fn test_region_is_minimum_region_aligned() {
         let file = create_temp_shmem_file().expect("temp file");
         file.set_len(MINIMUM_REGION_ALIGNMENT as u64)
             .expect("set len");
 
-        let region = MappedRegion::new(&file, MINIMUM_REGION_ALIGNMENT).expect("map file");
+        let region = Region::map_file(&file, MINIMUM_REGION_ALIGNMENT).expect("map file");
         assert_eq!(
             region
                 .addr()

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -84,13 +84,6 @@ fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg(not(test))]
-#[allow(dead_code)]
-const _: () = {
-    let _ = Region::alloc;
-    let _ = RegionBacking::Heap;
-};
-
 /// Maps a file into memory.
 #[cfg(unix)]
 fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use std::{fs::File, ptr::NonNull, sync::Arc};
+use std::{fs::File, num::NonZeroUsize, ptr::NonNull, sync::Arc};
 
 pub(crate) const MINIMUM_REGION_ALIGNMENT: usize = 4096;
 
@@ -20,8 +20,8 @@ impl Region {
         }))
     }
 
-    pub(crate) fn alloc(size: usize) -> Result<Arc<Self>, Error> {
-        let layout = std::alloc::Layout::from_size_align(size, MINIMUM_REGION_ALIGNMENT)
+    pub(crate) fn alloc(size: NonZeroUsize) -> Result<Arc<Self>, Error> {
+        let layout = std::alloc::Layout::from_size_align(size.get(), MINIMUM_REGION_ALIGNMENT)
             .map_err(|_| Error::InvalidBufferSize)?;
         let addr = {
             // SAFETY: layout is valid and non-zero.
@@ -33,7 +33,7 @@ impl Region {
 
         Ok(Arc::new(Self {
             addr,
-            size,
+            size: size.get(),
             backing: RegionBacking::Heap(layout),
         }))
     }
@@ -230,7 +230,8 @@ mod tests {
 
     #[test]
     fn test_alloc_region_is_4096_aligned() {
-        let region = Region::alloc(MINIMUM_REGION_ALIGNMENT * 2).expect("allocation failed");
+        let region = Region::alloc(NonZeroUsize::new(MINIMUM_REGION_ALIGNMENT * 2).unwrap())
+            .expect("allocation failed");
         assert_eq!(
             region
                 .addr()
@@ -243,7 +244,8 @@ mod tests {
 
     #[test]
     fn test_alloc_region_accepts_non_4096_multiple() {
-        let region = Region::alloc(MINIMUM_REGION_ALIGNMENT + 1).expect("allocation failed");
+        let region = Region::alloc(NonZeroUsize::new(MINIMUM_REGION_ALIGNMENT + 1).unwrap())
+            .expect("allocation failed");
         assert_eq!(
             region
                 .addr()

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -35,7 +35,8 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 pub unsafe fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(region_size)?;
-    let header = SharedQueueHeader::create_in_region::<T>(&region)?;
+    // SAFETY: `region` is freshly allocated and used only for this queue.
+    let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
     let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;
     let consumer = unsafe { Consumer::from_header(region, header) }?;
     Ok((producer, consumer))

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -2,6 +2,7 @@ use crate::{error::Error, normalized_capacity, shmem::Region, CacheAlignedAtomic
 use core::ptr::NonNull;
 use std::{
     fs::File,
+    num::NonZeroUsize,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -30,7 +31,7 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 /// having their destructors run.
 pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
-    let region = Region::alloc(region_size)?;
+    let region = Region::alloc(NonZeroUsize::new(region_size).ok_or(Error::InvalidBufferSize)?)?;
     // SAFETY: `region` is freshly allocated and used only for this queue.
     let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
     let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -26,13 +26,9 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 
 /// Creates a new in-process SPSC queue pair backed by a heap allocation.
 ///
-/// # Safety
-/// - The queue does not validate `T`.
-/// - If a thread may read, dereference, mutate, or drop a queued value, that
-///   operation must be valid for that value in that thread.
-/// - Values left buffered when the queue is dropped may be leaked instead of
-///   having their destructors run.
-pub unsafe fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
+/// Values left buffered when the queue is dropped may be leaked instead of
+/// having their destructors run.
+pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(region_size)?;
     // SAFETY: `region` is freshly allocated and used only for this queue.
@@ -701,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_pair_creates_in_process_queue() {
-        let (mut producer, mut consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
+        let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
 
         assert_eq!(producer.capacity(), 64);
         assert_eq!(consumer.capacity(), 64);
@@ -716,7 +712,7 @@ mod tests {
 
     #[test]
     fn test_pair_join_as_other_role() {
-        let (mut producer, consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
+        let (mut producer, consumer) = pair::<u64>(64).expect("pair failed");
         drop(consumer);
         let mut consumer = unsafe { producer.join_as_consumer() }.expect("join failed");
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -25,7 +25,14 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 }
 
 /// Creates a new in-process SPSC queue pair backed by a heap allocation.
-pub fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
+///
+/// # Safety
+/// - The queue does not validate `T`.
+/// - If a thread may read, dereference, mutate, or drop a queued value, that
+///   operation must be valid for that value in that thread.
+/// - Values left buffered when the queue is dropped may be leaked instead of
+///   having their destructors run.
+pub unsafe fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(region_size)?;
     let header = SharedQueueHeader::create_in_region::<T>(&region)?;
@@ -661,7 +668,7 @@ mod tests {
 
     #[test]
     fn test_pair_creates_in_process_queue() {
-        let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
+        let (mut producer, mut consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
 
         assert_eq!(producer.capacity(), 64);
         assert_eq!(consumer.capacity(), 64);
@@ -676,7 +683,7 @@ mod tests {
 
     #[test]
     fn test_pair_join_as_other_role() {
-        let (mut producer, consumer) = pair::<u64>(64).expect("pair failed");
+        let (mut producer, consumer) = unsafe { pair::<u64>(64) }.expect("pair failed");
         drop(consumer);
         let mut consumer = unsafe { producer.join_as_consumer() }.expect("join failed");
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -19,6 +19,21 @@ pub const fn minimum_file_size<T>(capacity: usize) -> usize {
     buffer_offset + normalized_capacity(capacity) * core::mem::size_of::<T>()
 }
 
+/// Calculates the minimum region size required for a queue with given capacity.
+pub const fn minimum_region_size<T>(capacity: usize) -> usize {
+    minimum_file_size::<T>(capacity)
+}
+
+/// Creates a new in-process SPSC queue pair backed by a heap allocation.
+pub fn pair<T>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
+    let region_size = minimum_region_size::<T>(capacity);
+    let region = Region::alloc(region_size)?;
+    let header = SharedQueueHeader::create_in_region::<T>(&region)?;
+    let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;
+    let consumer = unsafe { Consumer::from_header(region, header) }?;
+    Ok((producer, consumer))
+}
+
 /// Producer side of the SPSC shared queue.
 pub struct Producer<T> {
     queue: SharedQueue<T>,
@@ -642,5 +657,34 @@ mod tests {
             .expect("create failed");
 
         assert_eq!(producer.capacity(), 4);
+    }
+
+    #[test]
+    fn test_pair_creates_in_process_queue() {
+        let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
+
+        assert_eq!(producer.capacity(), 64);
+        assert_eq!(consumer.capacity(), 64);
+
+        producer.try_write(123).unwrap();
+        producer.commit();
+        consumer.sync();
+        let val = consumer.try_read().expect("read failed");
+        assert_eq!(*val, 123);
+        consumer.finalize();
+    }
+
+    #[test]
+    fn test_pair_join_as_other_role() {
+        let (mut producer, consumer) = pair::<u64>(64).expect("pair failed");
+        drop(consumer);
+        let mut consumer = unsafe { producer.join_as_consumer() }.expect("join failed");
+
+        producer.try_write(55).unwrap();
+        producer.commit();
+        consumer.sync();
+        let val = consumer.try_read().expect("read failed");
+        assert_eq!(*val, 55);
+        consumer.finalize();
     }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -56,7 +56,10 @@ impl<T> Producer<T> {
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        let (region, header) = SharedQueueHeader::create::<T>(file, file_size)?;
+        // SAFETY: caller guarantees this file is uniquely created as a
+        // producer, so initializing the queue header for this mapping happens
+        // exactly once.
+        let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
         unsafe { Self::from_header(region, header) }
@@ -185,7 +188,10 @@ impl<T> Consumer<T> {
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        let (region, header) = SharedQueueHeader::create::<T>(file, file_size)?;
+        // SAFETY: caller guarantees this file is uniquely created as a
+        // consumer, so initializing the queue header for this mapping happens
+        // exactly once.
+        let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
         unsafe { Self::from_header(region, header) }
@@ -407,15 +413,29 @@ struct SharedQueueHeader {
 }
 
 impl SharedQueueHeader {
-    fn create<T>(file: &File, size: usize) -> Result<(Arc<Region>, NonNull<Self>), Error> {
+    /// Creates and initializes a new shared queue header in `file`.
+    ///
+    /// # Safety
+    /// - The mapping created for `file` must be used to initialize at most one
+    ///   queue header.
+    /// - The returned `region` must not be passed to any other queue-header
+    ///   initialization routine.
+    unsafe fn create<T>(file: &File, size: usize) -> Result<(Arc<Region>, NonNull<Self>), Error> {
         file.set_len(size as u64)?;
 
         let region = Region::map_file(file, size)?;
-        let header = Self::create_in_region::<T>(&region)?;
+        // SAFETY: caller guarantees this mapping is initialized exactly once.
+        let header = unsafe { Self::create_in_region::<T>(&region) }?;
         Ok((region, header))
     }
 
-    fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
+    /// Initializes a shared queue header in `region`.
+    ///
+    /// # Safety
+    /// - `region` must be uniquely used for queue-header initialization.
+    /// - This function must be called at most once for a given region.
+    /// - `region` must not already contain an initialized queue header.
+    unsafe fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
         let header = region.addr().cast::<Self>();
         // SAFETY: The header is non-null and aligned properly.

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -188,9 +188,9 @@ impl<T> Consumer<T> {
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this file is uniquely created as a
-        // consumer, so initializing the queue header for this mapping happens
-        // exactly once.
+        // SAFETY: caller guarantees this file is uniquely created as a consumer,
+        // meaning no prior `create` call has mapped this file, so the queue
+        // header for this mapping is initialized exactly once.
         let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -432,9 +432,7 @@ impl SharedQueueHeader {
     /// Initializes a shared queue header in `region`.
     ///
     /// # Safety
-    /// - `region` must be uniquely used for queue-header initialization.
-    /// - This function must be called at most once for a given region.
-    /// - `region` must not already contain an initialized queue header.
+    /// - This function must be called at most once for a given `region`.
     unsafe fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
         let header = region.addr().cast::<Self>();
@@ -442,6 +440,8 @@ impl SharedQueueHeader {
         //         Alignment is guaranteed because mmap ensures that the
         //         memory is aligned to the page size, which is sufficient for the
         //         alignment of `SharedQueueHeader`.
+        //         Access is exclusive because the caller guarantees this region
+        //         is initialized at most once.
         unsafe { Self::initialize(header, buffer_size_in_items) };
         Ok(header)
     }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -1,6 +1,4 @@
-use crate::{
-    error::Error, normalized_capacity, shmem::MappedRegion, CacheAlignedAtomicSize, VERSION,
-};
+use crate::{error::Error, normalized_capacity, shmem::Region, CacheAlignedAtomicSize, VERSION};
 use core::ptr::NonNull;
 use std::{
     fs::File,
@@ -71,7 +69,7 @@ impl<T> Producer<T> {
     /// - `header` must be non-null and properly aligned.
     /// - allocation backing `region` must be of sufficient size.
     unsafe fn from_header(
-        region: Arc<MappedRegion>,
+        region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -200,7 +198,7 @@ impl<T> Consumer<T> {
     /// - `header` must be non-null and properly aligned.
     /// - allocation backing `region` must be of sufficient size.
     unsafe fn from_header(
-        region: Arc<MappedRegion>,
+        region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -283,7 +281,7 @@ struct SharedQueue<T> {
 
     // NB: Region must be declared last so it is dropped last ensuring `header` and
     // `buffer` remain valid for their entire lifetime.
-    region: Arc<MappedRegion>,
+    region: Arc<Region>,
 }
 
 impl<T> SharedQueue<T> {
@@ -293,14 +291,14 @@ impl<T> SharedQueue<T> {
     /// - `header` must be non-null and properly aligned.
     /// - `region` must back the allocation at `header`.
     unsafe fn from_header(
-        region: Arc<MappedRegion>,
+        region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Self, Error> {
         // SAFETY: `header` is non-null and aligned properly.
         let size = unsafe { (header.as_ref().buffer_mask as usize).wrapping_add(1) };
 
         if !size.is_power_of_two()
-            || SharedQueueHeader::calculate_buffer_size_in_items::<T>(region.file_size())? != size
+            || SharedQueueHeader::calculate_buffer_size_in_items::<T>(region.size())? != size
         {
             return Err(Error::InvalidBufferSize);
         }
@@ -387,18 +385,23 @@ struct SharedQueueHeader {
 }
 
 impl SharedQueueHeader {
-    fn create<T>(file: &File, size: usize) -> Result<(Arc<MappedRegion>, NonNull<Self>), Error> {
+    fn create<T>(file: &File, size: usize) -> Result<(Arc<Region>, NonNull<Self>), Error> {
         file.set_len(size as u64)?;
 
-        let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(size)?;
-        let region = MappedRegion::new(file, size)?;
+        let region = Region::map_file(file, size)?;
+        let header = Self::create_in_region::<T>(&region)?;
+        Ok((region, header))
+    }
+
+    fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
+        let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
         let header = region.addr().cast::<Self>();
         // SAFETY: The header is non-null and aligned properly.
         //         Alignment is guaranteed because mmap ensures that the
         //         memory is aligned to the page size, which is sufficient for the
         //         alignment of `SharedQueueHeader`.
         unsafe { Self::initialize(header, buffer_size_in_items) };
-        Ok((region, header))
+        Ok(header)
     }
 
     const fn buffer_offset<T>() -> usize {
@@ -463,9 +466,14 @@ impl SharedQueueHeader {
         header.magic.store(MAGIC, Ordering::Release);
     }
 
-    fn join<T>(file: &File) -> Result<(Arc<MappedRegion>, NonNull<Self>), Error> {
+    fn join<T>(file: &File) -> Result<(Arc<Region>, NonNull<Self>), Error> {
         let file_size = file.metadata()?.len() as usize;
-        let region = MappedRegion::new(file, file_size)?;
+        let region = Region::map_file(file, file_size)?;
+        let header = Self::join_region::<T>(&region)?;
+        Ok((region, header))
+    }
+
+    fn join_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let header = region.addr().cast::<Self>();
         {
             // SAFETY: The header is non-null and aligned properly.
@@ -483,13 +491,13 @@ impl SharedQueueHeader {
                 });
             }
             if (header.buffer_mask as usize).wrapping_add(1)
-                != Self::calculate_buffer_size_in_items::<T>(file_size)?
+                != Self::calculate_buffer_size_in_items::<T>(region.size())?
             {
                 return Err(Error::InvalidBufferSize);
             }
         }
 
-        Ok((region, header))
+        Ok(header)
     }
 }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -52,14 +52,19 @@ impl<T> Producer<T> {
     /// the given size.
     ///
     /// # Safety
-    /// - The provided file must be uniquely created as a Producer.
+    /// - The file must be created and initialized exactly once.
+    /// - Initialization may be performed by either a [`Producer`] or a
+    ///   [`Consumer`], but that process or thread must be designated
+    ///   externally as the sole initializer.
+    /// - This queue permits exactly one [`Producer`]. If initialization is
+    ///   performed as a [`Producer`], no other [`Producer`] may join it.
     /// - The queue does not validate `T` across processes.
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this file is uniquely created as a
-        // producer, so initializing the queue header for this mapping happens
-        // exactly once.
+        // SAFETY: caller guarantees this process or thread is the externally
+        // designated sole initializer, so initializing the queue header for
+        // this mapping happens exactly once.
         let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -69,7 +74,8 @@ impl<T> Producer<T> {
     /// Joins an existing producer for the shared queue in the provided file.
     ///
     /// # Safety
-    /// - The provided file must be uniquely joined as a Producer.
+    /// - This queue permits exactly one [`Producer`]. No other [`Producer`]
+    ///   may have created or joined the same file.
     /// - The queue does not validate `T` across processes.
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
@@ -184,14 +190,19 @@ impl<T> Consumer<T> {
     /// the given size.
     ///
     /// # Safety
-    /// - The provided file must be uniquely created as a Consumer.
+    /// - The file must be created and initialized exactly once.
+    /// - Initialization may be performed by either a [`Producer`] or a
+    ///   [`Consumer`], but that process or thread must be designated
+    ///   externally as the sole initializer.
+    /// - This queue permits exactly one [`Consumer`]. If initialization is
+    ///   performed as a [`Consumer`], no other [`Consumer`] may join it.
     /// - The queue does not validate `T` across processes.
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.
     pub unsafe fn create(file: &File, file_size: usize) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this file is uniquely created as a consumer,
-        // meaning no prior `create` call has mapped this file, so the queue
-        // header for this mapping is initialized exactly once.
+        // SAFETY: caller guarantees this process or thread is the externally
+        // designated sole initializer, so initializing the queue header for
+        // this mapping happens exactly once.
         let (region, header) = unsafe { SharedQueueHeader::create::<T>(file, file_size) }?;
         // SAFETY: `header` is non-null and aligned properly and allocated with
         //         size of `file_size`.
@@ -201,7 +212,8 @@ impl<T> Consumer<T> {
     /// Joins an existing consumer for the shared queue in the provided file.
     ///
     /// # Safety
-    /// - The provided file must be uniquely joined as a Consumer.
+    /// - This queue permits exactly one [`Consumer`]. No other [`Consumer`]
+    ///   may have created or joined the same file.
     /// - The queue does not validate `T` across processes.
     /// - If a process may read, dereference, mutate, or drop a queued value,
     ///   that operation must be valid for that value in that process.


### PR DESCRIPTION
## Motivation
- Want API for in-process queues for simpler replacement of other queues (such as crossbeam)

## Summary
- Add heap-based allocation backing
- Add SPSC/MPMC `pair` functions that use new heap backing