### PR TITLE
Gate Send/Sync on T's implementation

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -183,8 +183,8 @@ impl<T> Clone for Producer<T> {
     }
 }
 
-unsafe impl<T> Send for Producer<T> {}
-unsafe impl<T> Sync for Producer<T> {}
+unsafe impl<T: Send> Send for Producer<T> {}
+unsafe impl<T: Sync> Sync for Producer<T> {}
 
 pub struct Consumer<T> {
     queue: SharedQueue<T>,
@@ -348,8 +348,8 @@ impl<T> Clone for Consumer<T> {
     }
 }
 
-unsafe impl<T> Send for Consumer<T> {}
-unsafe impl<T> Sync for Consumer<T> {}
+unsafe impl<T: Send> Send for Consumer<T> {}
+unsafe impl<T: Sync> Sync for Consumer<T> {}
 
 /// Calculates the minimum file size required for a queue with given capacity.
 /// Note that file size MAY need to be increased beyond this to account for

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -175,7 +175,7 @@ impl<T> Producer<T> {
     }
 }
 
-unsafe impl<T> Send for Producer<T> {}
+unsafe impl<T: Send> Send for Producer<T> {}
 
 /// Consumer side of the SPSC shared queue.
 pub struct Consumer<T> {
@@ -307,7 +307,7 @@ impl<T> Consumer<T> {
     }
 }
 
-unsafe impl<T> Send for Consumer<T> {}
+unsafe impl<T: Send> Send for Consumer<T> {}
 
 struct SharedQueue<T> {
     header: NonNull<SharedQueueHeader>,


### PR DESCRIPTION
### Problem
- Although documented, the Send/Sync impls are very odd without gating on T's implementation. Better to reject, and advanced users can opt-in via unsafe impl on T (or wrapper of T)

### Solution
- Gate Send/Sync impls on T implementing that trait