### PR TITLE
Enforce alignment requirements

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ pub enum Error {
     InvalidMagic,
     InvalidVersion { expected: u32, actual: u32 },
     InvalidBufferSize,
+    InvalidRegionAlignment { minimum: usize, actual: usize },
     Io(std::io::Error),
     Mmap(std::io::Error),
 }
@@ -24,6 +25,10 @@ impl Display for Error {
                 actual & 0xFFFF,
             ),
             Self::InvalidBufferSize => write!(f, "invalid buffer size"),
+            Self::InvalidRegionAlignment { minimum, actual } => write!(
+                f,
+                "invalid region alignment; minimum={minimum}; actual={actual}"
+            ),
             Self::Io(err) => write!(f, "io; err={err}"),
             Self::Mmap(err) => write!(f, "mmap; err={err}"),
         }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -495,6 +495,13 @@ impl SharedQueueHeader {
     }
 
     const fn buffer_offset<T: Sized>() -> usize {
+        const {
+            assert!(
+                core::mem::align_of::<T>() <= crate::shmem::MINIMUM_REGION_ALIGNMENT,
+                "types with alignment > MINIMUM_REGION_ALIGNMENT are not supported"
+            )
+        }
+
         core::mem::size_of::<Self>().next_multiple_of(core::mem::align_of::<T>())
     }
 

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -11,6 +11,7 @@ pub(crate) struct MappedRegion {
 impl MappedRegion {
     pub(crate) fn new(file: &File, size: usize) -> Result<Arc<Self>, Error> {
         let addr = map_file(file, size)?;
+        validate_region_alignment(addr)?;
         Ok(Arc::new(Self {
             addr,
             file_size: size,
@@ -37,6 +38,18 @@ impl Drop for MappedRegion {
 // is synchronized by the queue protocol built on top of it.
 unsafe impl Send for MappedRegion {}
 unsafe impl Sync for MappedRegion {}
+
+fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
+    let actual = addr.as_ptr().align_offset(MINIMUM_REGION_ALIGNMENT);
+    if actual != 0 {
+        return Err(Error::InvalidRegionAlignment {
+            minimum: MINIMUM_REGION_ALIGNMENT,
+            actual,
+        });
+    }
+
+    Ok(())
+}
 
 /// Maps a file into memory.
 #[cfg(unix)]
@@ -159,5 +172,26 @@ pub(crate) fn create_temp_shmem_file() -> Result<File, Error> {
             Ok(file)
         }
         Err(err) => Err(Error::Io(err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mapped_region_is_minimum_region_aligned() {
+        let file = create_temp_shmem_file().expect("temp file");
+        file.set_len(MINIMUM_REGION_ALIGNMENT as u64)
+            .expect("set len");
+
+        let region = MappedRegion::new(&file, MINIMUM_REGION_ALIGNMENT).expect("map file");
+        assert_eq!(
+            region
+                .addr()
+                .as_ptr()
+                .align_offset(MINIMUM_REGION_ALIGNMENT),
+            0
+        );
     }
 }

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -1,6 +1,8 @@
 use crate::error::Error;
 use std::{fs::File, ptr::NonNull, sync::Arc};
 
+pub(crate) const MINIMUM_REGION_ALIGNMENT: usize = 4096;
+
 pub(crate) struct MappedRegion {
     addr: NonNull<u8>,
     file_size: usize,

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -405,6 +405,13 @@ impl SharedQueueHeader {
     }
 
     const fn buffer_offset<T: Sized>() -> usize {
+        const {
+            assert!(
+                core::mem::align_of::<T>() <= crate::shmem::MINIMUM_REGION_ALIGNMENT,
+                "types with alignment > MINIMUM_REGION_ALIGNMENT are not supported"
+            )
+        }
+
         (core::mem::size_of::<Self>() + core::mem::align_of::<T>() - 1)
             & !(core::mem::align_of::<T>() - 1)
     }


### PR DESCRIPTION
### Problem
- Things might break if our alignment requirements (T <=4096 , region >=4096) are not met.

### Changes
- Enforce alignment requirements:
	- compile-time assert on T's alignment
	- runtime error on region alignment 