### PR TITLE
feat: add futex-backed waiting

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -348,10 +348,15 @@ fn run_mpmc_consumer(
     exit: Arc<AtomicBool>,
     consumer_reserve_failures: Arc<AtomicU64>,
 ) {
+    let wait_timeout = Duration::from_millis(10);
     run_consumer_loop(exit, move || {
-        let Some(batch) = consumer.reserve_read_batch(SYNC_CADENCE) else {
-            consumer_reserve_failures.fetch_add(1, Ordering::Relaxed);
-            return;
+        let batch = match consumer.reserve_read_batch_timeout(SYNC_CADENCE, wait_timeout) {
+            Ok(Some(batch)) => batch,
+            Ok(None) => return,
+            Err(WaitError::Timeout) => {
+                consumer_reserve_failures.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
         };
         let _ = batch.len();
     });

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -6,12 +6,16 @@ use common::{
     run_total_throughput_loop, setup_exit_handler, Item, SYNC_CADENCE,
 };
 use shaq::{
+    error::WaitError,
     mpmc::{Consumer as MpmcConsumer, Producer as MpmcProducer},
     spsc::{Consumer as SpscConsumer, Producer as SpscProducer},
 };
-use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 const QUEUE_SIZE: usize = 16 * 1024 * 1024;
@@ -216,13 +220,20 @@ fn run_spsc_consumer(
     exit: Arc<AtomicBool>,
     consumer_reserve_failures: Arc<AtomicU64>,
 ) {
+    let wait_timeout = Duration::from_millis(10);
     run_consumer_loop(exit, move || {
-        consumer.sync();
-        for _ in 0..SYNC_CADENCE {
-            let Some(_item) = consumer.try_read() else {
+        match consumer.read_ptr_timeout(wait_timeout) {
+            Ok(_item) => {}
+            Err(WaitError::Timeout) => {
                 consumer_reserve_failures.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+
+        for _ in 1..SYNC_CADENCE {
+            if consumer.try_read().is_none() {
                 break;
-            };
+            }
         }
         consumer.finalize();
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,13 @@ pub enum Error {
     Mmap(std::io::Error),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitError {
+    Timeout,
+}
+
 impl std::error::Error for Error {}
+impl std::error::Error for WaitError {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -42,6 +48,14 @@ impl Display for Error {
     }
 }
 
+impl Display for WaitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "wait timed out"),
+        }
+    }
+}
+
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         Self::Io(err)
@@ -58,5 +72,10 @@ mod tests {
         let actual: u32 = (3u32 << 16) | 7; // 3.7
         let err = Error::InvalidVersion { expected, actual };
         assert_eq!(err.to_string(), "invalid version; expected=1.0; found=3.7");
+    }
+
+    #[test]
+    fn test_wait_timeout_display() {
+        assert_eq!(WaitError::Timeout.to_string(), "wait timed out");
     }
 }

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -5,7 +5,7 @@
 //!
 //! # Why no wake is lost
 //!
-//! The producer publishes the cursor (Release), then in [`WaitState::wake`]
+//! The producer publishes the cursor (Release), then in [`Waiters::wake`]
 //! issues a SeqCst fence and loads `waiters`, skipping the wake syscall if
 //! it is zero. A waiter increments `waiters`, issues a SeqCst fence (in
 //! `register`), then rechecks for data before sleeping. SeqCst fences are
@@ -25,7 +25,7 @@
 //! multiple of 2^32 between snapshot and compare the wait oversleeps; that
 //! is bounded by the timeout and astronomically unlikely.
 
-use crate::{error::WaitError, CacheAlignedAtomicU32};
+use crate::{error::WaitError, CacheAlignedAtomicSize};
 use core::{
     hint::spin_loop,
     sync::atomic::{fence, AtomicUsize, Ordering},
@@ -48,14 +48,14 @@ fn remaining_until(deadline: Instant) -> Result<Duration, WaitError> {
 }
 
 #[repr(C)]
-pub(crate) struct WaitState {
+pub(crate) struct Waiters {
     /// Approximate count of waiters registered against the queue's
     /// publication cursor.
-    waiters: CacheAlignedAtomicU32,
+    waiters: CacheAlignedAtomicSize,
 }
 
-impl WaitState {
-    /// Initializes this wait state inside a newly created shared-memory header.
+impl Waiters {
+    /// Initializes the waiter count inside a newly created shared-memory header.
     pub(crate) fn initialize(&self) {
         self.waiters.store(0, Ordering::Release);
     }
@@ -161,12 +161,12 @@ impl WaitState {
             return;
         }
 
-        let count = waiters.min(count.min(MAX_WAKE_COUNT as usize) as u32);
+        let count = waiters.min(count).min(MAX_WAKE_COUNT) as u32;
         imp::wake(cursor, count);
     }
 }
 
-const MAX_WAKE_COUNT: u32 = i32::MAX as u32;
+const MAX_WAKE_COUNT: usize = i32::MAX as usize;
 
 #[cfg(target_os = "linux")]
 mod imp {

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -64,14 +64,11 @@ impl Waiters {
     ///
     /// `cursor` is the queue's publication cursor used as the futex word
     /// while sleeping; an advance of `cursor` must imply that `check` can
-    /// observe new data. `spin_attempts` controls how many extra checks run
-    /// before registering as a waiter and entering the platform wait backend;
-    /// spinning happens only before the first sleep.
+    /// observe new data.
     pub(crate) fn wait_for<T>(
         &self,
         cursor: &AtomicUsize,
         timeout: Duration,
-        spin_attempts: usize,
         mut check: impl FnMut() -> Option<T>,
     ) -> Result<T, WaitError> {
         let deadline = deadline_from_timeout(timeout);
@@ -82,7 +79,7 @@ impl Waiters {
 
         // Spin only before the first sleep; once this thread has blocked it
         // is on the slow path and goes straight back to waiting.
-        for _ in 0..spin_attempts {
+        for _ in 0..SPIN_ATTEMPTS {
             spin_loop();
             if let Some(value) = check() {
                 return Ok(value);
@@ -167,6 +164,10 @@ impl Waiters {
 }
 
 const MAX_WAKE_COUNT: usize = i32::MAX as usize;
+
+/// Extra `check` attempts before a waiter's first sleep in
+/// [`Waiters::wait_for`].
+const SPIN_ATTEMPTS: usize = 2048;
 
 #[cfg(target_os = "linux")]
 mod imp {

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -2,6 +2,8 @@ use crate::{error::WaitError, CacheAlignedAtomicU32};
 use core::{hint::spin_loop, sync::atomic::Ordering};
 use std::time::{Duration, Instant};
 
+type SequenceNumber = u32;
+
 fn deadline_from_timeout(timeout: Duration) -> Instant {
     Instant::now()
         .checked_add(timeout)
@@ -70,7 +72,7 @@ impl WaitState {
         }
     }
 
-    fn register(&self) -> u32 {
+    fn register(&self) -> SequenceNumber {
         self.waiters.fetch_add(1, Ordering::AcqRel);
         self.sequence.load(Ordering::Acquire)
     }
@@ -79,7 +81,7 @@ impl WaitState {
         self.waiters.fetch_sub(1, Ordering::AcqRel);
     }
 
-    fn wait(&self, expected: u32, deadline: Instant) -> Result<(), WaitError> {
+    fn wait(&self, expected: SequenceNumber, deadline: Instant) -> Result<(), WaitError> {
         // Avoid entering the platform wait backend if a wake already advanced
         // the sequence after the caller's post-registration recheck.
         if self.sequence.load(Ordering::Acquire) != expected {
@@ -108,7 +110,7 @@ const MAX_WAKE_COUNT: u32 = i32::MAX as u32;
 
 #[cfg(target_os = "linux")]
 mod imp {
-    use super::remaining_until;
+    use super::{remaining_until, SequenceNumber};
     use crate::error::WaitError;
     use core::sync::atomic::AtomicU32;
     use std::time::{Duration, Instant};
@@ -119,7 +121,7 @@ mod imp {
     /// return success for ordinary wakes and for spurious wakes.
     pub(super) fn wait(
         futex: &AtomicU32,
-        expected: u32,
+        expected: SequenceNumber,
         deadline: Instant,
     ) -> Result<(), WaitError> {
         loop {
@@ -198,7 +200,7 @@ mod imp {
 
 #[cfg(not(target_os = "linux"))]
 mod imp {
-    use super::remaining_until;
+    use super::{remaining_until, SequenceNumber};
     use crate::error::WaitError;
     use core::{
         hint::spin_loop,
@@ -211,7 +213,7 @@ mod imp {
     /// `Ok(())` means the caller should recheck its own condition.
     pub(super) fn wait(
         futex: &AtomicU32,
-        expected: u32,
+        expected: SequenceNumber,
         deadline: Instant,
     ) -> Result<(), WaitError> {
         loop {

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,32 +1,33 @@
-fn deadline_from_timeout(timeout: std::time::Duration) -> std::time::Instant {
-    std::time::Instant::now()
+use crate::{error::WaitError, CacheAlignedAtomicU32};
+use core::{hint::spin_loop, sync::atomic::Ordering};
+use std::time::{Duration, Instant};
+
+fn deadline_from_timeout(timeout: Duration) -> Instant {
+    Instant::now()
         .checked_add(timeout)
         .expect("timeout duration overflowed Instant")
 }
 
-fn remaining_until(
-    deadline: std::time::Instant,
-) -> Result<std::time::Duration, crate::error::WaitError> {
+fn remaining_until(deadline: Instant) -> Result<Duration, WaitError> {
     deadline
-        .checked_duration_since(std::time::Instant::now())
+        .checked_duration_since(Instant::now())
         .filter(|remaining| !remaining.is_zero())
-        .ok_or(crate::error::WaitError::Timeout)
+        .ok_or(WaitError::Timeout)
 }
 
 #[repr(C)]
 pub(crate) struct WaitState {
     /// Sequence word observed by waiters and advanced by wakers.
-    sequence: crate::CacheAlignedAtomicU32,
+    sequence: CacheAlignedAtomicU32,
     /// Approximate count of waiters registered against `sequence`.
-    waiters: crate::CacheAlignedAtomicU32,
+    waiters: CacheAlignedAtomicU32,
 }
 
 impl WaitState {
     /// Initializes this wait state inside a newly created shared-memory header.
     pub(crate) fn initialize(&self) {
-        self.sequence
-            .store(0, core::sync::atomic::Ordering::Release);
-        self.waiters.store(0, core::sync::atomic::Ordering::Release);
+        self.sequence.store(0, Ordering::Release);
+        self.waiters.store(0, Ordering::Release);
     }
 
     /// Runs `check` until it returns a value or `timeout` elapses.
@@ -35,10 +36,10 @@ impl WaitState {
     /// a waiter and entering the platform wait backend.
     pub(crate) fn wait_for<T>(
         &self,
-        timeout: std::time::Duration,
+        timeout: Duration,
         spin_attempts: usize,
         mut check: impl FnMut() -> Option<T>,
-    ) -> Result<T, crate::error::WaitError> {
+    ) -> Result<T, WaitError> {
         let deadline = deadline_from_timeout(timeout);
         loop {
             if let Some(value) = check() {
@@ -46,7 +47,7 @@ impl WaitState {
             }
 
             for _ in 0..spin_attempts {
-                core::hint::spin_loop();
+                spin_loop();
                 if let Some(value) = check() {
                     return Ok(value);
                 }
@@ -70,24 +71,18 @@ impl WaitState {
     }
 
     fn register(&self) -> u32 {
-        self.waiters
-            .fetch_add(1, core::sync::atomic::Ordering::AcqRel);
-        self.sequence.load(core::sync::atomic::Ordering::Acquire)
+        self.waiters.fetch_add(1, Ordering::AcqRel);
+        self.sequence.load(Ordering::Acquire)
     }
 
     fn unregister(&self) {
-        self.waiters
-            .fetch_sub(1, core::sync::atomic::Ordering::AcqRel);
+        self.waiters.fetch_sub(1, Ordering::AcqRel);
     }
 
-    fn wait(
-        &self,
-        expected: u32,
-        deadline: std::time::Instant,
-    ) -> Result<(), crate::error::WaitError> {
+    fn wait(&self, expected: u32, deadline: Instant) -> Result<(), WaitError> {
         // Avoid entering the platform wait backend if a wake already advanced
         // the sequence after the caller's post-registration recheck.
-        if self.sequence.load(core::sync::atomic::Ordering::Acquire) != expected {
+        if self.sequence.load(Ordering::Acquire) != expected {
             return Ok(());
         }
 
@@ -98,13 +93,12 @@ impl WaitState {
     pub(crate) fn wake(&self, count: usize) {
         debug_assert!(count > 0);
 
-        let waiters = self.waiters.load(core::sync::atomic::Ordering::Acquire);
+        let waiters = self.waiters.load(Ordering::Acquire);
         if waiters == 0 {
             return;
         }
 
-        self.sequence
-            .fetch_add(1, core::sync::atomic::Ordering::Release);
+        self.sequence.fetch_add(1, Ordering::Release);
         let count = waiters.min(count.min(MAX_WAKE_COUNT as usize) as u32);
         imp::wake(&self.sequence, count);
     }
@@ -114,17 +108,22 @@ const MAX_WAKE_COUNT: u32 = i32::MAX as u32;
 
 #[cfg(target_os = "linux")]
 mod imp {
+    use super::remaining_until;
+    use crate::error::WaitError;
+    use core::sync::atomic::AtomicU32;
+    use std::time::{Duration, Instant};
+
     /// Blocks with Linux `FUTEX_WAIT` while `futex` still equals `expected`.
     ///
     /// `Ok(())` means the caller should recheck its own condition; Linux can
     /// return success for ordinary wakes and for spurious wakes.
     pub(super) fn wait(
-        futex: &core::sync::atomic::AtomicU32,
+        futex: &AtomicU32,
         expected: u32,
-        deadline: std::time::Instant,
-    ) -> Result<(), crate::error::WaitError> {
+        deadline: Instant,
+    ) -> Result<(), WaitError> {
         loop {
-            let remaining = super::remaining_until(deadline)?;
+            let remaining = remaining_until(deadline)?;
 
             let timeout_storage = duration_to_timespec(remaining);
             let timeout_ptr = &timeout_storage as *const libc::timespec;
@@ -154,14 +153,14 @@ mod imp {
             match errno() {
                 libc::EAGAIN => return Ok(()),
                 libc::EINTR => continue,
-                libc::ETIMEDOUT => return Err(crate::error::WaitError::Timeout),
+                libc::ETIMEDOUT => return Err(WaitError::Timeout),
                 err => panic!("unexpected futex wait error: errno={err}"),
             }
         }
     }
 
     /// Wakes waiters blocked in Linux `FUTEX_WAIT` on `futex`.
-    pub(super) fn wake(futex: &core::sync::atomic::AtomicU32, count: u32) {
+    pub(super) fn wake(futex: &AtomicU32, count: u32) {
         debug_assert!(count <= libc::c_int::MAX as u32);
 
         // SAFETY: `futex.as_ptr()` is a valid pointer to a 4-byte aligned atomic.
@@ -180,10 +179,10 @@ mod imp {
         );
     }
 
-    /// Converts a [`std::time::Duration`] to the relative [`libc::timespec`]
+    /// Converts a [`Duration`] to the relative [`libc::timespec`]
     /// timeout format expected by futex.
     #[inline]
-    const fn duration_to_timespec(duration: std::time::Duration) -> libc::timespec {
+    const fn duration_to_timespec(duration: Duration) -> libc::timespec {
         debug_assert!(duration.as_secs() <= libc::time_t::MAX as u64);
         libc::timespec {
             tv_sec: duration.as_secs() as libc::time_t,
@@ -199,25 +198,33 @@ mod imp {
 
 #[cfg(not(target_os = "linux"))]
 mod imp {
+    use super::remaining_until;
+    use crate::error::WaitError;
+    use core::{
+        hint::spin_loop,
+        sync::atomic::{AtomicU32, Ordering},
+    };
+    use std::time::Instant;
+
     /// Busy-waits until `futex` no longer equals `expected` or timeout elapses.
     ///
     /// `Ok(())` means the caller should recheck its own condition.
     pub(super) fn wait(
-        futex: &core::sync::atomic::AtomicU32,
+        futex: &AtomicU32,
         expected: u32,
-        deadline: std::time::Instant,
-    ) -> Result<(), crate::error::WaitError> {
+        deadline: Instant,
+    ) -> Result<(), WaitError> {
         loop {
-            if futex.load(core::sync::atomic::Ordering::Acquire) != expected {
+            if futex.load(Ordering::Acquire) != expected {
                 return Ok(());
             }
 
-            super::remaining_until(deadline)?;
+            remaining_until(deadline)?;
 
-            core::hint::spin_loop();
+            spin_loop();
         }
     }
 
     /// No-ops because spin waiters observe the shared sequence word directly.
-    pub(super) fn wake(_futex: &core::sync::atomic::AtomicU32, _count: u32) {}
+    pub(super) fn wake(_futex: &AtomicU32, _count: u32) {}
 }

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -71,11 +71,13 @@ impl Waiters {
         timeout: Duration,
         mut check: impl FnMut() -> Option<T>,
     ) -> Result<T, WaitError> {
-        let deadline = deadline_from_timeout(timeout);
-
         if let Some(value) = check() {
             return Ok(value);
         }
+
+        // Taken only after the first check so an immediately satisfied call
+        // never reads the clock; the timeout still bounds the spin below.
+        let deadline = deadline_from_timeout(timeout);
 
         // Spin only before the first sleep; once this thread has blocked it
         // is on the slow path and goes straight back to waiting.

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,8 +1,60 @@
+//! Futex-backed waiting for the shared-memory queues.
+//!
+//! The futex word is the queue's own 64-bit publication cursor (the write
+//! cursor for spsc, the producer publication cursor for mpmc) rather than a
+//! dedicated sequence word. Every publish advances the cursor
+//! unconditionally, so there is no conditional "bump the sequence only if
+//! waiters are registered" step that a racing waiter could miss.
+//!
+//! # Lost-wake freedom
+//!
+//! The producer and consumer run a Dekker-style store/load protocol, which is
+//! only correct if all four accesses participate in the SeqCst total order:
+//!
+//! - Producer (at each visibility point): publish the cursor with a SeqCst
+//!   store (P1), then load `waiters` with SeqCst (P2); wake if non-zero.
+//! - Consumer (in [`WaitState::wait_for`]): increment `waiters` with a SeqCst
+//!   RMW (C1), then snapshot the cursor with a SeqCst load and recheck the
+//!   condition (C2); sleep only if the condition still fails.
+//!
+//! In the SeqCst total order, either C1 precedes P2 — then P2 observes
+//! `waiters >= 1` and the producer issues a wake — or P2 precedes C1, hence
+//! P1 precedes C2, and C2 must observe the published cursor (a SeqCst load
+//! ordered after a SeqCst store to the same location cannot read an older
+//! value): the consumer's recheck sees the publication and never sleeps, or
+//! `FUTEX_WAIT`'s in-kernel compare fails with `EAGAIN`. At least one arm
+//! always holds, so the lost-wake cycle (producer skips the wake *and* the
+//! consumer sleeps past the publication) is impossible. Acquire/Release is
+//! not enough here: it permits both P2 and C2 to read stale values
+//! (StoreLoad reordering), which is exactly the lost-wake interleaving.
+//!
+//! # Mixed-width access to the cursor
+//!
+//! All userspace accesses to the cursor are full-width 64-bit atomics; only
+//! the kernel's `FUTEX_WAIT` compare reads 32 bits. The futex address is the
+//! low half of the cursor — the half that changes on every publication — at
+//! byte offset 0 on little-endian targets and 4 on big-endian targets. It is
+//! 4-byte aligned either way, and an aligned 4-byte read cannot tear against
+//! aligned 64-bit atomic writes. Never materialize an `&AtomicU32` into the
+//! cursor in Rust code — only a raw pointer passed to the syscall.
+//!
+//! ABA caveat: if the cursor advances by an exact multiple of 2^32 between
+//! the consumer's snapshot and the kernel's compare, the wait sleeps despite
+//! progress. This is bounded by the caller's timeout and astronomically
+//! unlikely in practice.
+//!
+//! The futex syscalls deliberately do not use `FUTEX_PRIVATE_FLAG`: the
+//! queues live in shared memory mapped by multiple processes.
+
 use crate::{error::WaitError, CacheAlignedAtomicU32};
-use core::{hint::spin_loop, sync::atomic::Ordering};
+use core::{
+    hint::spin_loop,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 use std::time::{Duration, Instant};
 
-type SequenceNumber = u32;
+/// Snapshot of a queue's 64-bit publication cursor.
+type SequenceNumber = usize;
 
 fn deadline_from_timeout(timeout: Duration) -> Instant {
     Instant::now()
@@ -19,25 +71,26 @@ fn remaining_until(deadline: Instant) -> Result<Duration, WaitError> {
 
 #[repr(C)]
 pub(crate) struct WaitState {
-    /// Sequence word observed by waiters and advanced by wakers.
-    sequence: CacheAlignedAtomicU32,
-    /// Approximate count of waiters registered against `sequence`.
+    /// Approximate count of waiters registered against the queue's
+    /// publication cursor.
     waiters: CacheAlignedAtomicU32,
 }
 
 impl WaitState {
     /// Initializes this wait state inside a newly created shared-memory header.
     pub(crate) fn initialize(&self) {
-        self.sequence.store(0, Ordering::Release);
         self.waiters.store(0, Ordering::Release);
     }
 
     /// Runs `check` until it returns a value or `timeout` elapses.
     ///
-    /// `spin_attempts` controls how many extra checks run before registering as
-    /// a waiter and entering the platform wait backend.
+    /// `cursor` is the queue's publication cursor used as the futex word
+    /// while sleeping; an advance of `cursor` must imply that `check` can
+    /// observe new data. `spin_attempts` controls how many extra checks run
+    /// before registering as a waiter and entering the platform wait backend.
     pub(crate) fn wait_for<T>(
         &self,
+        cursor: &AtomicUsize,
         timeout: Duration,
         spin_attempts: usize,
         mut check: impl FnMut() -> Option<T>,
@@ -55,9 +108,10 @@ impl WaitState {
                 }
             }
 
-            let sequence = self.register();
+            let snapshot = self.register(cursor);
             // Recheck after registering because a producer can publish after
             // the unregistered check and before this thread starts waiting.
+            // This is C2 in the module-level ordering argument.
             if let Some(value) = check() {
                 self.unregister();
                 return Ok(value);
@@ -66,43 +120,57 @@ impl WaitState {
             // Platform waits can return after a matching wake or a spurious
             // wake, so success only means the caller's condition should be
             // checked again at the top of the loop.
-            let wait_result = self.wait(sequence, deadline);
+            let wait_result = Self::wait(cursor, snapshot, deadline);
             self.unregister();
             wait_result?;
         }
     }
 
-    fn register(&self) -> SequenceNumber {
-        self.waiters.fetch_add(1, Ordering::AcqRel);
-        self.sequence.load(Ordering::Acquire)
+    /// Registers this thread as a waiter and snapshots the cursor.
+    ///
+    /// The SeqCst RMW (C1) followed by the SeqCst cursor load are the
+    /// consumer half of the module-level ordering argument.
+    fn register(&self, cursor: &AtomicUsize) -> SequenceNumber {
+        self.waiters.fetch_add(1, Ordering::SeqCst);
+        cursor.load(Ordering::SeqCst)
     }
 
     fn unregister(&self) {
         self.waiters.fetch_sub(1, Ordering::AcqRel);
     }
 
-    fn wait(&self, expected: SequenceNumber, deadline: Instant) -> Result<(), WaitError> {
-        // Avoid entering the platform wait backend if a wake already advanced
-        // the sequence after the caller's post-registration recheck.
-        if self.sequence.load(Ordering::Acquire) != expected {
+    fn wait(
+        cursor: &AtomicUsize,
+        expected: SequenceNumber,
+        deadline: Instant,
+    ) -> Result<(), WaitError> {
+        // Avoid entering the platform wait backend if a publication already
+        // advanced the cursor after the caller's post-registration recheck.
+        if cursor.load(Ordering::SeqCst) != expected {
             return Ok(());
         }
 
-        imp::wait(&self.sequence, expected, deadline)
+        imp::wait(cursor, expected, deadline)
     }
 
-    /// Wakes up to `count` registered waiters.
-    pub(crate) fn wake(&self, count: usize) {
+    /// Wakes up to `count` waiters registered against `cursor`.
+    ///
+    /// Callers must publish `cursor` with a SeqCst (full-barrier) operation
+    /// before calling this (P1 in the module-level ordering argument). The
+    /// publication itself must be unconditional — only the wake syscall is
+    /// elided when no waiter is registered.
+    pub(crate) fn wake(&self, cursor: &AtomicUsize, count: usize) {
         debug_assert!(count > 0);
 
-        let waiters = self.waiters.load(Ordering::Acquire);
+        // P2 in the module-level ordering argument. A plain load keeps the
+        // hot publish path free of RMWs on a line consumers rarely write.
+        let waiters = self.waiters.load(Ordering::SeqCst);
         if waiters == 0 {
             return;
         }
 
-        self.sequence.fetch_add(1, Ordering::Release);
         let count = waiters.min(count.min(MAX_WAKE_COUNT as usize) as u32);
-        imp::wake(&self.sequence, count);
+        imp::wake(cursor, count);
     }
 }
 
@@ -112,18 +180,34 @@ const MAX_WAKE_COUNT: u32 = i32::MAX as u32;
 mod imp {
     use super::{remaining_until, SequenceNumber};
     use crate::error::WaitError;
-    use core::sync::atomic::AtomicU32;
+    use core::sync::atomic::AtomicUsize;
     use std::time::{Duration, Instant};
 
-    /// Blocks with Linux `FUTEX_WAIT` while `futex` still equals `expected`.
+    /// Returns the futex word: the low 32 bits of the 64-bit cursor, the
+    /// half that changes on every publication.
+    ///
+    /// Only the kernel reads through this pointer; never materialize an
+    /// `&AtomicU32` over the cursor in Rust code (see module docs).
+    fn futex_word(cursor: &AtomicUsize) -> *mut u32 {
+        let ptr = cursor.as_ptr().cast::<u32>();
+        // The low half lives at byte offset 4 on big-endian targets.
+        #[cfg(target_endian = "big")]
+        // SAFETY: in bounds; the low half of the 8-byte cursor is at offset 4.
+        let ptr = unsafe { ptr.add(1) };
+        ptr
+    }
+
+    /// Blocks with Linux `FUTEX_WAIT` while the low 32 bits of `cursor` still
+    /// equal the low 32 bits of `expected`.
     ///
     /// `Ok(())` means the caller should recheck its own condition; Linux can
     /// return success for ordinary wakes and for spurious wakes.
     pub(super) fn wait(
-        futex: &AtomicU32,
+        cursor: &AtomicUsize,
         expected: SequenceNumber,
         deadline: Instant,
     ) -> Result<(), WaitError> {
+        let expected = expected as u32;
         loop {
             let remaining = remaining_until(deadline)?;
 
@@ -131,13 +215,16 @@ mod imp {
             let timeout_ptr = &timeout_storage as *const libc::timespec;
 
             // SAFETY:
-            // - `futex.as_ptr()` is a valid pointer to a 4-byte aligned atomic.
+            // - `futex_word(cursor)` is a valid, 4-byte aligned pointer into a
+            //   live 64-bit atomic; the kernel only reads 32 bits through it.
             // - `timeout_ptr` points to a live `timespec`.
             // - `FUTEX_WAIT` only blocks if the value still equals `expected`.
+            // - No `FUTEX_PRIVATE_FLAG`: the cursor lives in cross-process
+            //   shared memory.
             let result = unsafe {
                 libc::syscall(
                     libc::SYS_futex,
-                    futex.as_ptr(),
+                    futex_word(cursor),
                     libc::FUTEX_WAIT,
                     expected as libc::c_int,
                     timeout_ptr,
@@ -161,15 +248,19 @@ mod imp {
         }
     }
 
-    /// Wakes waiters blocked in Linux `FUTEX_WAIT` on `futex`.
-    pub(super) fn wake(futex: &AtomicU32, count: u32) {
+    /// Wakes waiters blocked in Linux `FUTEX_WAIT` on `cursor`.
+    pub(super) fn wake(cursor: &AtomicUsize, count: u32) {
         debug_assert!(count <= libc::c_int::MAX as u32);
 
-        // SAFETY: `futex.as_ptr()` is a valid pointer to a 4-byte aligned atomic.
+        // SAFETY:
+        // - `futex_word(cursor)` is a valid, 4-byte aligned pointer into a
+        //   live 64-bit atomic.
+        // - No `FUTEX_PRIVATE_FLAG`: the cursor lives in cross-process
+        //   shared memory.
         let result = unsafe {
             libc::syscall(
                 libc::SYS_futex,
-                futex.as_ptr(),
+                futex_word(cursor),
                 libc::FUTEX_WAKE,
                 count as libc::c_int,
             )
@@ -204,20 +295,20 @@ mod imp {
     use crate::error::WaitError;
     use core::{
         hint::spin_loop,
-        sync::atomic::{AtomicU32, Ordering},
+        sync::atomic::{AtomicUsize, Ordering},
     };
     use std::time::Instant;
 
-    /// Busy-waits until `futex` no longer equals `expected` or timeout elapses.
+    /// Busy-waits until `cursor` no longer equals `expected` or timeout elapses.
     ///
     /// `Ok(())` means the caller should recheck its own condition.
     pub(super) fn wait(
-        futex: &AtomicU32,
+        cursor: &AtomicUsize,
         expected: SequenceNumber,
         deadline: Instant,
     ) -> Result<(), WaitError> {
         loop {
-            if futex.load(Ordering::Acquire) != expected {
+            if cursor.load(Ordering::SeqCst) != expected {
                 return Ok(());
             }
 
@@ -227,6 +318,6 @@ mod imp {
         }
     }
 
-    /// No-ops because spin waiters observe the shared sequence word directly.
-    pub(super) fn wake(_futex: &AtomicU32, _count: u32) {}
+    /// No-ops because spin waiters observe the shared cursor directly.
+    pub(super) fn wake(_cursor: &AtomicUsize, _count: u32) {}
 }

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -56,10 +56,9 @@ use std::time::{Duration, Instant};
 /// Snapshot of a queue's 64-bit publication cursor.
 type SequenceNumber = usize;
 
-fn deadline_from_timeout(timeout: Duration) -> Instant {
-    Instant::now()
-        .checked_add(timeout)
-        .expect("timeout duration overflowed Instant")
+/// `None` when the timeout overflows `Instant`: the wait is unbounded.
+fn deadline_from_timeout(timeout: Duration) -> Option<Instant> {
+    Instant::now().checked_add(timeout)
 }
 
 fn remaining_until(deadline: Instant) -> Result<Duration, WaitError> {
@@ -87,7 +86,8 @@ impl WaitState {
     /// `cursor` is the queue's publication cursor used as the futex word
     /// while sleeping; an advance of `cursor` must imply that `check` can
     /// observe new data. `spin_attempts` controls how many extra checks run
-    /// before registering as a waiter and entering the platform wait backend.
+    /// before registering as a waiter and entering the platform wait backend;
+    /// spinning happens only before the first sleep.
     pub(crate) fn wait_for<T>(
         &self,
         cursor: &AtomicUsize,
@@ -96,18 +96,21 @@ impl WaitState {
         mut check: impl FnMut() -> Option<T>,
     ) -> Result<T, WaitError> {
         let deadline = deadline_from_timeout(timeout);
-        loop {
+
+        if let Some(value) = check() {
+            return Ok(value);
+        }
+
+        // Spin only before the first sleep; once this thread has blocked it
+        // is on the slow path and goes straight back to waiting.
+        for _ in 0..spin_attempts {
+            spin_loop();
             if let Some(value) = check() {
                 return Ok(value);
             }
+        }
 
-            for _ in 0..spin_attempts {
-                spin_loop();
-                if let Some(value) = check() {
-                    return Ok(value);
-                }
-            }
-
+        loop {
             let snapshot = self.register(cursor);
             // Recheck after registering because a producer can publish after
             // the unregistered check and before this thread starts waiting.
@@ -119,10 +122,14 @@ impl WaitState {
 
             // Platform waits can return after a matching wake or a spurious
             // wake, so success only means the caller's condition should be
-            // checked again at the top of the loop.
+            // checked again.
             let wait_result = Self::wait(cursor, snapshot, deadline);
             self.unregister();
             wait_result?;
+
+            if let Some(value) = check() {
+                return Ok(value);
+            }
         }
     }
 
@@ -142,7 +149,7 @@ impl WaitState {
     fn wait(
         cursor: &AtomicUsize,
         expected: SequenceNumber,
-        deadline: Instant,
+        deadline: Option<Instant>,
     ) -> Result<(), WaitError> {
         // Avoid entering the platform wait backend if a publication already
         // advanced the cursor after the caller's post-registration recheck.
@@ -205,19 +212,24 @@ mod imp {
     pub(super) fn wait(
         cursor: &AtomicUsize,
         expected: SequenceNumber,
-        deadline: Instant,
+        deadline: Option<Instant>,
     ) -> Result<(), WaitError> {
         let expected = expected as u32;
         loop {
-            let remaining = remaining_until(deadline)?;
-
-            let timeout_storage = duration_to_timespec(remaining);
-            let timeout_ptr = &timeout_storage as *const libc::timespec;
+            // A null timeout makes `FUTEX_WAIT` block indefinitely.
+            let timeout_storage = match deadline {
+                Some(deadline) => Some(duration_to_timespec(remaining_until(deadline)?)),
+                None => None,
+            };
+            let timeout_ptr = timeout_storage
+                .as_ref()
+                .map_or(core::ptr::null(), |timeout| timeout as *const libc::timespec);
 
             // SAFETY:
             // - `futex_word(cursor)` is a valid, 4-byte aligned pointer into a
             //   live 64-bit atomic; the kernel only reads 32 bits through it.
-            // - `timeout_ptr` points to a live `timespec`.
+            // - `timeout_ptr` is null (block indefinitely) or points to a
+            //   live `timespec`.
             // - `FUTEX_WAIT` only blocks if the value still equals `expected`.
             // - No `FUTEX_PRIVATE_FLAG`: the cursor lives in cross-process
             //   shared memory.
@@ -276,9 +288,16 @@ mod imp {
     /// timeout format expected by futex.
     #[inline]
     const fn duration_to_timespec(duration: Duration) -> libc::timespec {
-        debug_assert!(duration.as_secs() <= libc::time_t::MAX as u64);
+        // Clamp instead of casting: a wrapped-negative `tv_sec` would make
+        // the kernel reject the timespec with EINVAL.
+        let secs = duration.as_secs();
+        let tv_sec = if secs > libc::time_t::MAX as u64 {
+            libc::time_t::MAX
+        } else {
+            secs as libc::time_t
+        };
         libc::timespec {
-            tv_sec: duration.as_secs() as libc::time_t,
+            tv_sec,
             tv_nsec: duration.subsec_nanos() as libc::c_long,
         }
     }
@@ -293,28 +312,28 @@ mod imp {
 mod imp {
     use super::{remaining_until, SequenceNumber};
     use crate::error::WaitError;
-    use core::{
-        hint::spin_loop,
-        sync::atomic::{AtomicUsize, Ordering},
-    };
+    use core::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Instant;
 
-    /// Busy-waits until `cursor` no longer equals `expected` or timeout elapses.
+    /// Polls until `cursor` no longer equals `expected` or timeout elapses,
+    /// yielding the thread between checks.
     ///
     /// `Ok(())` means the caller should recheck its own condition.
     pub(super) fn wait(
         cursor: &AtomicUsize,
         expected: SequenceNumber,
-        deadline: Instant,
+        deadline: Option<Instant>,
     ) -> Result<(), WaitError> {
         loop {
             if cursor.load(Ordering::SeqCst) != expected {
                 return Ok(());
             }
 
-            remaining_until(deadline)?;
+            if let Some(deadline) = deadline {
+                remaining_until(deadline)?;
+            }
 
-            spin_loop();
+            std::thread::yield_now();
         }
     }
 

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,55 +1,34 @@
 //! Futex-backed waiting for the shared-memory queues.
 //!
-//! The futex word is the queue's own 64-bit publication cursor (the write
-//! cursor for spsc, the producer publication cursor for mpmc) rather than a
-//! dedicated sequence word. Every publish advances the cursor
-//! unconditionally, so there is no conditional "bump the sequence only if
-//! waiters are registered" step that a racing waiter could miss.
+//! The futex word is the queue's own 64-bit publication cursor: every publish
+//! advances it, so there is no separate sequence word a waiter could miss.
 //!
-//! # Lost-wake freedom
+//! # Why no wake is lost
 //!
-//! The producer and consumer run a Dekker-style store/load protocol, which is
-//! only correct if all four accesses participate in the SeqCst total order:
+//! The producer publishes the cursor (Release), then in [`WaitState::wake`]
+//! issues a SeqCst fence and loads `waiters`, skipping the wake syscall if
+//! it is zero. A waiter increments `waiters`, issues a SeqCst fence (in
+//! `register`), then rechecks for data before sleeping. SeqCst fences are
+//! totally ordered, and a load after the later fence must see a store made
+//! before the earlier one. So either the producer's load sees the waiter
+//! and wakes it, or the waiter's recheck sees the publication (or
+//! `FUTEX_WAIT` bounces with `EAGAIN`) and it never sleeps. Without the
+//! fences both loads can be stale and a wake can be lost.
 //!
-//! - Producer (at each visibility point): publish the cursor with a SeqCst
-//!   store (P1), then load `waiters` with SeqCst (P2); wake if non-zero.
-//! - Consumer (in [`WaitState::wait_for`]): increment `waiters` with a SeqCst
-//!   RMW (C1), then snapshot the cursor with a SeqCst load and recheck the
-//!   condition (C2); sleep only if the condition still fails.
+//! # The futex word
 //!
-//! In the SeqCst total order, either C1 precedes P2 — then P2 observes
-//! `waiters >= 1` and the producer issues a wake — or P2 precedes C1, hence
-//! P1 precedes C2, and C2 must observe the published cursor (a SeqCst load
-//! ordered after a SeqCst store to the same location cannot read an older
-//! value): the consumer's recheck sees the publication and never sleeps, or
-//! `FUTEX_WAIT`'s in-kernel compare fails with `EAGAIN`. At least one arm
-//! always holds, so the lost-wake cycle (producer skips the wake *and* the
-//! consumer sleeps past the publication) is impossible. Acquire/Release is
-//! not enough here: it permits both P2 and C2 to read stale values
-//! (StoreLoad reordering), which is exactly the lost-wake interleaving.
-//!
-//! # Mixed-width access to the cursor
-//!
-//! All userspace accesses to the cursor are full-width 64-bit atomics; only
-//! the kernel's `FUTEX_WAIT` compare reads 32 bits. The futex address is the
-//! low half of the cursor — the half that changes on every publication — at
-//! byte offset 0 on little-endian targets and 4 on big-endian targets. It is
-//! 4-byte aligned either way, and an aligned 4-byte read cannot tear against
-//! aligned 64-bit atomic writes. Never materialize an `&AtomicU32` into the
-//! cursor in Rust code — only a raw pointer passed to the syscall.
-//!
-//! ABA caveat: if the cursor advances by an exact multiple of 2^32 between
-//! the consumer's snapshot and the kernel's compare, the wait sleeps despite
-//! progress. This is bounded by the caller's timeout and astronomically
-//! unlikely in practice.
-//!
-//! The futex syscalls deliberately do not use `FUTEX_PRIVATE_FLAG`: the
-//! queues live in shared memory mapped by multiple processes.
+//! Userspace accesses the cursor only as a 64-bit atomic; the kernel's
+//! 32-bit `FUTEX_WAIT` compare reads its low half (byte offset 0 on
+//! little-endian, 4 on big-endian), which is 4-byte aligned and cannot tear.
+//! Never materialize an `&AtomicU32` into the cursor in Rust code — only a
+//! raw pointer passed to the syscall. If the cursor advances by an exact
+//! multiple of 2^32 between snapshot and compare the wait oversleeps; that
+//! is bounded by the timeout and astronomically unlikely.
 
 use crate::{error::WaitError, CacheAlignedAtomicU32};
 use core::{
     hint::spin_loop,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{fence, AtomicUsize, Ordering},
 };
 use std::time::{Duration, Instant};
 
@@ -113,8 +92,9 @@ impl WaitState {
         loop {
             let snapshot = self.register(cursor);
             // Recheck after registering because a producer can publish after
-            // the unregistered check and before this thread starts waiting.
-            // This is C2 in the module-level ordering argument.
+            // the unregistered check and before this thread starts waiting;
+            // the fence in `register` makes this recheck reliable (see
+            // module docs).
             if let Some(value) = check() {
                 self.unregister();
                 return Ok(value);
@@ -135,11 +115,13 @@ impl WaitState {
 
     /// Registers this thread as a waiter and snapshots the cursor.
     ///
-    /// The SeqCst RMW (C1) followed by the SeqCst cursor load are the
-    /// consumer half of the module-level ordering argument.
+    /// Increment-then-fence is the waiter half of the lost-wake protocol
+    /// (see module docs); the caller must recheck for data after this call,
+    /// before sleeping.
     fn register(&self, cursor: &AtomicUsize) -> SequenceNumber {
-        self.waiters.fetch_add(1, Ordering::SeqCst);
-        cursor.load(Ordering::SeqCst)
+        self.waiters.fetch_add(1, Ordering::Relaxed);
+        fence(Ordering::SeqCst);
+        cursor.load(Ordering::Acquire)
     }
 
     fn unregister(&self) {
@@ -153,7 +135,7 @@ impl WaitState {
     ) -> Result<(), WaitError> {
         // Avoid entering the platform wait backend if a publication already
         // advanced the cursor after the caller's post-registration recheck.
-        if cursor.load(Ordering::SeqCst) != expected {
+        if cursor.load(Ordering::Acquire) != expected {
             return Ok(());
         }
 
@@ -162,16 +144,19 @@ impl WaitState {
 
     /// Wakes up to `count` waiters registered against `cursor`.
     ///
-    /// Callers must publish `cursor` with a SeqCst (full-barrier) operation
-    /// before calling this (P1 in the module-level ordering argument). The
-    /// publication itself must be unconditional — only the wake syscall is
-    /// elided when no waiter is registered.
+    /// Callers must publish `cursor` with (at least) a Release store before
+    /// calling this; the fence here pairs that store with a registering
+    /// waiter (see module docs). The publication itself must be
+    /// unconditional — only the wake syscall is elided when no waiter is
+    /// registered.
     pub(crate) fn wake(&self, cursor: &AtomicUsize, count: usize) {
         debug_assert!(count > 0);
 
-        // P2 in the module-level ordering argument. A plain load keeps the
-        // hot publish path free of RMWs on a line consumers rarely write.
-        let waiters = self.waiters.load(Ordering::SeqCst);
+        // Fence-then-load is the producer half of the lost-wake protocol.
+        // A plain load keeps the hot publish path free of RMWs on a line
+        // consumers rarely write.
+        fence(Ordering::SeqCst);
+        let waiters = self.waiters.load(Ordering::Relaxed);
         if waiters == 0 {
             return;
         }
@@ -223,7 +208,9 @@ mod imp {
             };
             let timeout_ptr = timeout_storage
                 .as_ref()
-                .map_or(core::ptr::null(), |timeout| timeout as *const libc::timespec);
+                .map_or(core::ptr::null(), |timeout| {
+                    timeout as *const libc::timespec
+                });
 
             // SAFETY:
             // - `futex_word(cursor)` is a valid, 4-byte aligned pointer into a
@@ -325,7 +312,7 @@ mod imp {
         deadline: Option<Instant>,
     ) -> Result<(), WaitError> {
         loop {
-            if cursor.load(Ordering::SeqCst) != expected {
+            if cursor.load(Ordering::Acquire) != expected {
                 return Ok(());
             }
 

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -1,0 +1,223 @@
+fn deadline_from_timeout(timeout: std::time::Duration) -> std::time::Instant {
+    std::time::Instant::now()
+        .checked_add(timeout)
+        .expect("timeout duration overflowed Instant")
+}
+
+fn remaining_until(
+    deadline: std::time::Instant,
+) -> Result<std::time::Duration, crate::error::WaitError> {
+    deadline
+        .checked_duration_since(std::time::Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or(crate::error::WaitError::Timeout)
+}
+
+#[repr(C)]
+pub(crate) struct WaitState {
+    /// Sequence word observed by waiters and advanced by wakers.
+    sequence: crate::CacheAlignedAtomicU32,
+    /// Approximate count of waiters registered against `sequence`.
+    waiters: crate::CacheAlignedAtomicU32,
+}
+
+impl WaitState {
+    /// Initializes this wait state inside a newly created shared-memory header.
+    pub(crate) fn initialize(&self) {
+        self.sequence
+            .store(0, core::sync::atomic::Ordering::Release);
+        self.waiters.store(0, core::sync::atomic::Ordering::Release);
+    }
+
+    /// Runs `check` until it returns a value or `timeout` elapses.
+    ///
+    /// `spin_attempts` controls how many extra checks run before registering as
+    /// a waiter and entering the platform wait backend.
+    pub(crate) fn wait_for<T>(
+        &self,
+        timeout: std::time::Duration,
+        spin_attempts: usize,
+        mut check: impl FnMut() -> Option<T>,
+    ) -> Result<T, crate::error::WaitError> {
+        let deadline = deadline_from_timeout(timeout);
+        loop {
+            if let Some(value) = check() {
+                return Ok(value);
+            }
+
+            for _ in 0..spin_attempts {
+                core::hint::spin_loop();
+                if let Some(value) = check() {
+                    return Ok(value);
+                }
+            }
+
+            let sequence = self.register();
+            // Recheck after registering because a producer can publish after
+            // the unregistered check and before this thread starts waiting.
+            if let Some(value) = check() {
+                self.unregister();
+                return Ok(value);
+            }
+
+            // Platform waits can return after a matching wake or a spurious
+            // wake, so success only means the caller's condition should be
+            // checked again at the top of the loop.
+            let wait_result = self.wait(sequence, deadline);
+            self.unregister();
+            wait_result?;
+        }
+    }
+
+    fn register(&self) -> u32 {
+        self.waiters
+            .fetch_add(1, core::sync::atomic::Ordering::AcqRel);
+        self.sequence.load(core::sync::atomic::Ordering::Acquire)
+    }
+
+    fn unregister(&self) {
+        self.waiters
+            .fetch_sub(1, core::sync::atomic::Ordering::AcqRel);
+    }
+
+    fn wait(
+        &self,
+        expected: u32,
+        deadline: std::time::Instant,
+    ) -> Result<(), crate::error::WaitError> {
+        // Avoid entering the platform wait backend if a wake already advanced
+        // the sequence after the caller's post-registration recheck.
+        if self.sequence.load(core::sync::atomic::Ordering::Acquire) != expected {
+            return Ok(());
+        }
+
+        imp::wait(&self.sequence, expected, deadline)
+    }
+
+    /// Wakes up to `count` registered waiters.
+    pub(crate) fn wake(&self, count: usize) {
+        debug_assert!(count > 0);
+
+        let waiters = self.waiters.load(core::sync::atomic::Ordering::Acquire);
+        if waiters == 0 {
+            return;
+        }
+
+        self.sequence
+            .fetch_add(1, core::sync::atomic::Ordering::Release);
+        let count = waiters.min(count.min(MAX_WAKE_COUNT as usize) as u32);
+        imp::wake(&self.sequence, count);
+    }
+}
+
+const MAX_WAKE_COUNT: u32 = i32::MAX as u32;
+
+#[cfg(target_os = "linux")]
+mod imp {
+    /// Blocks with Linux `FUTEX_WAIT` while `futex` still equals `expected`.
+    ///
+    /// `Ok(())` means the caller should recheck its own condition; Linux can
+    /// return success for ordinary wakes and for spurious wakes.
+    pub(super) fn wait(
+        futex: &core::sync::atomic::AtomicU32,
+        expected: u32,
+        deadline: std::time::Instant,
+    ) -> Result<(), crate::error::WaitError> {
+        loop {
+            let remaining = super::remaining_until(deadline)?;
+
+            let timeout_storage = duration_to_timespec(remaining);
+            let timeout_ptr = &timeout_storage as *const libc::timespec;
+
+            // SAFETY:
+            // - `futex.as_ptr()` is a valid pointer to a 4-byte aligned atomic.
+            // - `timeout_ptr` points to a live `timespec`.
+            // - `FUTEX_WAIT` only blocks if the value still equals `expected`.
+            let result = unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    futex.as_ptr(),
+                    libc::FUTEX_WAIT,
+                    expected as libc::c_int,
+                    timeout_ptr,
+                )
+            };
+
+            if result == 0 {
+                return Ok(());
+            }
+
+            if result != -1 {
+                panic!("unexpected futex wait result: {result}");
+            }
+
+            match errno() {
+                libc::EAGAIN => return Ok(()),
+                libc::EINTR => continue,
+                libc::ETIMEDOUT => return Err(crate::error::WaitError::Timeout),
+                err => panic!("unexpected futex wait error: errno={err}"),
+            }
+        }
+    }
+
+    /// Wakes waiters blocked in Linux `FUTEX_WAIT` on `futex`.
+    pub(super) fn wake(futex: &core::sync::atomic::AtomicU32, count: u32) {
+        debug_assert!(count <= libc::c_int::MAX as u32);
+
+        // SAFETY: `futex.as_ptr()` is a valid pointer to a 4-byte aligned atomic.
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_futex,
+                futex.as_ptr(),
+                libc::FUTEX_WAKE,
+                count as libc::c_int,
+            )
+        };
+        debug_assert!(
+            result >= 0,
+            "unexpected futex wake error: errno={}",
+            errno()
+        );
+    }
+
+    /// Converts a [`std::time::Duration`] to the relative [`libc::timespec`]
+    /// timeout format expected by futex.
+    #[inline]
+    const fn duration_to_timespec(duration: std::time::Duration) -> libc::timespec {
+        debug_assert!(duration.as_secs() <= libc::time_t::MAX as u64);
+        libc::timespec {
+            tv_sec: duration.as_secs() as libc::time_t,
+            tv_nsec: duration.subsec_nanos() as libc::c_long,
+        }
+    }
+
+    fn errno() -> i32 {
+        // SAFETY: `__errno_location` returns this thread's errno location on Linux.
+        unsafe { *libc::__errno_location() }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    /// Busy-waits until `futex` no longer equals `expected` or timeout elapses.
+    ///
+    /// `Ok(())` means the caller should recheck its own condition.
+    pub(super) fn wait(
+        futex: &core::sync::atomic::AtomicU32,
+        expected: u32,
+        deadline: std::time::Instant,
+    ) -> Result<(), crate::error::WaitError> {
+        loop {
+            if futex.load(core::sync::atomic::Ordering::Acquire) != expected {
+                return Ok(());
+            }
+
+            super::remaining_until(deadline)?;
+
+            core::hint::spin_loop();
+        }
+    }
+
+    /// No-ops because spin waiters observe the shared sequence word directly.
+    pub(super) fn wake(_futex: &core::sync::atomic::AtomicU32, _count: u32) {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use core::sync::atomic::{AtomicU32, AtomicUsize};
+use core::sync::atomic::AtomicUsize;
 
 // NB: To simplify casting we only support 64bit or wider systems.
 const _: () = assert!(size_of::<usize>() >= size_of::<u64>());
@@ -32,21 +32,6 @@ struct CacheAlignedAtomicSize {
 
 impl core::ops::Deref for CacheAlignedAtomicSize {
     type Target = AtomicUsize;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-/// `AtomicU32` with 64-byte alignment for wait state.
-#[derive(Default)]
-#[repr(C, align(64))]
-struct CacheAlignedAtomicU32 {
-    inner: AtomicU32,
-}
-
-impl core::ops::Deref for CacheAlignedAtomicU32 {
-    type Target = AtomicU32;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::{AtomicU32, AtomicUsize};
 
 // NB: To simplify casting we only support 64bit or wider systems.
 const _: () = assert!(size_of::<usize>() >= size_of::<u64>());
 
 pub mod error;
+mod futex;
 pub mod mpmc;
 mod shmem;
 pub mod spsc;
@@ -31,6 +32,21 @@ struct CacheAlignedAtomicSize {
 
 impl core::ops::Deref for CacheAlignedAtomicSize {
     type Target = AtomicUsize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// `AtomicU32` with 64-byte alignment for wait state.
+#[derive(Default)]
+#[repr(C, align(64))]
+struct CacheAlignedAtomicU32 {
+    inner: AtomicU32,
+}
+
+impl core::ops::Deref for CacheAlignedAtomicU32 {
+    type Target = AtomicU32;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::{Error, WaitError},
-    futex::WaitState,
+    futex::Waiters,
     normalized_capacity,
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
@@ -336,7 +336,7 @@ impl<T> Consumer<T> {
         // SAFETY: `self.queue.header` points to this consumer's live shared
         // queue header.
         let header = unsafe { self.queue.header.as_ref() };
-        header.wait_state.wait_for(
+        header.waiters.wait_for(
             &header.producer_publication,
             timeout,
             CONSUMER_WAIT_SPIN_ATTEMPTS,
@@ -627,8 +627,8 @@ struct SharedQueueHeader {
     /// Consumers advance this in-order after dropping/reading claimed slots.
     /// Producers use it to determine how much free space is available.
     consumer_release: CacheAlignedAtomicSize,
-    /// Wait state used for consumer wait/wake coordination.
-    wait_state: WaitState,
+    /// Consumer wait/wake coordination.
+    waiters: Waiters,
 }
 
 impl SharedQueueHeader {
@@ -723,7 +723,7 @@ impl SharedQueueHeader {
         header.producer_publication.store(0, Ordering::Release);
         header.consumer_reservation.store(0, Ordering::Release);
         header.consumer_release.store(0, Ordering::Release);
-        header.wait_state.initialize();
+        header.waiters.initialize();
         header.buffer_mask = u32::try_from(buffer_size_in_items - 1).unwrap();
         header.version = VERSION;
         header.magic.store(MAGIC, Ordering::Release);
@@ -776,7 +776,7 @@ impl SharedQueueHeader {
         header
             .producer_publication
             .store(start.wrapping_add(count), Ordering::Release);
-        header.wait_state.wake(&header.producer_publication, count);
+        header.waiters.wake(&header.producer_publication, count);
     }
 
     /// # Safety

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -770,12 +770,12 @@ impl SharedQueueHeader {
         while header.producer_publication.load(Ordering::Acquire) != start {
             core::hint::spin_loop();
         }
-        // SeqCst publication followed by the SeqCst waiters load inside
-        // `wake` forms the producer half of the lost-wake-free protocol; see
-        // the `futex` module docs. Release is not sufficient here.
+        // Release publication; `wake` supplies the fence that pairs it with
+        // a registering waiter and must be called unconditionally; see the
+        // `futex` module docs.
         header
             .producer_publication
-            .store(start.wrapping_add(count), Ordering::SeqCst);
+            .store(start.wrapping_add(count), Ordering::Release);
         header.wait_state.wake(&header.producer_publication, count);
     }
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -336,9 +336,12 @@ impl<T> Consumer<T> {
         // SAFETY: `self.queue.header` points to this consumer's live shared
         // queue header.
         let header = unsafe { self.queue.header.as_ref() };
-        header
-            .wait_state
-            .wait_for(timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, check)
+        header.wait_state.wait_for(
+            &header.producer_publication,
+            timeout,
+            CONSUMER_WAIT_SPIN_ATTEMPTS,
+            check,
+        )
     }
 
     /// Makes reserved-but-not-released reads left behind by a previous
@@ -767,10 +770,13 @@ impl SharedQueueHeader {
         while header.producer_publication.load(Ordering::Acquire) != start {
             core::hint::spin_loop();
         }
+        // SeqCst publication followed by the SeqCst waiters load inside
+        // `wake` forms the producer half of the lost-wake-free protocol; see
+        // the `futex` module docs. Release is not sufficient here.
         header
             .producer_publication
-            .store(start.wrapping_add(count), Ordering::Release);
-        header.wait_state.wake(count);
+            .store(start.wrapping_add(count), Ordering::SeqCst);
+        header.wait_state.wake(&header.producer_publication, count);
     }
 
     /// # Safety

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1,15 +1,23 @@
 //! DPDK-style bounded MPMC ring queue
 
-use crate::{error::Error, normalized_capacity, shmem::Region, CacheAlignedAtomicSize, VERSION};
+use crate::{
+    error::{Error, WaitError},
+    futex::WaitState,
+    normalized_capacity,
+    shmem::Region,
+    CacheAlignedAtomicSize, VERSION,
+};
 use core::{marker::PhantomData, ptr::NonNull, sync::atomic::Ordering};
 use std::{
     fs::File,
     num::NonZeroUsize,
     sync::{atomic::AtomicU64, Arc},
+    time::Duration,
 };
 
 /// Unique identifier for MPMC queue in shared memory.
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqmpmc");
+const CONSUMER_WAIT_SPIN_ATTEMPTS: usize = 2048;
 
 pub struct Producer<T> {
     queue: SharedQueue<T>,
@@ -255,6 +263,12 @@ impl<T> Consumer<T> {
         self.reserve_read().map(ReadGuard::read)
     }
 
+    /// Attempts to read a value from the queue, waiting up to `timeout` for
+    /// a producer to publish data.
+    pub fn read_timeout(&self, timeout: Duration) -> Result<T, WaitError> {
+        self.reserve_read_timeout(timeout).map(ReadGuard::read)
+    }
+
     /// Attempts to reserve a value from the queue, returning a guard.
     /// The slot is released back to producers when the guard is dropped.
     ///
@@ -269,6 +283,12 @@ impl<T> Consumer<T> {
             start: position,
             _marker: PhantomData,
         })
+    }
+
+    /// Attempts to reserve a value from the queue, waiting up to `timeout` for
+    /// a producer to publish data.
+    pub fn reserve_read_timeout(&self, timeout: Duration) -> Result<ReadGuard<'_, T>, WaitError> {
+        self.wait_for_read(timeout, || self.reserve_read())
     }
 
     /// Attempts to reserve up to `max` values from the queue.
@@ -289,6 +309,36 @@ impl<T> Consumer<T> {
             buffer_mask: self.queue.buffer_mask,
             _marker: PhantomData,
         })
+    }
+
+    /// Attempts to reserve up to `max` values from the queue, waiting up to
+    /// `timeout` for a producer to publish data.
+    ///
+    /// Returns `Ok(None)` immediately when `max == 0`.
+    pub fn reserve_read_batch_timeout(
+        &self,
+        max: usize,
+        timeout: Duration,
+    ) -> Result<Option<ReadBatch<'_, T>>, WaitError> {
+        if max == 0 {
+            return Ok(None);
+        }
+
+        self.wait_for_read(timeout, || self.reserve_read_batch(max))
+            .map(Some)
+    }
+
+    fn wait_for_read<R>(
+        &self,
+        timeout: Duration,
+        check: impl FnMut() -> Option<R>,
+    ) -> Result<R, WaitError> {
+        // SAFETY: `self.queue.header` points to this consumer's live shared
+        // queue header.
+        let header = unsafe { self.queue.header.as_ref() };
+        header
+            .wait_state
+            .wait_for(timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, check)
     }
 
     /// Makes reserved-but-not-released reads left behind by a previous
@@ -574,6 +624,8 @@ struct SharedQueueHeader {
     /// Consumers advance this in-order after dropping/reading claimed slots.
     /// Producers use it to determine how much free space is available.
     consumer_release: CacheAlignedAtomicSize,
+    /// Wait state used for consumer wait/wake coordination.
+    wait_state: WaitState,
 }
 
 impl SharedQueueHeader {
@@ -668,6 +720,7 @@ impl SharedQueueHeader {
         header.producer_publication.store(0, Ordering::Release);
         header.consumer_reservation.store(0, Ordering::Release);
         header.consumer_release.store(0, Ordering::Release);
+        header.wait_state.initialize();
         header.buffer_mask = u32::try_from(buffer_size_in_items - 1).unwrap();
         header.version = VERSION;
         header.magic.store(MAGIC, Ordering::Release);
@@ -717,6 +770,7 @@ impl SharedQueueHeader {
         header
             .producer_publication
             .store(start.wrapping_add(count), Ordering::Release);
+        header.wait_state.wake(count);
     }
 
     /// # Safety
@@ -952,6 +1006,13 @@ mod tests {
         (file, producer, consumer)
     }
 
+    fn expect_wait_ok<T>(result: Result<T, WaitError>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(WaitError::Timeout) => panic!("wait timed out"),
+        }
+    }
+
     #[test]
     fn test_producer_consumer() {
         let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
@@ -967,6 +1028,61 @@ mod tests {
             assert_eq!(consumer.try_read(), Some(i as Item));
         }
         assert_eq!(consumer.try_read(), None);
+    }
+
+    #[test]
+    fn test_read_timeout_observes_publication() {
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
+
+        assert!(matches!(
+            consumer.read_timeout(Duration::ZERO),
+            Err(WaitError::Timeout)
+        ));
+
+        producer.try_write(42).unwrap();
+
+        assert_eq!(expect_wait_ok(consumer.read_timeout(Duration::ZERO)), 42);
+        assert_eq!(consumer.try_read(), None);
+    }
+
+    #[test]
+    fn test_reserve_read_timeout_observes_publication() {
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
+
+        assert!(matches!(
+            consumer.reserve_read_timeout(Duration::ZERO),
+            Err(WaitError::Timeout)
+        ));
+
+        producer.try_write(7).unwrap();
+
+        let guard = expect_wait_ok(consumer.reserve_read_timeout(Duration::ZERO));
+        assert_eq!(*guard.as_ref(), 7);
+    }
+
+    #[test]
+    fn test_reserve_read_batch_timeout_observes_publication() {
+        let (_file, producer, consumer) = create_test_queue::<Item>(BUFFER_SIZE);
+
+        assert!(matches!(
+            consumer.reserve_read_batch_timeout(4, Duration::ZERO),
+            Err(WaitError::Timeout)
+        ));
+        assert!(matches!(
+            consumer.reserve_read_batch_timeout(0, Duration::ZERO),
+            Ok(None)
+        ));
+
+        assert!(producer.try_write_slice(&[1, 2, 3]));
+
+        let batch = match expect_wait_ok(consumer.reserve_read_batch_timeout(4, Duration::ZERO)) {
+            Some(batch) => batch,
+            None => panic!("batch should be returned"),
+        };
+        assert_eq!(batch.len(), 3);
+        for (index, expected) in [1, 2, 3].into_iter().enumerate() {
+            assert_eq!(unsafe { batch.read(index) }, expected);
+        }
     }
 
     #[test]

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -17,7 +17,6 @@ use std::{
 
 /// Unique identifier for MPMC queue in shared memory.
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqmpmc");
-const CONSUMER_WAIT_SPIN_ATTEMPTS: usize = 2048;
 
 pub struct Producer<T> {
     queue: SharedQueue<T>,
@@ -336,12 +335,9 @@ impl<T> Consumer<T> {
         // SAFETY: `self.queue.header` points to this consumer's live shared
         // queue header.
         let header = unsafe { self.queue.header.as_ref() };
-        header.waiters.wait_for(
-            &header.producer_publication,
-            timeout,
-            CONSUMER_WAIT_SPIN_ATTEMPTS,
-            check,
-        )
+        header
+            .waiters
+            .wait_for(&header.producer_publication, timeout, check)
     }
 
     /// Makes reserved-but-not-released reads left behind by a previous

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{Error, WaitError},
-    futex::WaitState,
+    futex::Waiters,
     normalized_capacity,
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
@@ -177,7 +177,7 @@ impl<T> Producer<T> {
         header
             .write
             .store(self.queue.cached_write, Ordering::Release);
-        header.wait_state.wake(&header.write, 1);
+        header.waiters.wake(&header.write, 1);
     }
 
     /// Synchronize the producer's cached read position with the queue's read
@@ -324,7 +324,7 @@ impl<T> Consumer<T> {
         // SAFETY: `header` points to this consumer's live shared queue header.
         let header = unsafe { header.as_ref() };
         header
-            .wait_state
+            .waiters
             .wait_for(&header.write, timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, || {
                 self.queue.load_write();
                 if !self.queue.is_empty() {
@@ -463,8 +463,8 @@ struct SharedQueueHeader {
     // Hot cache lines.
     write: CacheAlignedAtomicSize,
     read: CacheAlignedAtomicSize,
-    /// Wait state used only for consumer wait/wake coordination.
-    wait_state: WaitState,
+    /// Consumer wait/wake coordination.
+    waiters: Waiters,
 }
 
 impl SharedQueueHeader {
@@ -558,7 +558,7 @@ impl SharedQueueHeader {
         let header = unsafe { header.as_mut() };
         header.write.store(0, Ordering::Release);
         header.read.store(0, Ordering::Release);
-        header.wait_state.initialize();
+        header.waiters.initialize();
         header.buffer_mask = u32::try_from(buffer_size_in_items - 1).unwrap();
         header.version = VERSION;
         header.magic.store(MAGIC, Ordering::Release);

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -795,6 +795,21 @@ mod tests {
     }
 
     #[test]
+    fn test_wait_readable_max_timeout_does_not_panic() {
+        let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
+
+        producer.try_write(1).unwrap();
+        producer.commit();
+
+        // `Duration::MAX` overflows `Instant`; the deadline must saturate
+        // instead of panicking. Data is already committed so this returns
+        // immediately.
+        consumer
+            .wait_readable_timeout(Duration::MAX)
+            .expect("wait failed");
+    }
+
+    #[test]
     fn test_wait_readable_timeout_cleans_waiter() {
         let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -1,4 +1,10 @@
-use crate::{error::Error, normalized_capacity, shmem::Region, CacheAlignedAtomicSize, VERSION};
+use crate::{
+    error::{Error, WaitError},
+    futex::WaitState,
+    normalized_capacity,
+    shmem::Region,
+    CacheAlignedAtomicSize, VERSION,
+};
 use core::ptr::NonNull;
 use std::{
     fs::File,
@@ -7,10 +13,12 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
+    time::Duration,
 };
 
 /// Unique identifier for SPSC queue in shared memory.
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqspsc");
+const CONSUMER_WAIT_SPIN_ATTEMPTS: usize = 2048;
 
 /// Calculates the minimum file size required for a queue with given capacity.
 /// Note that file size MAY need to be increased beyond this to account for
@@ -162,10 +170,11 @@ impl<T> Producer<T> {
 
     /// Commits the reserved position, making it visible to the consumer.
     pub fn commit(&self) {
-        self.queue
-            .header()
+        let header = self.queue.header();
+        header
             .write
             .store(self.queue.cached_write, Ordering::Release);
+        header.wait_state.wake(1);
     }
 
     /// Synchronize the producer's cached read position with the queue's read
@@ -305,6 +314,35 @@ impl<T> Consumer<T> {
     pub fn sync(&mut self) {
         self.queue.load_write();
     }
+
+    /// Blocks until at least one committed item is readable or `timeout` elapses.
+    pub fn wait_readable_timeout(&mut self, timeout: Duration) -> Result<(), WaitError> {
+        let header = self.queue.header;
+        // SAFETY: `header` points to this consumer's live shared queue header.
+        let wait_state = &unsafe { header.as_ref() }.wait_state;
+        wait_state.wait_for(timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, || {
+            self.queue.load_write();
+            if !self.queue.is_empty() {
+                Some(())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Blocks until a committed item can be reserved for reading or `timeout`
+    /// elapses.
+    ///
+    /// The caller must still process all returned pointers and call
+    /// [`Self::finalize`] to release consumed capacity back to the producer.
+    pub fn read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError> {
+        loop {
+            if let Some(ptr) = self.try_read_ptr() {
+                return Ok(ptr);
+            }
+            self.wait_readable_timeout(timeout)?;
+        }
+    }
 }
 
 unsafe impl<T: Send> Send for Consumer<T> {}
@@ -420,6 +458,8 @@ struct SharedQueueHeader {
     // Hot cache lines.
     write: CacheAlignedAtomicSize,
     read: CacheAlignedAtomicSize,
+    /// Wait state used only for consumer wait/wake coordination.
+    wait_state: WaitState,
 }
 
 impl SharedQueueHeader {
@@ -513,6 +553,7 @@ impl SharedQueueHeader {
         let header = unsafe { header.as_mut() };
         header.write.store(0, Ordering::Release);
         header.read.store(0, Ordering::Release);
+        header.wait_state.initialize();
         header.buffer_mask = u32::try_from(buffer_size_in_items - 1).unwrap();
         header.version = VERSION;
         header.magic.store(MAGIC, Ordering::Release);
@@ -557,7 +598,7 @@ impl SharedQueueHeader {
 mod tests {
     use super::*;
     use crate::shmem::create_temp_shmem_file;
-    use std::sync::atomic::AtomicU64;
+    use std::{sync::atomic::AtomicU64, time::Duration};
 
     fn create_test_queue<T>(file_size: usize) -> (File, Producer<T>, Consumer<T>) {
         let file = create_temp_shmem_file().unwrap();
@@ -722,6 +763,55 @@ mod tests {
         consumer.sync();
         let val = consumer.try_read().expect("read failed");
         assert_eq!(*val, 55);
+        consumer.finalize();
+    }
+
+    #[test]
+    fn test_read_ptr_timeout_observes_commit() {
+        let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
+
+        let spot = unsafe { producer.reserve() }.expect("reserve failed");
+        unsafe { spot.write(42) };
+
+        assert!(matches!(
+            consumer.wait_readable_timeout(Duration::ZERO),
+            Err(WaitError::Timeout)
+        ));
+
+        producer.commit();
+
+        let ptr = match consumer.read_ptr_timeout(Duration::ZERO) {
+            Ok(ptr) => ptr,
+            Err(WaitError::Timeout) => panic!("read timed out after commit"),
+        };
+        // SAFETY: `ptr` points at a readable `u64`; the value is Copy.
+        assert_eq!(unsafe { *ptr.as_ptr() }, 42);
+        consumer.finalize();
+    }
+
+    #[test]
+    fn test_wait_readable_timeout_cleans_waiter() {
+        let (mut producer, mut consumer) = pair::<u64>(64).expect("pair failed");
+
+        assert!(matches!(
+            consumer.wait_readable_timeout(Duration::from_millis(1)),
+            Err(WaitError::Timeout)
+        ));
+
+        assert!(matches!(
+            consumer.read_ptr_timeout(Duration::from_millis(1)),
+            Err(WaitError::Timeout)
+        ));
+
+        producer.try_write(9).unwrap();
+        producer.commit();
+
+        let ptr = match consumer.read_ptr_timeout(Duration::ZERO) {
+            Ok(ptr) => ptr,
+            Err(WaitError::Timeout) => panic!("read timed out after commit"),
+        };
+        // SAFETY: `ptr` points at a readable `u64`; the value is Copy.
+        assert_eq!(unsafe { *ptr.as_ptr() }, 9);
         consumer.finalize();
     }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -171,10 +171,13 @@ impl<T> Producer<T> {
     /// Commits the reserved position, making it visible to the consumer.
     pub fn commit(&self) {
         let header = self.queue.header();
+        // SeqCst publication followed by the SeqCst waiters load inside
+        // `wake` forms the producer half of the lost-wake-free protocol; see
+        // the `futex` module docs. Release is not sufficient here.
         header
             .write
-            .store(self.queue.cached_write, Ordering::Release);
-        header.wait_state.wake(1);
+            .store(self.queue.cached_write, Ordering::SeqCst);
+        header.wait_state.wake(&header.write, 1);
     }
 
     /// Synchronize the producer's cached read position with the queue's read
@@ -319,15 +322,17 @@ impl<T> Consumer<T> {
     pub fn wait_readable_timeout(&mut self, timeout: Duration) -> Result<(), WaitError> {
         let header = self.queue.header;
         // SAFETY: `header` points to this consumer's live shared queue header.
-        let wait_state = &unsafe { header.as_ref() }.wait_state;
-        wait_state.wait_for(timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, || {
-            self.queue.load_write();
-            if !self.queue.is_empty() {
-                Some(())
-            } else {
-                None
-            }
-        })
+        let header = unsafe { header.as_ref() };
+        header
+            .wait_state
+            .wait_for(&header.write, timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, || {
+                self.queue.load_write();
+                if !self.queue.is_empty() {
+                    Some(())
+                } else {
+                    None
+                }
+            })
     }
 
     /// Blocks until a committed item can be reserved for reading or `timeout`

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -171,12 +171,12 @@ impl<T> Producer<T> {
     /// Commits the reserved position, making it visible to the consumer.
     pub fn commit(&self) {
         let header = self.queue.header();
-        // SeqCst publication followed by the SeqCst waiters load inside
-        // `wake` forms the producer half of the lost-wake-free protocol; see
-        // the `futex` module docs. Release is not sufficient here.
+        // Release publication; `wake` supplies the fence that pairs it with
+        // a registering waiter and must be called unconditionally; see the
+        // `futex` module docs.
         header
             .write
-            .store(self.queue.cached_write, Ordering::SeqCst);
+            .store(self.queue.cached_write, Ordering::Release);
         header.wait_state.wake(&header.write, 1);
     }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -335,6 +335,20 @@ impl<T> Consumer<T> {
     /// Blocks until a committed item can be reserved for reading or `timeout`
     /// elapses.
     ///
+    /// The caller must still call [`Self::finalize`] to release consumed
+    /// capacity back to the producer.
+    pub fn read_timeout(&mut self, timeout: Duration) -> Result<&T, WaitError> {
+        // SAFETY: `read_ptr_timeout` returns a pointer to properly aligned
+        //         location for `T`.
+        //         IF producer properly wrote items, or T is POD, it is
+        //         safe to convert to reference here.
+        self.read_ptr_timeout(timeout)
+            .map(|p| unsafe { p.as_ref() })
+    }
+
+    /// Blocks until a committed item can be reserved for reading or `timeout`
+    /// elapses.
+    ///
     /// The caller must still process all returned pointers and call
     /// [`Self::finalize`] to release consumed capacity back to the producer.
     pub fn read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError> {

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -18,7 +18,6 @@ use std::{
 
 /// Unique identifier for SPSC queue in shared memory.
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqspsc");
-const CONSUMER_WAIT_SPIN_ATTEMPTS: usize = 2048;
 
 /// Calculates the minimum file size required for a queue with given capacity.
 /// Note that file size MAY need to be increased beyond this to account for
@@ -323,16 +322,14 @@ impl<T> Consumer<T> {
         let header = self.queue.header;
         // SAFETY: `header` points to this consumer's live shared queue header.
         let header = unsafe { header.as_ref() };
-        header
-            .waiters
-            .wait_for(&header.write, timeout, CONSUMER_WAIT_SPIN_ATTEMPTS, || {
-                self.queue.load_write();
-                if !self.queue.is_empty() {
-                    Some(())
-                } else {
-                    None
-                }
-            })
+        header.waiters.wait_for(&header.write, timeout, || {
+            self.queue.load_write();
+            if !self.queue.is_empty() {
+                Some(())
+            } else {
+                None
+            }
+        })
     }
 
     /// Blocks until a committed item can be reserved for reading or `timeout`
@@ -341,12 +338,13 @@ impl<T> Consumer<T> {
     /// The caller must still process all returned pointers and call
     /// [`Self::finalize`] to release consumed capacity back to the producer.
     pub fn read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError> {
-        loop {
-            if let Some(ptr) = self.try_read_ptr() {
-                return Ok(ptr);
-            }
-            self.wait_readable_timeout(timeout)?;
-        }
+        let header = self.queue.header;
+        // SAFETY: `header` points to this consumer's live shared queue header.
+        let header = unsafe { header.as_ref() };
+        header.waiters.wait_for(&header.write, timeout, || {
+            self.queue.load_write();
+            self.try_read_ptr()
+        })
     }
 }
 


### PR DESCRIPTION
### Problem
- Polling on many workers is inefficient

### Changes
- Add waiting using futex on linux
	- Simply spin on other platforms that we do not really care about 