### PR TITLE
broadcast: SliceConsumer

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -132,6 +132,26 @@ impl Layout {
     }
 
     fn checked_new<T>(config: &BroadcastConfig) -> Option<Self> {
+        if align_of::<T>() > ProducerLane::block_align() {
+            return None;
+        }
+        Self::checked_new_for_payload(config, size_of::<T>(), align_of::<T>())
+    }
+
+    fn new_for_payload(
+        config: &BroadcastConfig,
+        payload_size: usize,
+        payload_align: usize,
+    ) -> Result<Self, Error> {
+        Self::checked_new_for_payload(config, payload_size, payload_align)
+            .ok_or(Error::InvalidBufferSize)
+    }
+
+    fn checked_new_for_payload(
+        config: &BroadcastConfig,
+        payload_size: usize,
+        payload_align: usize,
+    ) -> Option<Self> {
         if config.capacity == 0 {
             return None;
         }
@@ -155,12 +175,17 @@ impl Layout {
             size_of::<SharedQueueHeader>().next_multiple_of(ConsumerState::block_align());
         let consumer_state_bytes = ConsumerState::block_size(config.consumer_slots)?;
 
-        let block_align = ProducerLane::<T>::block_align();
+        let block_align = ProducerLane::block_align();
         let producer_blocks_offset = consumer_state_offset
             .checked_add(consumer_state_bytes)?
             .checked_next_multiple_of(block_align)?;
-        let block_stride = ProducerLane::<T>::block_size(capacity, config.consumer_slots)?
-            .checked_next_multiple_of(block_align)?;
+        let block_stride = producer_lane::block_size_for_payload(
+            capacity,
+            config.consumer_slots,
+            payload_size,
+            payload_align,
+        )?
+        .checked_next_multiple_of(block_align)?;
         let producer_blocks_bytes = block_stride.checked_mul(config.producer_slots)?;
         let total = producer_blocks_offset.checked_add(producer_blocks_bytes)?;
 
@@ -168,8 +193,8 @@ impl Layout {
             capacity,
             producer_slots: config.producer_slots,
             consumer_slots: config.consumer_slots,
-            payload_size: size_of::<T>(),
-            payload_align: align_of::<T>(),
+            payload_size,
+            payload_align,
             consumer_state_offset,
             producer_blocks_offset,
             block_stride,
@@ -191,7 +216,7 @@ impl Layout {
         };
         // `capacity` is already a power of two, so the recomputed layout must
         // match the stored capacity exactly.
-        let layout = Layout::new::<T>(&config)?;
+        let layout = Layout::new_for_payload(&config, header.payload_size, header.payload_align)?;
         if layout.capacity as usize != capacity || region_size < layout.total {
             return Err(Error::InvalidBufferSize);
         }
@@ -209,6 +234,8 @@ struct SharedQueue<T> {
     capacity: u32,
     producer_slots: usize,
     block_stride: usize,
+    payload_size: usize,
+    payload_align: usize,
     _marker: PhantomData<T>,
 }
 
@@ -268,7 +295,7 @@ impl<T> SharedQueue<T> {
             // SAFETY: `lane < producer_slots`; blocks are `block_stride` apart.
             let block = unsafe { producer_blocks.byte_add(lane.wrapping_mul(layout.block_stride)) };
             // SAFETY: the block is sized for `(capacity, consumer_slots)`.
-            unsafe { ProducerLane::<T>::init(block, layout.consumer_slots) };
+            unsafe { ProducerLane::init(block, layout.consumer_slots) };
         }
 
         // Header initialization publishes the queue, so it runs after every
@@ -299,6 +326,8 @@ impl<T> SharedQueue<T> {
             capacity: layout.capacity,
             producer_slots: layout.producer_slots,
             block_stride: layout.block_stride,
+            payload_size: layout.payload_size,
+            payload_align: layout.payload_align,
             _marker: PhantomData,
         }
     }
@@ -309,7 +338,7 @@ impl<T> SharedQueue<T> {
     }
 
     /// A view over producer lane `lane`.
-    fn lane(&self, lane: usize) -> ProducerLane<T> {
+    fn lane(&self, lane: usize) -> ProducerLane {
         debug_assert!(lane < self.producer_slots);
         // SAFETY: `lane < producer_slots`; blocks are `block_stride` apart.
         let block = unsafe {
@@ -317,7 +346,15 @@ impl<T> SharedQueue<T> {
                 .byte_add(lane.wrapping_mul(self.block_stride))
         };
         // SAFETY: the block was initialized with these parameters.
-        unsafe { ProducerLane::from_block(block, self.capacity, self.consumer_slots()) }
+        unsafe {
+            ProducerLane::from_block(
+                block,
+                self.capacity,
+                self.consumer_slots(),
+                self.payload_size,
+                self.payload_align,
+            )
+        }
     }
 
     /// Claims a free producer lane, returning its index.
@@ -417,6 +454,8 @@ impl<T> Clone for SharedQueue<T> {
             capacity: self.capacity,
             producer_slots: self.producer_slots,
             block_stride: self.block_stride,
+            payload_size: self.payload_size,
+            payload_align: self.payload_align,
             _marker: PhantomData,
         }
     }
@@ -434,7 +473,7 @@ unsafe impl<T: Send> Sync for SharedQueue<T> {}
 /// `queue` is kept for `try_clone` and to keep the region mapping alive.
 pub struct Producer<T> {
     queue: SharedQueue<T>,
-    lane: ProducerLane<T>,
+    lane: ProducerLane,
     index: usize,
 }
 
@@ -650,6 +689,7 @@ impl<T> WriteGuard<'_, T> {
             self.producer
                 .lane
                 .payload_ptr(self.start)
+                .cast::<T>()
                 .as_ptr()
                 .write(value)
         };
@@ -691,6 +731,7 @@ impl<T> WriteBatch<'_, T> {
             .producer
             .lane
             .payload_ptr(self.start.wrapping_add(index))
+            .cast::<T>()
             .as_ptr();
         // SAFETY: forwarded; the cell is reserved for this producer.
         unsafe { &mut *ptr.cast() }
@@ -719,7 +760,7 @@ pub struct Consumer<T> {
     queue: SharedQueue<T>,
     index: usize,
     /// One cached view per lane (avoids rebuilding it on every read).
-    lanes: Box<[ProducerLane<T>]>,
+    lanes: Box<[ProducerLane]>,
     /// Next sequence to read per lane (local cache of the published cursors).
     next_by_lane: Box<[usize]>,
     /// Lane to start the next round-robin scan from (rotates for fairness).
@@ -774,7 +815,7 @@ impl<T> Consumer<T> {
         let index = queue.acquire_consumer_index()?;
         // Cache a view per lane (independent of `queue`), and join each — at the
         // frontier, or up to one ring behind it when `from_backlog`.
-        let lanes: Box<[ProducerLane<T>]> = (0..queue.producer_slots())
+        let lanes: Box<[ProducerLane]> = (0..queue.producer_slots())
             .map(|lane| queue.lane(lane))
             .collect();
         let next_by_lane = lanes
@@ -822,7 +863,7 @@ impl<T> Consumer<T> {
         queue.recover_consumer_index(index);
         // Resume each lane at the dead owner's recorded position (read-only, so
         // its backpressure is never dropped).
-        let lanes: Box<[ProducerLane<T>]> = (0..queue.producer_slots())
+        let lanes: Box<[ProducerLane]> = (0..queue.producer_slots())
             .map(|lane| queue.lane(lane))
             .collect();
         let next_by_lane = lanes
@@ -862,18 +903,18 @@ impl<T> Consumer<T> {
         Ok(())
     }
 
-    fn join_lane(lane: &ProducerLane<T>, index: usize, from_backlog: bool) -> usize {
+    fn join_lane(lane: &ProducerLane, index: usize, from_backlog: bool) -> usize {
         let consumer_state = lane.consumer_state();
         consumer_state.join(index, from_backlog, lane.published(), || lane.reserved())
     }
 
-    fn recover_lane(lane: &ProducerLane<T>, index: usize) -> usize {
+    fn recover_lane(lane: &ProducerLane, index: usize) -> usize {
         let consumer_state = lane.consumer_state();
         consumer_state.recover(index, lane.published(), || lane.reserved())
     }
 
     #[inline]
-    fn lane(&self, lane: usize) -> &ProducerLane<T> {
+    fn lane(&self, lane: usize) -> &ProducerLane {
         debug_assert!(lane < self.lanes.len());
         // SAFETY: every caller passes a lane produced by this consumer's
         // round-robin state or a guard/batch that was created from it.
@@ -953,6 +994,7 @@ impl<T> Consumer<T> {
             self.lane(readable.lane)
                 .payload_ptr(readable.sequence)
                 .as_ptr()
+                .cast::<T>()
                 .read()
         };
         self.advance(readable.lane, NonZeroUsize::MIN);
@@ -970,7 +1012,10 @@ impl<T> Consumer<T> {
     }
 
     fn reserve_read_at(&mut self, readable: ReadableLane) -> ReadGuard<'_, T> {
-        let payload = self.lane(readable.lane).payload_ptr(readable.sequence);
+        let payload = self
+            .lane(readable.lane)
+            .payload_ptr(readable.sequence)
+            .cast();
         ReadGuard {
             consumer: self,
             lane: readable.lane,
@@ -1127,6 +1172,7 @@ impl<T> ReadBatch<'_, T> {
             &*self.consumer.lanes[self.lane]
                 .payload_ptr(self.start.wrapping_add(index))
                 .as_ptr()
+                .cast()
         }
     }
 
@@ -1145,6 +1191,7 @@ impl<T> ReadBatch<'_, T> {
             self.consumer.lanes[self.lane]
                 .payload_ptr(self.start.wrapping_add(index))
                 .as_ptr()
+                .cast::<T>()
                 .read()
         }
     }
@@ -1864,7 +1911,7 @@ mod tests {
         // the index, join, record the cursor) so nothing releases the slot.
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        Consumer::join_lane(&lane, index, false);
+        Consumer::<Payload>::join_lane(&lane, index, false);
 
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
@@ -1894,7 +1941,7 @@ mod tests {
         // its owner "crashes" (no release).
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        Consumer::join_lane(&lane, index, false);
+        Consumer::<Payload>::join_lane(&lane, index, false);
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -32,7 +32,7 @@ mod consumer_state;
 mod producer_lane;
 
 use core::marker::PhantomData;
-use core::mem::size_of;
+use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -71,6 +71,8 @@ struct SharedQueueHeader {
     capacity: u32, // per-lane ring capacity (power of two)
     producer_slots: u32,
     consumer_slots: u32,
+    payload_size: usize,
+    payload_align: usize,
     /// Count of consumers blocked waiting for any lane to publish.
     waiters: Waiters,
     /// Futex word for blocked consumers: bumped only when a publish wakes one
@@ -95,6 +97,8 @@ impl SharedQueueHeader {
                 capacity: layout.capacity,
                 producer_slots: layout.producer_slots as u32,
                 consumer_slots: layout.consumer_slots as u32,
+                payload_size: layout.payload_size,
+                payload_align: layout.payload_align,
                 waiters: Waiters::default(),
                 wake_seq: CacheAlignedAtomicSize::default(),
             });
@@ -114,6 +118,8 @@ struct Layout {
     capacity: u32,
     producer_slots: usize,
     consumer_slots: usize,
+    payload_size: usize,
+    payload_align: usize,
     consumer_state_offset: usize,
     producer_blocks_offset: usize,
     block_stride: usize,
@@ -162,6 +168,8 @@ impl Layout {
             capacity,
             producer_slots: config.producer_slots,
             consumer_slots: config.consumer_slots,
+            payload_size: size_of::<T>(),
+            payload_align: align_of::<T>(),
             consumer_state_offset,
             producer_blocks_offset,
             block_stride,
@@ -171,6 +179,10 @@ impl Layout {
 
     /// Reconstructs and validates the layout from an initialized header.
     fn from_header<T>(header: &SharedQueueHeader, region_size: usize) -> Result<Self, Error> {
+        if header.payload_size != size_of::<T>() || header.payload_align != align_of::<T>() {
+            return Err(Error::InvalidBufferSize);
+        }
+
         let capacity = header.capacity as usize;
         let config = BroadcastConfig {
             capacity,
@@ -1312,6 +1324,45 @@ mod tests {
         // SAFETY: sized-but-zeroed file → magic mismatch.
         let err = unsafe { SharedQueue::<Payload>::join(&file) };
         assert!(matches!(err, Err(Error::InvalidMagic)));
+    }
+
+    #[test]
+    fn header_records_payload_layout() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let size = Layout::new::<Payload>(&config).expect("layout").total;
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
+        // SAFETY: freshly allocated region, initialized exactly once.
+        let queue = unsafe { SharedQueue::<Payload>::create_in_region(&region, &config) }.unwrap();
+
+        assert_eq!(queue.header().payload_size, size_of::<Payload>());
+        assert_eq!(queue.header().payload_align, align_of::<Payload>());
+    }
+
+    #[test]
+    fn typed_join_rejects_payload_layout_mismatch() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let size = Layout::new::<u64>(&config).expect("layout").total;
+        let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
+        // SAFETY: freshly allocated region, initialized exactly once.
+        unsafe { SharedQueue::<u64>::create_in_region(&region, &config) }.unwrap();
+
+        // Same payload size as `u64`, but different alignment.
+        // SAFETY: the region is a live broadcast queue; validation should fail.
+        let err = unsafe { SharedQueue::<[u8; 8]>::join_region(&region) };
+        assert!(matches!(err, Err(Error::InvalidBufferSize)));
+
+        // Different payload size.
+        // SAFETY: the region is a live broadcast queue; validation should fail.
+        let err = unsafe { SharedQueue::<[u8; 4]>::join_region(&region) };
+        assert!(matches!(err, Err(Error::InvalidBufferSize)));
     }
 
     #[test]

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -225,7 +225,7 @@ impl Layout {
 }
 
 /// A handle onto the shared region: the header plus the section base pointers.
-struct SharedQueue<T> {
+struct SharedQueue {
     region: Arc<Region>,
     header: NonNull<SharedQueueHeader>,
     consumer_state: ConsumerState,
@@ -236,15 +236,14 @@ struct SharedQueue<T> {
     block_stride: usize,
     payload_size: usize,
     payload_align: usize,
-    _marker: PhantomData<T>,
 }
 
-impl<T> SharedQueue<T> {
+impl SharedQueue {
     /// Initializes a broadcast region and returns a handle.
     ///
     /// # Safety
     /// - `region` must be initialized as a broadcast queue at most once.
-    unsafe fn create_in_region(
+    unsafe fn create_in_region<T>(
         region: &Arc<Region>,
         config: &BroadcastConfig,
     ) -> Result<Self, Error> {
@@ -261,7 +260,7 @@ impl<T> SharedQueue<T> {
     ///
     /// # Safety
     /// - `region` must reference memory laid out by [`Self::create_in_region`].
-    unsafe fn join_region(region: &Arc<Region>) -> Result<Self, Error> {
+    unsafe fn join_region<T>(region: &Arc<Region>) -> Result<Self, Error> {
         let header = region.addr().cast::<SharedQueueHeader>();
         // SAFETY: regions are page-aligned (>= align_of::<SharedQueueHeader>()).
         let header_ref = unsafe { header.as_ref() };
@@ -328,7 +327,6 @@ impl<T> SharedQueue<T> {
             block_stride: layout.block_stride,
             payload_size: layout.payload_size,
             payload_align: layout.payload_align,
-            _marker: PhantomData,
         }
     }
 
@@ -424,27 +422,27 @@ impl<T> SharedQueue<T> {
     /// # Safety
     /// - `file` must be initialized as a queue at most once (by the designated
     ///   initializer) and not resized while any handle is joined.
-    unsafe fn create(file: &File, config: &BroadcastConfig) -> Result<Self, Error> {
+    unsafe fn create<T>(file: &File, config: &BroadcastConfig) -> Result<Self, Error> {
         let layout = Layout::new::<T>(config)?;
         file.set_len(layout.total as u64)?;
         let region = Region::map_file(file, layout.total)?;
         // SAFETY: caller guarantees this mapping is initialized exactly once.
-        unsafe { Self::create_in_region(&region, config) }
+        unsafe { Self::create_in_region::<T>(&region, config) }
     }
 
     /// Maps and validates an existing broadcast queue in `file`.
     ///
     /// # Safety
     /// - `file` must refer to a live broadcast queue, not resized while joined.
-    unsafe fn join(file: &File) -> Result<Self, Error> {
+    unsafe fn join<T>(file: &File) -> Result<Self, Error> {
         let file_size = file.metadata()?.len() as usize;
         let region = Region::map_file(file, file_size)?;
         // SAFETY: validated against the stored header.
-        unsafe { Self::join_region(&region) }
+        unsafe { Self::join_region::<T>(&region) }
     }
 }
 
-impl<T> Clone for SharedQueue<T> {
+impl Clone for SharedQueue {
     fn clone(&self) -> Self {
         Self {
             region: Arc::clone(&self.region),
@@ -456,15 +454,14 @@ impl<T> Clone for SharedQueue<T> {
             block_stride: self.block_stride,
             payload_size: self.payload_size,
             payload_align: self.payload_align,
-            _marker: PhantomData,
         }
     }
 }
 
 // SAFETY: the region is shared (file-backed / heap) and access is synchronized
 // by the queue protocol; the pointers are stable for the region's lifetime.
-unsafe impl<T: Send> Send for SharedQueue<T> {}
-unsafe impl<T: Send> Sync for SharedQueue<T> {}
+unsafe impl Send for SharedQueue {}
+unsafe impl Sync for SharedQueue {}
 
 /// A producer: owns one lane and publishes into it. Single-threaded use (its
 /// write ops take `&mut self`); move it between threads to hand off ownership.
@@ -472,9 +469,10 @@ unsafe impl<T: Send> Sync for SharedQueue<T> {}
 /// Holds the lane view directly (stable for the producer's lifetime); the
 /// `queue` is kept for `try_clone` and to keep the region mapping alive.
 pub struct Producer<T> {
-    queue: SharedQueue<T>,
+    queue: SharedQueue,
     lane: ProducerLane,
     index: usize,
+    _marker: PhantomData<T>,
 }
 
 impl<T> Producer<T> {
@@ -489,7 +487,7 @@ impl<T> Producer<T> {
     ///   consumer to duplicate by raw reads.
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
         // SAFETY: caller guarantees this mapping is initialized exactly once.
-        let queue = unsafe { SharedQueue::create(file, &config) }?;
+        let queue = unsafe { SharedQueue::create::<T>(file, &config) }?;
         Self::from_queue(queue)
     }
 
@@ -500,14 +498,19 @@ impl<T> Producer<T> {
     ///   with the same `T` as every other handle (see [`Self::create`]).
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         Self::from_queue(queue)
     }
 
-    fn from_queue(queue: SharedQueue<T>) -> Result<Self, Error> {
+    fn from_queue(queue: SharedQueue) -> Result<Self, Error> {
         let index = queue.acquire_producer_lane()?;
         let lane = queue.lane(index);
-        Ok(Self { queue, lane, index })
+        Ok(Self {
+            queue,
+            lane,
+            index,
+            _marker: PhantomData,
+        })
     }
 
     /// The lane this producer owns. Record it so a replacement can
@@ -530,17 +533,22 @@ impl<T> Producer<T> {
     ///   drops on the same queue.
     pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         Self::recover_in_queue(queue, index)
     }
 
-    fn recover_in_queue(queue: SharedQueue<T>, index: usize) -> Result<Self, Error> {
+    fn recover_in_queue(queue: SharedQueue, index: usize) -> Result<Self, Error> {
         if index >= queue.producer_slots() {
             return Err(Error::InvalidIndex);
         }
         let lane = queue.lane(index);
         lane.recover();
-        Ok(Self { queue, lane, index })
+        Ok(Self {
+            queue,
+            lane,
+            index,
+            _marker: PhantomData,
+        })
     }
 
     /// Force-releases a lane whose producer died, returning it to the free pool
@@ -554,7 +562,7 @@ impl<T> Producer<T> {
     ///   as [`Self::recover`].
     pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::<T>::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         if index >= queue.producer_slots() {
             return Err(Error::InvalidIndex);
         }
@@ -757,7 +765,7 @@ impl<T> Drop for WriteBatch<'_, T> {
 /// A consumer: owns one consumer index and reads every lane round-robin. Reads
 /// only items published after it joins. Single-threaded use (`&mut self`).
 pub struct Consumer<T> {
-    queue: SharedQueue<T>,
+    queue: SharedQueue,
     index: usize,
     /// One cached view per lane (avoids rebuilding it on every read).
     lanes: Box<[ProducerLane]>,
@@ -765,6 +773,7 @@ pub struct Consumer<T> {
     next_by_lane: Box<[usize]>,
     /// Lane to start the next round-robin scan from (rotates for fairness).
     scan_start_lane: usize,
+    _marker: PhantomData<T>,
 }
 
 #[derive(Clone, Copy)]
@@ -783,7 +792,7 @@ impl<T> Consumer<T> {
     ///   handles.
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
         // SAFETY: caller guarantees this mapping is initialized exactly once.
-        let queue = unsafe { SharedQueue::create(file, &config) }?;
+        let queue = unsafe { SharedQueue::create::<T>(file, &config) }?;
         Self::from_queue(queue, false)
     }
 
@@ -794,7 +803,7 @@ impl<T> Consumer<T> {
     /// - Same as [`Producer::join`]: live queue, same `T` across all handles.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         Self::from_queue(queue, false)
     }
 
@@ -807,11 +816,11 @@ impl<T> Consumer<T> {
     /// - Same as [`Self::join`].
     pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         Self::from_queue(queue, true)
     }
 
-    fn from_queue(queue: SharedQueue<T>, from_backlog: bool) -> Result<Self, Error> {
+    fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
         let index = queue.acquire_consumer_index()?;
         // Cache a view per lane (independent of `queue`), and join each — at the
         // frontier, or up to one ring behind it when `from_backlog`.
@@ -828,6 +837,7 @@ impl<T> Consumer<T> {
             lanes,
             next_by_lane,
             scan_start_lane: 0,
+            _marker: PhantomData,
         })
     }
 
@@ -852,11 +862,11 @@ impl<T> Consumer<T> {
     ///   drops on the same queue.
     pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         Self::recover_in_queue(queue, index)
     }
 
-    fn recover_in_queue(queue: SharedQueue<T>, index: usize) -> Result<Self, Error> {
+    fn recover_in_queue(queue: SharedQueue, index: usize) -> Result<Self, Error> {
         if index >= queue.consumer_slots() {
             return Err(Error::InvalidIndex);
         }
@@ -876,6 +886,7 @@ impl<T> Consumer<T> {
             lanes,
             next_by_lane,
             scan_start_lane: 0,
+            _marker: PhantomData,
         })
     }
 
@@ -892,7 +903,7 @@ impl<T> Consumer<T> {
     ///   as [`Self::recover`].
     pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
         // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::<T>::join(file) }?;
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
         if index >= queue.consumer_slots() {
             return Err(Error::InvalidIndex);
         }
@@ -1218,7 +1229,7 @@ mod tests {
         let size = Layout::new::<Payload>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once here.
-        let queue = unsafe { SharedQueue::<Payload>::create_in_region(&region, &config) }.unwrap();
+        let queue = unsafe { SharedQueue::create_in_region::<Payload>(&region, &config) }.unwrap();
         Producer::from_queue(queue).unwrap()
     }
 
@@ -1369,7 +1380,7 @@ mod tests {
         let file = create_temp_shmem_file().expect("temp file");
         file.set_len(size as u64).expect("set_len");
         // SAFETY: sized-but-zeroed file → magic mismatch.
-        let err = unsafe { SharedQueue::<Payload>::join(&file) };
+        let err = unsafe { SharedQueue::join::<Payload>(&file) };
         assert!(matches!(err, Err(Error::InvalidMagic)));
     }
 
@@ -1383,7 +1394,7 @@ mod tests {
         let size = Layout::new::<Payload>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once.
-        let queue = unsafe { SharedQueue::<Payload>::create_in_region(&region, &config) }.unwrap();
+        let queue = unsafe { SharedQueue::create_in_region::<Payload>(&region, &config) }.unwrap();
 
         assert_eq!(queue.header().payload_size, size_of::<Payload>());
         assert_eq!(queue.header().payload_align, align_of::<Payload>());
@@ -1399,16 +1410,16 @@ mod tests {
         let size = Layout::new::<u64>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once.
-        unsafe { SharedQueue::<u64>::create_in_region(&region, &config) }.unwrap();
+        unsafe { SharedQueue::create_in_region::<u64>(&region, &config) }.unwrap();
 
         // Same payload size as `u64`, but different alignment.
         // SAFETY: the region is a live broadcast queue; validation should fail.
-        let err = unsafe { SharedQueue::<[u8; 8]>::join_region(&region) };
+        let err = unsafe { SharedQueue::join_region::<[u8; 8]>(&region) };
         assert!(matches!(err, Err(Error::InvalidBufferSize)));
 
         // Different payload size.
         // SAFETY: the region is a live broadcast queue; validation should fail.
-        let err = unsafe { SharedQueue::<[u8; 4]>::join_region(&region) };
+        let err = unsafe { SharedQueue::join_region::<[u8; 4]>(&region) };
         assert!(matches!(err, Err(Error::InvalidBufferSize)));
     }
 
@@ -1829,11 +1840,11 @@ mod tests {
 
     /// Allocates a heap-backed queue and returns the shared handle (recovery
     /// tests need the queue directly to simulate a crashed handle).
-    fn recovery_queue(config: &BroadcastConfig) -> SharedQueue<Payload> {
+    fn recovery_queue(config: &BroadcastConfig) -> SharedQueue {
         let size = Layout::new::<Payload>(config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once.
-        unsafe { SharedQueue::<Payload>::create_in_region(&region, config) }.unwrap()
+        unsafe { SharedQueue::create_in_region::<Payload>(&region, config) }.unwrap()
     }
 
     #[test]
@@ -1858,12 +1869,12 @@ mod tests {
 
         // The only lane is held, so a normal join is refused.
         assert!(matches!(
-            Producer::from_queue(queue.clone()),
+            Producer::<Payload>::from_queue(queue.clone()),
             Err(Error::ProducerSlotsExhausted)
         ));
 
         // Recover the lane and keep publishing where the dead producer stopped.
-        let mut recovered = Producer::recover_in_queue(queue.clone(), 0).unwrap();
+        let mut recovered = Producer::<Payload>::recover_in_queue(queue.clone(), 0).unwrap();
         assert_eq!(recovered.index(), 0);
         assert!(recovered.try_write(3).is_ok());
 
@@ -1892,7 +1903,7 @@ mod tests {
         assert_eq!(lane.published(), 0);
 
         // Recovery rewinds the reservation back to the publication.
-        let recovered = Producer::recover_in_queue(queue.clone(), 0).unwrap();
+        let recovered = Producer::<Payload>::recover_in_queue(queue.clone(), 0).unwrap();
         assert_eq!(recovered.lane.reserved(), 0);
         assert_eq!(recovered.lane.published(), 0);
     }
@@ -1950,7 +1961,7 @@ mod tests {
 
         // A fresh join can't proceed — the index is still owned.
         assert!(matches!(
-            Consumer::from_queue(queue.clone(), false),
+            Consumer::<Payload>::from_queue(queue.clone(), false),
             Err(Error::ConsumerSlotsExhausted)
         ));
 
@@ -1977,11 +1988,11 @@ mod tests {
         };
         let queue = recovery_queue(&config);
         assert!(matches!(
-            Producer::recover_in_queue(queue.clone(), 1),
+            Producer::<Payload>::recover_in_queue(queue.clone(), 1),
             Err(Error::InvalidIndex)
         ));
         assert!(matches!(
-            Consumer::recover_in_queue(queue.clone(), 1),
+            Consumer::<Payload>::recover_in_queue(queue.clone(), 1),
             Err(Error::InvalidIndex)
         ));
     }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -35,6 +35,7 @@ use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
+use core::slice;
 use core::sync::atomic::{AtomicU64, Ordering};
 use std::fs::File;
 use std::mem::MaybeUninit;
@@ -207,7 +208,12 @@ impl Layout {
         if header.payload_size != size_of::<T>() || header.payload_align != align_of::<T>() {
             return Err(Error::InvalidBufferSize);
         }
+        Self::from_header_payload(header, region_size)
+    }
 
+    /// Reconstructs and validates the layout from an initialized header without
+    /// knowing the producer's Rust payload type.
+    fn from_header_payload(header: &SharedQueueHeader, region_size: usize) -> Result<Self, Error> {
         let capacity = header.capacity as usize;
         let config = BroadcastConfig {
             capacity,
@@ -261,6 +267,22 @@ impl SharedQueue {
     /// # Safety
     /// - `region` must reference memory laid out by [`Self::create_in_region`].
     unsafe fn join_region<T>(region: &Arc<Region>) -> Result<Self, Error> {
+        unsafe { Self::join_region_with(region, Layout::from_header::<T>) }
+    }
+
+    /// Validates an initialized broadcast region and returns a handle without
+    /// checking against a Rust payload type.
+    ///
+    /// # Safety
+    /// - `region` must reference memory laid out by [`Self::create_in_region`].
+    unsafe fn join_region_untyped(region: &Arc<Region>) -> Result<Self, Error> {
+        unsafe { Self::join_region_with(region, Layout::from_header_payload) }
+    }
+
+    unsafe fn join_region_with(
+        region: &Arc<Region>,
+        layout_from_header: impl FnOnce(&SharedQueueHeader, usize) -> Result<Layout, Error>,
+    ) -> Result<Self, Error> {
         let header = region.addr().cast::<SharedQueueHeader>();
         // SAFETY: regions are page-aligned (>= align_of::<SharedQueueHeader>()).
         let header_ref = unsafe { header.as_ref() };
@@ -273,7 +295,7 @@ impl SharedQueue {
                 actual: header_ref.version,
             });
         }
-        let layout = Layout::from_header::<T>(header_ref, region.size())?;
+        let layout = layout_from_header(header_ref, region.size())?;
         Ok(Self::from_region(Arc::clone(region), layout))
     }
 
@@ -440,6 +462,18 @@ impl SharedQueue {
         // SAFETY: validated against the stored header.
         unsafe { Self::join_region::<T>(&region) }
     }
+
+    /// Maps and validates an existing broadcast queue in `file` without
+    /// checking against a Rust payload type.
+    ///
+    /// # Safety
+    /// - `file` must refer to a live broadcast queue, not resized while joined.
+    unsafe fn join_untyped(file: &File) -> Result<Self, Error> {
+        let file_size = file.metadata()?.len() as usize;
+        let region = Region::map_file(file, file_size)?;
+        // SAFETY: validated against the stored header.
+        unsafe { Self::join_region_untyped(&region) }
+    }
 }
 
 impl Clone for SharedQueue {
@@ -587,6 +621,18 @@ impl<T> Producer<T> {
     /// [`Consumer::join_from_backlog`]).
     pub fn join_as_consumer_from_backlog(&self) -> Result<Consumer<T>, Error> {
         Consumer::from_queue(self.queue.clone(), true)
+    }
+
+    /// Joins the same queue as an untyped consumer. The consumer discovers the
+    /// payload size from the queue header and reads each payload as bytes.
+    pub fn join_as_slice_consumer(&self) -> Result<SliceConsumer, Error> {
+        SliceConsumer::from_queue(self.queue.clone(), false)
+    }
+
+    /// Like [`Self::join_as_slice_consumer`], but starts up to one ring behind
+    /// the frontier so the consumer reads data published before it joined.
+    pub fn join_as_slice_consumer_from_backlog(&self) -> Result<SliceConsumer, Error> {
+        SliceConsumer::from_queue(self.queue.clone(), true)
     }
 
     /// Publishes one value, or returns it on backpressure (the slowest consumer
@@ -762,9 +808,9 @@ impl<T> Drop for WriteBatch<'_, T> {
     }
 }
 
-/// A consumer: owns one consumer index and reads every lane round-robin. Reads
-/// only items published after it joins. Single-threaded use (`&mut self`).
-pub struct Consumer<T> {
+/// Shared consumer machinery: owns a consumer index, tracks one cursor per
+/// producer lane, and reserves raw payload pointers.
+struct ConsumerCore {
     queue: SharedQueue,
     index: usize,
     /// One cached view per lane (avoids rebuilding it on every read).
@@ -773,56 +819,12 @@ pub struct Consumer<T> {
     next_by_lane: Box<[usize]>,
     /// Lane to start the next round-robin scan from (rotates for fairness).
     scan_start_lane: usize,
-    _marker: PhantomData<T>,
 }
 
-#[derive(Clone, Copy)]
-struct ReadableLane {
-    lane: usize,
-    sequence: usize,
-    published: usize,
-}
-
-impl<T> Consumer<T> {
-    /// Creates a broadcast queue in `file` and joins as a consumer.
-    ///
-    /// # Safety
-    /// - Same as [`Producer::create`]: `file` initialized as a queue exactly once
-    ///   (the consumer may be the initializer), same POD-like `T` across all
-    ///   handles.
-    pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
-        // SAFETY: caller guarantees this mapping is initialized exactly once.
-        let queue = unsafe { SharedQueue::create::<T>(file, &config) }?;
-        Self::from_queue(queue, false)
-    }
-
-    /// Joins an existing broadcast queue in `file` as a consumer, starting at the
-    /// current frontier (only items published after the join).
-    ///
-    /// # Safety
-    /// - Same as [`Producer::join`]: live queue, same `T` across all handles.
-    pub unsafe fn join(file: &File) -> Result<Self, Error> {
-        // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join::<T>(file) }?;
-        Self::from_queue(queue, false)
-    }
-
-    /// Like [`Self::join`], but starts up to one ring behind the frontier so the
-    /// consumer reads data published before it joined. Best for slow queues; on a
-    /// fast one that has already lapped, it falls back to the frontier (see
-    /// [`Self::join`]).
-    ///
-    /// # Safety
-    /// - Same as [`Self::join`].
-    pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
-        // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join::<T>(file) }?;
-        Self::from_queue(queue, true)
-    }
-
+impl ConsumerCore {
     fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
         let index = queue.acquire_consumer_index()?;
-        // Cache a view per lane (independent of `queue`), and join each — at the
+        // Cache a view per lane (independent of `queue`), and join each at the
         // frontier, or up to one ring behind it when `from_backlog`.
         let lanes: Box<[ProducerLane]> = (0..queue.producer_slots())
             .map(|lane| queue.lane(lane))
@@ -837,33 +839,7 @@ impl<T> Consumer<T> {
             lanes,
             next_by_lane,
             scan_start_lane: 0,
-            _marker: PhantomData,
         })
-    }
-
-    /// The consumer index this handle owns. Record it so a replacement can
-    /// [`recover`](Self::recover) it if this consumer's process dies.
-    pub fn index(&self) -> usize {
-        self.index
-    }
-
-    /// Takes over a consumer index whose owner died, without the usual ownership
-    /// handshake, **resuming where the dead owner left off** on each lane — its
-    /// unread items are still pinned by its reserve limit, so they are delivered.
-    /// To instead restart fresh, [`force_release`](Self::force_release) the index
-    /// and `join` it however you like.
-    ///
-    /// # Safety
-    /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
-    ///   `index` must be dead and no other live handle may use it — two consumers
-    ///   sharing an index corrupts each other's cursor.
-    /// - Recovery must be serialized externally; it must not race with other
-    ///   recovery/force-release operations or with producer/consumer joins or
-    ///   drops on the same queue.
-    pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
-        // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join::<T>(file) }?;
-        Self::recover_in_queue(queue, index)
     }
 
     fn recover_in_queue(queue: SharedQueue, index: usize) -> Result<Self, Error> {
@@ -871,8 +847,7 @@ impl<T> Consumer<T> {
             return Err(Error::InvalidIndex);
         }
         queue.recover_consumer_index(index);
-        // Resume each lane at the dead owner's recorded position (read-only, so
-        // its backpressure is never dropped).
+        // Resume each lane at the dead owner's recorded position.
         let lanes: Box<[ProducerLane]> = (0..queue.producer_slots())
             .map(|lane| queue.lane(lane))
             .collect();
@@ -886,24 +861,10 @@ impl<T> Consumer<T> {
             lanes,
             next_by_lane,
             scan_start_lane: 0,
-            _marker: PhantomData,
         })
     }
 
-    /// Force-releases a consumer index whose owner died, returning it to the free
-    /// pool: the lanes are un-wedged and a later [`join`](Self::join) /
-    /// [`join_from_backlog`](Self::join_from_backlog) can reclaim it fresh. Use this
-    /// (rather than [`recover`](Self::recover)) when you want to drop the dead
-    /// consumer's backlog and choose a new start position.
-    ///
-    /// # Safety
-    /// - As [`Self::join`], plus: the consumer that owned `index` must be dead and
-    ///   no other live handle may use it.
-    /// - Force-release must be serialized externally, with the same restrictions
-    ///   as [`Self::recover`].
-    pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
-        // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join::<T>(file) }?;
+    fn force_release(queue: SharedQueue, index: usize) -> Result<(), Error> {
         if index >= queue.consumer_slots() {
             return Err(Error::InvalidIndex);
         }
@@ -922,6 +883,14 @@ impl<T> Consumer<T> {
     fn recover_lane(lane: &ProducerLane, index: usize) -> usize {
         let consumer_state = lane.consumer_state();
         consumer_state.recover(index, lane.published(), || lane.reserved())
+    }
+
+    fn index(&self) -> usize {
+        self.index
+    }
+
+    fn payload_size(&self) -> usize {
+        self.queue.payload_size
     }
 
     #[inline]
@@ -973,6 +942,51 @@ impl<T> Consumer<T> {
         None
     }
 
+    /// Returns `(lane, payload)` for the next readable payload without advancing
+    /// this consumer's cursor.
+    ///
+    /// `lane` identifies which producer lane the payload came from. `payload`
+    /// points at the published cell for this consumer's current sequence on
+    /// that lane, and remains protected from overwrite until the caller later
+    /// calls [`Self::advance`] for the returned lane.
+    fn try_reserve_read(&mut self) -> Option<(usize, NonNull<u8>)> {
+        let readable = self.next_readable()?;
+        Some(self.reserve_read_at(readable))
+    }
+
+    fn reserve_read_at(&mut self, readable: ReadableLane) -> (usize, NonNull<u8>) {
+        let payload = self.lane(readable.lane).payload_ptr(readable.sequence);
+        (readable.lane, payload)
+    }
+
+    /// Returns `(lane, start, count)` for up to `max` consecutive readable
+    /// payloads from one producer lane without advancing this consumer's cursor.
+    ///
+    /// `lane` identifies the producer lane. `start` is the first sequence to
+    /// read on that lane. `count` is the number of consecutive published cells
+    /// reserved, bounded by both `max` and the lane's current publication. The
+    /// range `start..start + count` remains protected from overwrite until the
+    /// caller later calls [`Self::advance`] for the returned lane and count.
+    fn try_reserve_read_batch(
+        &mut self,
+        max: NonZeroUsize,
+    ) -> Option<(usize, usize, NonZeroUsize)> {
+        let readable = self.next_readable()?;
+        Some(self.reserve_read_batch_at(readable, max))
+    }
+
+    fn reserve_read_batch_at(
+        &mut self,
+        readable: ReadableLane,
+        max: NonZeroUsize,
+    ) -> (usize, usize, NonZeroUsize) {
+        // `next_readable` guarantees at least one published value past `sequence`.
+        let available = readable.published.wrapping_sub(readable.sequence);
+        let count = available.min(max.get());
+        let count = NonZeroUsize::new(count).expect("readable lane has at least one value");
+        (readable.lane, readable.sequence, count)
+    }
+
     /// Advances this consumer's cursor on `lane` by `count` consumed values,
     /// publishing the progress and rotating the scan start. The consumer is the
     /// sole reader of its own cursor (`&mut self`), so the cursor only moves here
@@ -991,24 +1005,147 @@ impl<T> Consumer<T> {
         self.scan_start_lane = scan_start_lane;
     }
 
+    /// Blocks until [`Self::next_readable`] would succeed, sleeping on the
+    /// queue's global wake counter (a publish on any lane wakes it).
+    fn wait_until_readable(&self, timeout: Duration) -> Result<ReadableLane, WaitError> {
+        self.queue.wait_for(timeout, || self.next_readable())
+    }
+}
+
+impl Drop for ConsumerCore {
+    fn drop(&mut self) {
+        // Drop each lane's reserve limit first, then the global ownership, so no
+        // limit lingers for an index another consumer could reclaim.
+        for lane in self.lanes.iter() {
+            lane.consumer_state().release(self.index);
+        }
+        self.queue.release_consumer_index(self.index);
+    }
+}
+
+// SAFETY: core consumer state is single-threaded by its public wrappers, but
+// may be moved between threads.
+unsafe impl Send for ConsumerCore {}
+
+/// A consumer: owns one consumer index and reads every lane round-robin. Reads
+/// only items published after it joins. Single-threaded use (`&mut self`).
+pub struct Consumer<T> {
+    core: ConsumerCore,
+    _marker: PhantomData<T>,
+}
+
+#[derive(Clone, Copy)]
+struct ReadableLane {
+    lane: usize,
+    sequence: usize,
+    published: usize,
+}
+
+impl<T> Consumer<T> {
+    /// Creates a broadcast queue in `file` and joins as a consumer.
+    ///
+    /// # Safety
+    /// - Same as [`Producer::create`]: `file` initialized as a queue exactly once
+    ///   (the consumer may be the initializer), same POD-like `T` across all
+    ///   handles.
+    pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
+        // SAFETY: caller guarantees this mapping is initialized exactly once.
+        let queue = unsafe { SharedQueue::create::<T>(file, &config) }?;
+        Self::from_queue(queue, false)
+    }
+
+    /// Joins an existing broadcast queue in `file` as a consumer, starting at the
+    /// current frontier (only items published after the join).
+    ///
+    /// # Safety
+    /// - Same as [`Producer::join`]: live queue, same `T` across all handles.
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
+        Self::from_queue(queue, false)
+    }
+
+    /// Like [`Self::join`], but starts up to one ring behind the frontier so the
+    /// consumer reads data published before it joined. Best for slow queues; on a
+    /// fast one that has already lapped, it falls back to the frontier (see
+    /// [`Self::join`]).
+    ///
+    /// # Safety
+    /// - Same as [`Self::join`].
+    pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
+        Self::from_queue(queue, true)
+    }
+
+    fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
+        Ok(Self {
+            core: ConsumerCore::from_queue(queue, from_backlog)?,
+            _marker: PhantomData,
+        })
+    }
+
+    /// The consumer index this handle owns. Record it so a replacement can
+    /// [`recover`](Self::recover) it if this consumer's process dies.
+    pub fn index(&self) -> usize {
+        self.core.index()
+    }
+
+    /// Takes over a consumer index whose owner died, without the usual ownership
+    /// handshake, **resuming where the dead owner left off** on each lane — its
+    /// unread items are still pinned by its reserve limit, so they are delivered.
+    /// To instead restart fresh, [`force_release`](Self::force_release) the index
+    /// and `join` it however you like.
+    ///
+    /// # Safety
+    /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
+    ///   `index` must be dead and no other live handle may use it — two consumers
+    ///   sharing an index corrupts each other's cursor.
+    /// - Recovery must be serialized externally; it must not race with other
+    ///   recovery/force-release operations or with producer/consumer joins or
+    ///   drops on the same queue.
+    pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
+        Self::recover_in_queue(queue, index)
+    }
+
+    fn recover_in_queue(queue: SharedQueue, index: usize) -> Result<Self, Error> {
+        Ok(Self {
+            core: ConsumerCore::recover_in_queue(queue, index)?,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Force-releases a consumer index whose owner died, returning it to the free
+    /// pool: the lanes are un-wedged and a later [`join`](Self::join) /
+    /// [`join_from_backlog`](Self::join_from_backlog) can reclaim it fresh. Use this
+    /// (rather than [`recover`](Self::recover)) when you want to drop the dead
+    /// consumer's backlog and choose a new start position.
+    ///
+    /// # Safety
+    /// - As [`Self::join`], plus: the consumer that owned `index` must be dead and
+    ///   no other live handle may use it.
+    /// - Force-release must be serialized externally, with the same restrictions
+    ///   as [`Self::recover`].
+    pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join::<T>(file) }?;
+        ConsumerCore::force_release(queue, index)
+    }
+
     /// Reads the next available value by copying it out, or `None` if every lane
     /// is caught up.
     pub fn try_read(&mut self) -> Option<T>
     where
         T: Copy,
     {
-        let readable = self.next_readable()?;
+        let (lane, payload) = self.core.try_reserve_read()?;
         // SAFETY: `sequence < publication`, so the cell is published (initialized);
         // this consumer's cursor still protects it from being overwritten until we
         // advance below. The copy happens before the cursor advances.
-        let value = unsafe {
-            self.lane(readable.lane)
-                .payload_ptr(readable.sequence)
-                .as_ptr()
-                .cast::<T>()
-                .read()
-        };
-        self.advance(readable.lane, NonZeroUsize::MIN);
+        let value = unsafe { payload.cast::<T>().as_ptr().read() };
+        self.core.advance(lane, NonZeroUsize::MIN);
         Some(value)
     }
 
@@ -1018,19 +1155,16 @@ impl<T> Consumer<T> {
     /// guard is dropped, which advances past it.
     #[must_use]
     pub fn try_reserve_read(&mut self) -> Option<ReadGuard<'_, T>> {
-        let readable = self.next_readable()?;
+        let readable = self.core.next_readable()?;
         Some(self.reserve_read_at(readable))
     }
 
     fn reserve_read_at(&mut self, readable: ReadableLane) -> ReadGuard<'_, T> {
-        let payload = self
-            .lane(readable.lane)
-            .payload_ptr(readable.sequence)
-            .cast();
+        let (lane, payload) = self.core.reserve_read_at(readable);
         ReadGuard {
-            consumer: self,
-            lane: readable.lane,
-            payload,
+            consumer: &mut self.core,
+            lane,
+            payload: payload.cast(),
         }
     }
 
@@ -1042,8 +1176,14 @@ impl<T> Consumer<T> {
     /// is dropped, which advances past the whole batch.
     #[must_use]
     pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
-        let readable = self.next_readable()?;
-        Some(self.reserve_read_batch_at(readable, max))
+        let (lane, start, count) = self.core.try_reserve_read_batch(max)?;
+        Some(ReadBatch {
+            consumer: &mut self.core,
+            lane,
+            start,
+            count,
+            _marker: PhantomData,
+        })
     }
 
     fn reserve_read_batch_at(
@@ -1051,15 +1191,13 @@ impl<T> Consumer<T> {
         readable: ReadableLane,
         max: NonZeroUsize,
     ) -> ReadBatch<'_, T> {
-        // `next_readable` guarantees at least one published value past `sequence`.
-        let available = readable.published.wrapping_sub(readable.sequence);
-        let count = available.min(max.get());
-        let count = NonZeroUsize::new(count).expect("readable lane has at least one value");
+        let (lane, start, count) = self.core.reserve_read_batch_at(readable, max);
         ReadBatch {
-            consumer: self,
-            lane: readable.lane,
-            start: readable.sequence,
+            consumer: &mut self.core,
+            lane,
+            start,
             count,
+            _marker: PhantomData,
         }
     }
 
@@ -1069,7 +1207,7 @@ impl<T> Consumer<T> {
         &mut self,
         timeout: Duration,
     ) -> Result<ReadGuard<'_, T>, WaitError> {
-        let readable = self.wait_until_readable(timeout)?;
+        let readable = self.core.wait_until_readable(timeout)?;
         Ok(self.reserve_read_at(readable))
     }
 
@@ -1080,7 +1218,7 @@ impl<T> Consumer<T> {
         max: NonZeroUsize,
         timeout: Duration,
     ) -> Result<ReadBatch<'_, T>, WaitError> {
-        let readable = self.wait_until_readable(timeout)?;
+        let readable = self.core.wait_until_readable(timeout)?;
         Ok(self.reserve_read_batch_at(readable, max))
     }
 
@@ -1093,23 +1231,6 @@ impl<T> Consumer<T> {
         let guard = self.reserve_read_timeout(timeout)?;
         Ok(guard.read())
     }
-
-    /// Blocks until [`Self::next_readable`] would succeed, sleeping on the queue's
-    /// global wake counter (a publish on any lane wakes it).
-    fn wait_until_readable(&self, timeout: Duration) -> Result<ReadableLane, WaitError> {
-        self.queue.wait_for(timeout, || self.next_readable())
-    }
-}
-
-impl<T> Drop for Consumer<T> {
-    fn drop(&mut self) {
-        // Drop each lane's reserve limit first, then the global ownership, so no
-        // limit lingers for an index another consumer could reclaim.
-        for lane in self.lanes.iter() {
-            lane.consumer_state().release(self.index);
-        }
-        self.queue.release_consumer_index(self.index);
-    }
 }
 
 // SAFETY: a consumer is single-threaded (read ops take `&mut self`) but may be
@@ -1121,7 +1242,7 @@ unsafe impl<T: Send> Send for Consumer<T> {}
 /// it); dropping the guard advances past it.
 #[must_use]
 pub struct ReadGuard<'a, T> {
-    consumer: &'a mut Consumer<T>,
+    consumer: &'a mut ConsumerCore,
     lane: usize,
     payload: NonNull<T>,
 }
@@ -1156,10 +1277,11 @@ impl<T> Drop for ReadGuard<'_, T> {
 /// whole batch.
 #[must_use]
 pub struct ReadBatch<'a, T> {
-    consumer: &'a mut Consumer<T>,
+    consumer: &'a mut ConsumerCore,
     lane: usize,
     start: usize,
     count: NonZeroUsize,
+    _marker: PhantomData<T>,
 }
 
 impl<T> ReadBatch<'_, T> {
@@ -1209,6 +1331,269 @@ impl<T> ReadBatch<'_, T> {
 }
 
 impl<T> Drop for ReadBatch<'_, T> {
+    fn drop(&mut self) {
+        self.consumer.advance(self.lane, self.count);
+    }
+}
+
+/// An untyped consumer that reads each broadcast payload as a byte slice.
+///
+/// `SliceConsumer` joins an existing queue without knowing its Rust payload
+/// type. The payload size is discovered from the queue header, and every read
+/// returns a guard exposing the payload bytes. Dropping the guard advances the
+/// consumer cursor, just like [`ReadGuard`].
+pub struct SliceConsumer {
+    core: ConsumerCore,
+}
+
+impl SliceConsumer {
+    /// Joins an existing broadcast queue in `file` as an untyped consumer,
+    /// starting at the current frontier.
+    ///
+    /// # Safety
+    /// - `file` must refer to a live broadcast queue, not resized while joined.
+    /// - Payload bytes must be meaningful to the caller without relying on Rust
+    ///   type validation.
+    pub unsafe fn join(file: &File) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join_untyped(file) }?;
+        Self::from_queue(queue, false)
+    }
+
+    /// Like [`Self::join`], but starts up to one ring behind the frontier so the
+    /// consumer reads data published before it joined.
+    ///
+    /// # Safety
+    /// - Same as [`Self::join`].
+    pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join_untyped(file) }?;
+        Self::from_queue(queue, true)
+    }
+
+    fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
+        Ok(Self {
+            core: ConsumerCore::from_queue(queue, from_backlog)?,
+        })
+    }
+
+    /// The consumer index this handle owns. Record it so a replacement can
+    /// [`recover`](Self::recover) it if this consumer's process dies.
+    pub fn index(&self) -> usize {
+        self.core.index()
+    }
+
+    /// Number of bytes in each payload cell, discovered from the queue header.
+    pub fn payload_size(&self) -> usize {
+        self.core.payload_size()
+    }
+
+    /// Takes over a consumer index whose owner died, resuming where the dead
+    /// owner left off on each lane.
+    ///
+    /// # Safety
+    /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
+    ///   `index` must be dead and no other live handle may use it.
+    /// - Recovery must be serialized externally; it must not race with other
+    ///   recovery/force-release operations or with producer/consumer joins or
+    ///   drops on the same queue.
+    pub unsafe fn recover(file: &File, index: usize) -> Result<Self, Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join_untyped(file) }?;
+        Self::recover_in_queue(queue, index)
+    }
+
+    fn recover_in_queue(queue: SharedQueue, index: usize) -> Result<Self, Error> {
+        Ok(Self {
+            core: ConsumerCore::recover_in_queue(queue, index)?,
+        })
+    }
+
+    /// Force-releases a consumer index whose owner died, returning it to the
+    /// free pool.
+    ///
+    /// # Safety
+    /// - As [`Self::join`], plus: the consumer that owned `index` must be dead
+    ///   and no other live handle may use it.
+    /// - Force-release must be serialized externally, with the same restrictions
+    ///   as [`Self::recover`].
+    pub unsafe fn force_release(file: &File, index: usize) -> Result<(), Error> {
+        // SAFETY: validated against the stored header.
+        let queue = unsafe { SharedQueue::join_untyped(file) }?;
+        ConsumerCore::force_release(queue, index)
+    }
+
+    /// Reserves the next available payload and exposes it as bytes, or `None` if
+    /// every lane is caught up. The returned guard holds this consumer's cursor
+    /// until it is dropped.
+    #[must_use]
+    pub fn try_read(&mut self) -> Option<SliceReadGuard<'_>> {
+        self.try_reserve_read()
+    }
+
+    /// Alias for [`Self::try_read`].
+    #[must_use]
+    pub fn try_reserve_read(&mut self) -> Option<SliceReadGuard<'_>> {
+        let readable = self.core.next_readable()?;
+        Some(self.reserve_read_at(readable))
+    }
+
+    fn reserve_read_at(&mut self, readable: ReadableLane) -> SliceReadGuard<'_> {
+        let (lane, payload) = self.core.reserve_read_at(readable);
+        let len = self.core.payload_size();
+        SliceReadGuard {
+            consumer: &mut self.core,
+            lane,
+            payload,
+            len,
+        }
+    }
+
+    /// Reserves up to `max` consecutive published payloads from the next
+    /// readable lane, or `None` if every lane is caught up.
+    #[must_use]
+    pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<SliceReadBatch<'_>> {
+        let (lane, start, count) = self.core.try_reserve_read_batch(max)?;
+        let payload_size = self.core.payload_size();
+        Some(SliceReadBatch {
+            consumer: &mut self.core,
+            lane,
+            start,
+            count,
+            payload_size,
+        })
+    }
+
+    fn reserve_read_batch_at(
+        &mut self,
+        readable: ReadableLane,
+        max: NonZeroUsize,
+    ) -> SliceReadBatch<'_> {
+        let (lane, start, count) = self.core.reserve_read_batch_at(readable, max);
+        let payload_size = self.core.payload_size();
+        SliceReadBatch {
+            consumer: &mut self.core,
+            lane,
+            start,
+            count,
+            payload_size,
+        }
+    }
+
+    /// Blocks until any lane has an unread payload or `timeout` elapses, then
+    /// returns a [`SliceReadGuard`] for it; `Err(Timeout)` if none arrived.
+    pub fn read_timeout(&mut self, timeout: Duration) -> Result<SliceReadGuard<'_>, WaitError> {
+        self.reserve_read_timeout(timeout)
+    }
+
+    /// Blocks until any lane has an unread payload or `timeout` elapses, then
+    /// returns a [`SliceReadGuard`] for it; `Err(Timeout)` if none arrived.
+    pub fn reserve_read_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<SliceReadGuard<'_>, WaitError> {
+        let readable = self.core.wait_until_readable(timeout)?;
+        Ok(self.reserve_read_at(readable))
+    }
+
+    /// Blocks until any lane has unread payloads or `timeout` elapses, then
+    /// returns a [`SliceReadBatch`] of up to `max` of them.
+    pub fn reserve_read_batch_timeout(
+        &mut self,
+        max: NonZeroUsize,
+        timeout: Duration,
+    ) -> Result<SliceReadBatch<'_>, WaitError> {
+        let readable = self.core.wait_until_readable(timeout)?;
+        Ok(self.reserve_read_batch_at(readable, max))
+    }
+}
+
+// SAFETY: a slice consumer is single-threaded (read ops take `&mut self`) but
+// may be moved between threads.
+unsafe impl Send for SliceConsumer {}
+
+/// An in-place borrow of one published payload as bytes.
+#[must_use]
+pub struct SliceReadGuard<'a> {
+    consumer: &'a mut ConsumerCore,
+    lane: usize,
+    payload: NonNull<u8>,
+    len: usize,
+}
+
+impl SliceReadGuard<'_> {
+    /// Byte length of the payload.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the payload bytes.
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: the cell is published and held by this consumer's cursor.
+        unsafe { slice::from_raw_parts(self.payload.as_ptr(), self.len) }
+    }
+}
+
+impl AsRef<[u8]> for SliceReadGuard<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl Drop for SliceReadGuard<'_> {
+    fn drop(&mut self) {
+        self.consumer.advance(self.lane, NonZeroUsize::MIN);
+    }
+}
+
+/// An in-place borrow of consecutive published payloads from one lane as bytes.
+#[must_use]
+pub struct SliceReadBatch<'a> {
+    consumer: &'a mut ConsumerCore,
+    lane: usize,
+    start: usize,
+    count: NonZeroUsize,
+    payload_size: usize,
+}
+
+impl SliceReadBatch<'_> {
+    pub fn len(&self) -> usize {
+        self.count.get()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Byte length of each payload in the batch.
+    pub fn payload_size(&self) -> usize {
+        self.payload_size
+    }
+
+    /// Byte slice for the payload at `index`.
+    ///
+    /// # Safety
+    /// - `index < len`.
+    pub unsafe fn as_slice(&self, index: usize) -> &[u8] {
+        debug_assert!(index < self.count.get());
+        // SAFETY: forwarded; the cell is published and held by this consumer's
+        // cursor until the batch is dropped.
+        unsafe {
+            let ptr = self
+                .consumer
+                .lane(self.lane)
+                .payload_ptr(self.start.wrapping_add(index))
+                .as_ptr();
+            slice::from_raw_parts(ptr, self.payload_size)
+        }
+    }
+}
+
+impl Drop for SliceReadBatch<'_> {
     fn drop(&mut self) {
         self.consumer.advance(self.lane, self.count);
     }
@@ -1421,6 +1806,76 @@ mod tests {
         // SAFETY: the region is a live broadcast queue; validation should fail.
         let err = unsafe { SharedQueue::join_region::<[u8; 4]>(&region) };
         assert!(matches!(err, Err(Error::InvalidBufferSize)));
+    }
+
+    #[test]
+    fn slice_consumer_reads_payload_bytes() {
+        let mut producer = create_heap_producer(BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        });
+        let mut consumer = producer.join_as_slice_consumer().unwrap();
+        assert_eq!(consumer.payload_size(), size_of::<Payload>());
+
+        let value = 0x0102_0304_0506_0708u64;
+        assert!(producer.try_write(value).is_ok());
+
+        let guard = consumer.try_read().expect("readable");
+        assert_eq!(guard.len(), size_of::<Payload>());
+        assert_eq!(guard.as_slice(), value.to_ne_bytes());
+        drop(guard);
+
+        assert!(consumer.try_read().is_none());
+    }
+
+    #[test]
+    fn slice_consumer_batch_reads_payload_bytes() {
+        let mut producer = create_heap_producer(BroadcastConfig {
+            capacity: 8,
+            producer_slots: 1,
+            consumer_slots: 1,
+        });
+        let mut consumer = producer.join_as_slice_consumer().unwrap();
+
+        assert!(producer.try_write_slice(&[11, 12, 13]));
+        {
+            let batch = consumer
+                .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+                .expect("readable batch");
+            assert_eq!(batch.len(), 2);
+            assert_eq!(batch.payload_size(), size_of::<Payload>());
+            // SAFETY: both indexes are below `batch.len()`.
+            unsafe {
+                assert_eq!(batch.as_slice(0), 11u64.to_ne_bytes());
+                assert_eq!(batch.as_slice(1), 12u64.to_ne_bytes());
+            }
+        }
+
+        let guard = consumer.try_read().expect("remaining item");
+        assert_eq!(guard.as_slice(), 13u64.to_ne_bytes());
+    }
+
+    #[cfg(not(miri))]
+    #[test]
+    fn slice_consumer_joins_file_without_payload_type() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let file = create_temp_shmem_file().expect("temp file");
+        // SAFETY: a fresh temp file, initialized exactly once here.
+        let mut producer = unsafe { Producer::<Payload>::create(&file, config) }.unwrap();
+        // SAFETY: the file now contains a live broadcast queue.
+        let mut consumer = unsafe { SliceConsumer::join(&file) }.unwrap();
+        assert_eq!(consumer.payload_size(), size_of::<Payload>());
+
+        let value = 0xfeed_face_cafe_beefu64;
+        assert!(producer.try_write(value).is_ok());
+
+        let guard = consumer.read_timeout(Duration::ZERO).expect("readable");
+        assert_eq!(guard.as_slice(), value.to_ne_bytes());
     }
 
     #[test]
@@ -1922,7 +2377,7 @@ mod tests {
         // the index, join, record the cursor) so nothing releases the slot.
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        Consumer::<Payload>::join_lane(&lane, index, false);
+        ConsumerCore::join_lane(&lane, index, false);
 
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
@@ -1952,7 +2407,7 @@ mod tests {
         // its owner "crashes" (no release).
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        Consumer::<Payload>::join_lane(&lane, index, false);
+        ConsumerCore::join_lane(&lane, index, false);
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -90,20 +90,20 @@ impl SharedQueueHeader {
     /// - Access to `header` must be unique.
     /// - The queue's non-header sections must already be initialized.
     unsafe fn init(header: NonNull<Self>, layout: &Layout) {
+        let value = Self {
+            magic: AtomicU64::new(0),
+            version: VERSION,
+            capacity: layout.capacity,
+            producer_slots: layout.producer_slots as u32,
+            consumer_slots: layout.consumer_slots as u32,
+            payload_size: layout.payload_size,
+            payload_align: layout.payload_align,
+            waiters: Waiters::default(),
+            wake_seq: CacheAlignedAtomicSize::default(),
+        };
+        let header_ptr = header.as_ptr();
         // SAFETY: caller guarantees valid, uniquely-owned storage for the header.
-        unsafe {
-            header.as_ptr().write(Self {
-                magic: AtomicU64::new(0),
-                version: VERSION,
-                capacity: layout.capacity,
-                producer_slots: layout.producer_slots as u32,
-                consumer_slots: layout.consumer_slots as u32,
-                payload_size: layout.payload_size,
-                payload_align: layout.payload_align,
-                waiters: Waiters::default(),
-                wake_seq: CacheAlignedAtomicSize::default(),
-            });
-        }
+        unsafe { header_ptr.write(value) };
 
         // Publish initialization last.
         // SAFETY: the header was initialized by the write above.
@@ -331,12 +331,10 @@ impl SharedQueue {
         let base = region.addr();
         let header = base.cast::<SharedQueueHeader>();
         // SAFETY: offsets lie within the region.
-        let consumer_state = unsafe {
-            ConsumerState::from_block(
-                base.byte_add(layout.consumer_state_offset),
-                layout.consumer_slots,
-            )
-        };
+        let consumer_state_block = unsafe { base.byte_add(layout.consumer_state_offset) };
+        // SAFETY: offsets lie within the region.
+        let consumer_state =
+            unsafe { ConsumerState::from_block(consumer_state_block, layout.consumer_slots) };
         // SAFETY: offsets lie within the region.
         let producer_blocks = unsafe { base.byte_add(layout.producer_blocks_offset) };
         Self {
@@ -738,15 +736,14 @@ impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
 impl<T> WriteGuard<'_, T> {
     /// Writes `value` into the reserved cell; the guard publishes it on drop.
     pub fn write(self, value: T) {
+        let ptr = self
+            .producer
+            .lane
+            .payload_ptr(self.start)
+            .cast::<T>()
+            .as_ptr();
         // SAFETY: the cell is reserved and not yet published; `T` is moved in.
-        unsafe {
-            self.producer
-                .lane
-                .payload_ptr(self.start)
-                .cast::<T>()
-                .as_ptr()
-                .write(value)
-        };
+        unsafe { ptr.write(value) };
     }
 }
 
@@ -1299,14 +1296,13 @@ impl<T> ReadBatch<'_, T> {
     /// - `index < len`
     pub unsafe fn as_ref(&self, index: usize) -> &T {
         debug_assert!(index < self.count.get());
+        let ptr = self.consumer.lanes[self.lane]
+            .payload_ptr(self.start.wrapping_add(index))
+            .as_ptr()
+            .cast();
         // SAFETY: the cell is published and held by this consumer's
         // cursor.
-        unsafe {
-            &*self.consumer.lanes[self.lane]
-                .payload_ptr(self.start.wrapping_add(index))
-                .as_ptr()
-                .cast()
-        }
+        unsafe { &*ptr }
     }
 
     /// Copies the value at `index` out.
@@ -1318,15 +1314,13 @@ impl<T> ReadBatch<'_, T> {
         T: Copy,
     {
         debug_assert!(index < self.count.get());
+        let ptr = self.consumer.lanes[self.lane]
+            .payload_ptr(self.start.wrapping_add(index))
+            .as_ptr()
+            .cast::<T>();
         // SAFETY: the cell is published and held by this consumer's
         // cursor.
-        unsafe {
-            self.consumer.lanes[self.lane]
-                .payload_ptr(self.start.wrapping_add(index))
-                .as_ptr()
-                .cast::<T>()
-                .read()
-        }
+        unsafe { ptr.read() }
     }
 }
 
@@ -1580,16 +1574,14 @@ impl SliceReadBatch<'_> {
     /// - `index < len`.
     pub unsafe fn as_slice(&self, index: usize) -> &[u8] {
         debug_assert!(index < self.count.get());
+        let ptr = self
+            .consumer
+            .lane(self.lane)
+            .payload_ptr(self.start.wrapping_add(index))
+            .as_ptr();
         // SAFETY: forwarded; the cell is published and held by this consumer's
         // cursor until the batch is dropped.
-        unsafe {
-            let ptr = self
-                .consumer
-                .lane(self.lane)
-                .payload_ptr(self.start.wrapping_add(index))
-                .as_ptr();
-            slice::from_raw_parts(ptr, self.payload_size)
-        }
+        unsafe { slice::from_raw_parts(ptr, self.payload_size) }
     }
 }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -31,8 +31,9 @@
 mod consumer_state;
 mod producer_lane;
 
+use core::alloc::Layout;
 use core::marker::PhantomData;
-use core::mem::{align_of, size_of};
+use core::mem::size_of;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::slice;
@@ -89,15 +90,15 @@ impl SharedQueueHeader {
     ///   [`SharedQueueHeader`].
     /// - Access to `header` must be unique.
     /// - The queue's non-header sections must already be initialized.
-    unsafe fn init(header: NonNull<Self>, layout: &Layout) {
+    unsafe fn init(header: NonNull<Self>, layout: &QueueLayout) {
         let value = Self {
             magic: AtomicU64::new(0),
             version: VERSION,
             capacity: layout.capacity,
             producer_slots: layout.producer_slots as u32,
             consumer_slots: layout.consumer_slots as u32,
-            payload_size: layout.payload_size,
-            payload_align: layout.payload_align,
+            payload_size: layout.payload_layout.size(),
+            payload_align: layout.payload_layout.align(),
             waiters: Waiters::default(),
             wake_seq: CacheAlignedAtomicSize::default(),
         };
@@ -115,44 +116,34 @@ impl SharedQueueHeader {
 
 /// Byte offsets and sizes of the region's sections (a construction-time helper;
 /// `SharedQueue` keeps only the runtime scalars from it).
-struct Layout {
+struct QueueLayout {
     capacity: u32,
     producer_slots: usize,
     consumer_slots: usize,
-    payload_size: usize,
-    payload_align: usize,
+    payload_layout: Layout,
     consumer_state_offset: usize,
     producer_blocks_offset: usize,
     block_stride: usize,
     total: usize,
 }
 
-impl Layout {
+impl QueueLayout {
     fn new<T>(config: &BroadcastConfig) -> Result<Self, Error> {
         Self::checked_new::<T>(config).ok_or(Error::InvalidBufferSize)
     }
 
     fn checked_new<T>(config: &BroadcastConfig) -> Option<Self> {
-        if align_of::<T>() > ProducerLane::block_align() {
+        Self::checked_new_for_payload(config, Layout::new::<T>())
+    }
+
+    fn new_for_payload(config: &BroadcastConfig, payload: Layout) -> Result<Self, Error> {
+        Self::checked_new_for_payload(config, payload).ok_or(Error::InvalidBufferSize)
+    }
+
+    fn checked_new_for_payload(config: &BroadcastConfig, payload: Layout) -> Option<Self> {
+        if payload.align() > ProducerLane::block_align() {
             return None;
         }
-        Self::checked_new_for_payload(config, size_of::<T>(), align_of::<T>())
-    }
-
-    fn new_for_payload(
-        config: &BroadcastConfig,
-        payload_size: usize,
-        payload_align: usize,
-    ) -> Result<Self, Error> {
-        Self::checked_new_for_payload(config, payload_size, payload_align)
-            .ok_or(Error::InvalidBufferSize)
-    }
-
-    fn checked_new_for_payload(
-        config: &BroadcastConfig,
-        payload_size: usize,
-        payload_align: usize,
-    ) -> Option<Self> {
         if config.capacity == 0 {
             return None;
         }
@@ -180,13 +171,9 @@ impl Layout {
         let producer_blocks_offset = consumer_state_offset
             .checked_add(consumer_state_bytes)?
             .checked_next_multiple_of(block_align)?;
-        let block_stride = producer_lane::block_size_for_payload(
-            capacity,
-            config.consumer_slots,
-            payload_size,
-            payload_align,
-        )?
-        .checked_next_multiple_of(block_align)?;
+        let block_stride =
+            producer_lane::block_size_for_payload(capacity, config.consumer_slots, payload)?
+                .checked_next_multiple_of(block_align)?;
         let producer_blocks_bytes = block_stride.checked_mul(config.producer_slots)?;
         let total = producer_blocks_offset.checked_add(producer_blocks_bytes)?;
 
@@ -194,8 +181,7 @@ impl Layout {
             capacity,
             producer_slots: config.producer_slots,
             consumer_slots: config.consumer_slots,
-            payload_size,
-            payload_align,
+            payload_layout: payload,
             consumer_state_offset,
             producer_blocks_offset,
             block_stride,
@@ -205,15 +191,31 @@ impl Layout {
 
     /// Reconstructs and validates the layout from an initialized header.
     fn from_header<T>(header: &SharedQueueHeader, region_size: usize) -> Result<Self, Error> {
-        if header.payload_size != size_of::<T>() || header.payload_align != align_of::<T>() {
+        let payload = Self::payload_from_header(header)?;
+        let expected = Layout::new::<T>();
+        if payload.size() != expected.size() || payload.align() != expected.align() {
             return Err(Error::InvalidBufferSize);
         }
-        Self::from_header_payload(header, region_size)
+        Self::from_header_with_payload(header, region_size, payload)
     }
 
     /// Reconstructs and validates the layout from an initialized header without
     /// knowing the producer's Rust payload type.
     fn from_header_payload(header: &SharedQueueHeader, region_size: usize) -> Result<Self, Error> {
+        let payload = Self::payload_from_header(header)?;
+        Self::from_header_with_payload(header, region_size, payload)
+    }
+
+    fn payload_from_header(header: &SharedQueueHeader) -> Result<Layout, Error> {
+        Layout::from_size_align(header.payload_size, header.payload_align)
+            .map_err(|_| Error::InvalidBufferSize)
+    }
+
+    fn from_header_with_payload(
+        header: &SharedQueueHeader,
+        region_size: usize,
+        payload: Layout,
+    ) -> Result<Self, Error> {
         let capacity = header.capacity as usize;
         let config = BroadcastConfig {
             capacity,
@@ -222,7 +224,7 @@ impl Layout {
         };
         // `capacity` is already a power of two, so the recomputed layout must
         // match the stored capacity exactly.
-        let layout = Layout::new_for_payload(&config, header.payload_size, header.payload_align)?;
+        let layout = QueueLayout::new_for_payload(&config, payload)?;
         if layout.capacity as usize != capacity || region_size < layout.total {
             return Err(Error::InvalidBufferSize);
         }
@@ -240,8 +242,7 @@ struct SharedQueue {
     capacity: u32,
     producer_slots: usize,
     block_stride: usize,
-    payload_size: usize,
-    payload_align: usize,
+    payload: Layout,
 }
 
 impl SharedQueue {
@@ -253,7 +254,7 @@ impl SharedQueue {
         region: &Arc<Region>,
         config: &BroadcastConfig,
     ) -> Result<Self, Error> {
-        let layout = Layout::new::<T>(config)?;
+        let layout = QueueLayout::new::<T>(config)?;
         if region.size() < layout.total {
             return Err(Error::InvalidBufferSize);
         }
@@ -267,7 +268,7 @@ impl SharedQueue {
     /// # Safety
     /// - `region` must reference memory laid out by [`Self::create_in_region`].
     unsafe fn join_region<T>(region: &Arc<Region>) -> Result<Self, Error> {
-        unsafe { Self::join_region_with(region, Layout::from_header::<T>) }
+        unsafe { Self::join_region_with(region, QueueLayout::from_header::<T>) }
     }
 
     /// Validates an initialized broadcast region and returns a handle without
@@ -276,12 +277,12 @@ impl SharedQueue {
     /// # Safety
     /// - `region` must reference memory laid out by [`Self::create_in_region`].
     unsafe fn join_region_untyped(region: &Arc<Region>) -> Result<Self, Error> {
-        unsafe { Self::join_region_with(region, Layout::from_header_payload) }
+        unsafe { Self::join_region_with(region, QueueLayout::from_header_payload) }
     }
 
     unsafe fn join_region_with(
         region: &Arc<Region>,
-        layout_from_header: impl FnOnce(&SharedQueueHeader, usize) -> Result<Layout, Error>,
+        layout_from_header: impl FnOnce(&SharedQueueHeader, usize) -> Result<QueueLayout, Error>,
     ) -> Result<Self, Error> {
         let header = region.addr().cast::<SharedQueueHeader>();
         // SAFETY: regions are page-aligned (>= align_of::<SharedQueueHeader>()).
@@ -301,7 +302,7 @@ impl SharedQueue {
 
     /// # Safety
     /// - `region` must be at least `layout.total` bytes and initialized once.
-    unsafe fn initialize(region: &Arc<Region>, layout: &Layout) {
+    unsafe fn initialize(region: &Arc<Region>, layout: &QueueLayout) {
         let base = region.addr();
 
         // Global consumer-ownership table: every index free.
@@ -327,7 +328,7 @@ impl SharedQueue {
         unsafe { SharedQueueHeader::init(header, layout) };
     }
 
-    fn from_region(region: Arc<Region>, layout: Layout) -> Self {
+    fn from_region(region: Arc<Region>, layout: QueueLayout) -> Self {
         let base = region.addr();
         let header = base.cast::<SharedQueueHeader>();
         // SAFETY: offsets lie within the region.
@@ -345,8 +346,7 @@ impl SharedQueue {
             capacity: layout.capacity,
             producer_slots: layout.producer_slots,
             block_stride: layout.block_stride,
-            payload_size: layout.payload_size,
-            payload_align: layout.payload_align,
+            payload: layout.payload_layout,
         }
     }
 
@@ -365,13 +365,7 @@ impl SharedQueue {
         };
         // SAFETY: the block was initialized with these parameters.
         unsafe {
-            ProducerLane::from_block(
-                block,
-                self.capacity,
-                self.consumer_slots(),
-                self.payload_size,
-                self.payload_align,
-            )
+            ProducerLane::from_block(block, self.capacity, self.consumer_slots(), self.payload)
         }
     }
 
@@ -443,7 +437,7 @@ impl SharedQueue {
     /// - `file` must be initialized as a queue at most once (by the designated
     ///   initializer) and not resized while any handle is joined.
     unsafe fn create<T>(file: &File, config: &BroadcastConfig) -> Result<Self, Error> {
-        let layout = Layout::new::<T>(config)?;
+        let layout = QueueLayout::new::<T>(config)?;
         file.set_len(layout.total as u64)?;
         let region = Region::map_file(file, layout.total)?;
         // SAFETY: caller guarantees this mapping is initialized exactly once.
@@ -484,8 +478,7 @@ impl Clone for SharedQueue {
             capacity: self.capacity,
             producer_slots: self.producer_slots,
             block_stride: self.block_stride,
-            payload_size: self.payload_size,
-            payload_align: self.payload_align,
+            payload: self.payload,
         }
     }
 }
@@ -887,7 +880,7 @@ impl ConsumerCore {
     }
 
     fn payload_size(&self) -> usize {
-        self.queue.payload_size
+        self.queue.payload.size()
     }
 
     #[inline]
@@ -1603,7 +1596,7 @@ mod tests {
     /// In-process (heap-backed) producer. The `Producer` keeps the region alive
     /// via its `SharedQueue`'s `Arc<Region>`.
     fn create_heap_producer(config: BroadcastConfig) -> Producer<Payload> {
-        let size = Layout::new::<Payload>(&config).expect("layout").total;
+        let size = QueueLayout::new::<Payload>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once here.
         let queue = unsafe { SharedQueue::create_in_region::<Payload>(&region, &config) }.unwrap();
@@ -1753,7 +1746,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        let size = Layout::new::<Payload>(&config).unwrap().total;
+        let size = QueueLayout::new::<Payload>(&config).unwrap().total;
         let file = create_temp_shmem_file().expect("temp file");
         file.set_len(size as u64).expect("set_len");
         // SAFETY: sized-but-zeroed file → magic mismatch.
@@ -1768,7 +1761,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        let size = Layout::new::<Payload>(&config).expect("layout").total;
+        let size = QueueLayout::new::<Payload>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once.
         let queue = unsafe { SharedQueue::create_in_region::<Payload>(&region, &config) }.unwrap();
@@ -1784,7 +1777,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        let size = Layout::new::<u64>(&config).expect("layout").total;
+        let size = QueueLayout::new::<u64>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once.
         unsafe { SharedQueue::create_in_region::<u64>(&region, &config) }.unwrap();
@@ -1877,7 +1870,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        assert!(Layout::new::<Payload>(&config).is_err());
+        assert!(QueueLayout::new::<Payload>(&config).is_err());
     }
 
     #[test]
@@ -1887,7 +1880,7 @@ mod tests {
             producer_slots: 1,
             consumer_slots: 1,
         };
-        assert!(Layout::new::<Payload>(&config).is_err());
+        assert!(QueueLayout::new::<Payload>(&config).is_err());
     }
 
     #[test]
@@ -2288,7 +2281,7 @@ mod tests {
     /// Allocates a heap-backed queue and returns the shared handle (recovery
     /// tests need the queue directly to simulate a crashed handle).
     fn recovery_queue(config: &BroadcastConfig) -> SharedQueue {
-        let size = Layout::new::<Payload>(config).expect("layout").total;
+        let size = QueueLayout::new::<Payload>(config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once.
         unsafe { SharedQueue::create_in_region::<Payload>(&region, config) }.unwrap()

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -129,11 +129,7 @@ struct QueueLayout {
 
 impl QueueLayout {
     fn new<T>(config: &BroadcastConfig) -> Result<Self, Error> {
-        Self::checked_new::<T>(config).ok_or(Error::InvalidBufferSize)
-    }
-
-    fn checked_new<T>(config: &BroadcastConfig) -> Option<Self> {
-        Self::checked_new_for_payload(config, Layout::new::<T>())
+        Self::checked_new_for_payload(config, Layout::new::<T>()).ok_or(Error::InvalidBufferSize)
     }
 
     fn new_for_payload(config: &BroadcastConfig, payload: Layout) -> Result<Self, Error> {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -794,6 +794,27 @@ impl<T> Drop for WriteBatch<'_, T> {
     }
 }
 
+/// A lane with published values past this consumer's cursor: `sequence` is the
+/// next unread sequence, `published` the publication that proved readability.
+/// The unread values stay protected from overwrite until the consumer calls
+/// [`ConsumerCore::advance`] for the lane.
+#[derive(Clone, Copy)]
+struct ReadableLane {
+    lane: usize,
+    sequence: usize,
+    published: usize,
+}
+
+impl ReadableLane {
+    /// Number of consecutive published values to read starting at `sequence`,
+    /// bounded by `max`.
+    fn count(&self, max: NonZeroUsize) -> NonZeroUsize {
+        let available = self.published.wrapping_sub(self.sequence);
+        let count = available.min(max.get());
+        NonZeroUsize::new(count).expect("readable lane has at least one value")
+    }
+}
+
 /// Shared consumer machinery: owns a consumer index, tracks one cursor per
 /// producer lane, and reserves raw payload pointers.
 struct ConsumerCore {
@@ -928,49 +949,9 @@ impl ConsumerCore {
         None
     }
 
-    /// Returns `(lane, payload)` for the next readable payload without advancing
-    /// this consumer's cursor.
-    ///
-    /// `lane` identifies which producer lane the payload came from. `payload`
-    /// points at the published cell for this consumer's current sequence on
-    /// that lane, and remains protected from overwrite until the caller later
-    /// calls [`Self::advance`] for the returned lane.
-    fn try_reserve_read(&mut self) -> Option<(usize, NonNull<u8>)> {
-        let readable = self.next_readable()?;
-        Some(self.reserve_read_at(readable))
-    }
-
-    fn reserve_read_at(&mut self, readable: ReadableLane) -> (usize, NonNull<u8>) {
-        let payload = self.lane(readable.lane).payload_ptr(readable.sequence);
-        (readable.lane, payload)
-    }
-
-    /// Returns `(lane, start, count)` for up to `max` consecutive readable
-    /// payloads from one producer lane without advancing this consumer's cursor.
-    ///
-    /// `lane` identifies the producer lane. `start` is the first sequence to
-    /// read on that lane. `count` is the number of consecutive published cells
-    /// reserved, bounded by both `max` and the lane's current publication. The
-    /// range `start..start + count` remains protected from overwrite until the
-    /// caller later calls [`Self::advance`] for the returned lane and count.
-    fn try_reserve_read_batch(
-        &mut self,
-        max: NonZeroUsize,
-    ) -> Option<(usize, usize, NonZeroUsize)> {
-        let readable = self.next_readable()?;
-        Some(self.reserve_read_batch_at(readable, max))
-    }
-
-    fn reserve_read_batch_at(
-        &mut self,
-        readable: ReadableLane,
-        max: NonZeroUsize,
-    ) -> (usize, usize, NonZeroUsize) {
-        // `next_readable` guarantees at least one published value past `sequence`.
-        let available = readable.published.wrapping_sub(readable.sequence);
-        let count = available.min(max.get());
-        let count = NonZeroUsize::new(count).expect("readable lane has at least one value");
-        (readable.lane, readable.sequence, count)
+    /// Pointer to the published cell at `readable`'s next unread sequence.
+    fn payload_ptr(&self, readable: ReadableLane) -> NonNull<u8> {
+        self.lane(readable.lane).payload_ptr(readable.sequence)
     }
 
     /// Advances this consumer's cursor on `lane` by `count` consumed values,
@@ -1018,13 +999,6 @@ unsafe impl Send for ConsumerCore {}
 pub struct Consumer<T> {
     core: ConsumerCore,
     _marker: PhantomData<T>,
-}
-
-#[derive(Clone, Copy)]
-struct ReadableLane {
-    lane: usize,
-    sequence: usize,
-    published: usize,
 }
 
 impl<T> Consumer<T> {
@@ -1126,12 +1100,13 @@ impl<T> Consumer<T> {
     where
         T: Copy,
     {
-        let (lane, payload) = self.core.try_reserve_read()?;
+        let readable = self.core.next_readable()?;
+        let payload = self.core.payload_ptr(readable);
         // SAFETY: `sequence < publication`, so the cell is published (initialized);
         // this consumer's cursor still protects it from being overwritten until we
         // advance below. The copy happens before the cursor advances.
         let value = unsafe { payload.cast::<T>().as_ptr().read() };
-        self.core.advance(lane, NonZeroUsize::MIN);
+        self.core.advance(readable.lane, NonZeroUsize::MIN);
         Some(value)
     }
 
@@ -1141,15 +1116,14 @@ impl<T> Consumer<T> {
     /// guard is dropped, which advances past it.
     #[must_use]
     pub fn try_reserve_read(&mut self) -> Option<ReadGuard<'_, T>> {
-        let readable = self.core.next_readable()?;
-        Some(self.reserve_read_at(readable))
+        Some(self.read_guard_for(self.core.next_readable()?))
     }
 
-    fn reserve_read_at(&mut self, readable: ReadableLane) -> ReadGuard<'_, T> {
-        let (lane, payload) = self.core.reserve_read_at(readable);
+    fn read_guard_for(&mut self, readable: ReadableLane) -> ReadGuard<'_, T> {
+        let payload = self.core.payload_ptr(readable);
         ReadGuard {
             consumer: &mut self.core,
-            lane,
+            lane: readable.lane,
             payload: payload.cast(),
         }
     }
@@ -1162,27 +1136,15 @@ impl<T> Consumer<T> {
     /// is dropped, which advances past the whole batch.
     #[must_use]
     pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
-        let (lane, start, count) = self.core.try_reserve_read_batch(max)?;
-        Some(ReadBatch {
-            consumer: &mut self.core,
-            lane,
-            start,
-            count,
-            _marker: PhantomData,
-        })
+        Some(self.read_batch_for(self.core.next_readable()?, max))
     }
 
-    fn reserve_read_batch_at(
-        &mut self,
-        readable: ReadableLane,
-        max: NonZeroUsize,
-    ) -> ReadBatch<'_, T> {
-        let (lane, start, count) = self.core.reserve_read_batch_at(readable, max);
+    fn read_batch_for(&mut self, readable: ReadableLane, max: NonZeroUsize) -> ReadBatch<'_, T> {
         ReadBatch {
             consumer: &mut self.core,
-            lane,
-            start,
-            count,
+            lane: readable.lane,
+            start: readable.sequence,
+            count: readable.count(max),
             _marker: PhantomData,
         }
     }
@@ -1193,8 +1155,7 @@ impl<T> Consumer<T> {
         &mut self,
         timeout: Duration,
     ) -> Result<ReadGuard<'_, T>, WaitError> {
-        let readable = self.core.wait_until_readable(timeout)?;
-        Ok(self.reserve_read_at(readable))
+        Ok(self.read_guard_for(self.core.wait_until_readable(timeout)?))
     }
 
     /// Blocks until any lane has unread values or `timeout` elapses, then returns
@@ -1204,8 +1165,7 @@ impl<T> Consumer<T> {
         max: NonZeroUsize,
         timeout: Duration,
     ) -> Result<ReadBatch<'_, T>, WaitError> {
-        let readable = self.core.wait_until_readable(timeout)?;
-        Ok(self.reserve_read_batch_at(readable, max))
+        Ok(self.read_batch_for(self.core.wait_until_readable(timeout)?, max))
     }
 
     /// Blocks until any lane has an unread value or `timeout` elapses, then
@@ -1417,16 +1377,15 @@ impl SliceConsumer {
     /// Alias for [`Self::try_read`].
     #[must_use]
     pub fn try_reserve_read(&mut self) -> Option<SliceReadGuard<'_>> {
-        let readable = self.core.next_readable()?;
-        Some(self.reserve_read_at(readable))
+        Some(self.read_guard_for(self.core.next_readable()?))
     }
 
-    fn reserve_read_at(&mut self, readable: ReadableLane) -> SliceReadGuard<'_> {
-        let (lane, payload) = self.core.reserve_read_at(readable);
+    fn read_guard_for(&mut self, readable: ReadableLane) -> SliceReadGuard<'_> {
+        let payload = self.core.payload_ptr(readable);
         let len = self.core.payload_size();
         SliceReadGuard {
             consumer: &mut self.core,
-            lane,
+            lane: readable.lane,
             payload,
             len,
         }
@@ -1436,29 +1395,16 @@ impl SliceConsumer {
     /// readable lane, or `None` if every lane is caught up.
     #[must_use]
     pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<SliceReadBatch<'_>> {
-        let (lane, start, count) = self.core.try_reserve_read_batch(max)?;
-        let payload_size = self.core.payload_size();
-        Some(SliceReadBatch {
-            consumer: &mut self.core,
-            lane,
-            start,
-            count,
-            payload_size,
-        })
+        Some(self.read_batch_for(self.core.next_readable()?, max))
     }
 
-    fn reserve_read_batch_at(
-        &mut self,
-        readable: ReadableLane,
-        max: NonZeroUsize,
-    ) -> SliceReadBatch<'_> {
-        let (lane, start, count) = self.core.reserve_read_batch_at(readable, max);
+    fn read_batch_for(&mut self, readable: ReadableLane, max: NonZeroUsize) -> SliceReadBatch<'_> {
         let payload_size = self.core.payload_size();
         SliceReadBatch {
             consumer: &mut self.core,
-            lane,
-            start,
-            count,
+            lane: readable.lane,
+            start: readable.sequence,
+            count: readable.count(max),
             payload_size,
         }
     }
@@ -1475,8 +1421,7 @@ impl SliceConsumer {
         &mut self,
         timeout: Duration,
     ) -> Result<SliceReadGuard<'_>, WaitError> {
-        let readable = self.core.wait_until_readable(timeout)?;
-        Ok(self.reserve_read_at(readable))
+        Ok(self.read_guard_for(self.core.wait_until_readable(timeout)?))
     }
 
     /// Blocks until any lane has unread payloads or `timeout` elapses, then
@@ -1486,8 +1431,7 @@ impl SliceConsumer {
         max: NonZeroUsize,
         timeout: Duration,
     ) -> Result<SliceReadBatch<'_>, WaitError> {
-        let readable = self.core.wait_until_readable(timeout)?;
-        Ok(self.reserve_read_batch_at(readable, max))
+        Ok(self.read_batch_for(self.core.wait_until_readable(timeout)?, max))
     }
 }
 

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -29,16 +29,18 @@ struct LaneHeader {
 /// A single producer's lane.
 ///
 /// The lane holds ownership state, the reserve/publication cursors, the
-/// per-lane consumer reserve-limit state, and the ring of `T`. The owning
+/// per-lane consumer reserve-limit state, and the ring of fixed-size payload
+/// cells. The owning
 /// producer mutates the ring and producer cursors (`&mut self`); consumers read
 /// published payloads and publish their own progress through [`LaneConsumerState`].
 ///
 /// Block layout: `LaneHeader`, then `[CacheAlignedAtomicSize; consumer_slots]`
-/// limits (one per cache line), then `[T; capacity]`.
-pub(crate) struct ProducerLane<T> {
+/// limits (one per cache line), then the payload ring.
+pub(crate) struct ProducerLane {
     header: NonNull<LaneHeader>,
     consumer_state: LaneConsumerState,
-    ring: NonNull<T>,
+    ring: NonNull<u8>,
+    payload_size: usize,
 
     mask: usize, // capacity - 1
 }
@@ -48,35 +50,34 @@ const fn consumer_state_offset() -> usize {
     size_of::<LaneHeader>().next_multiple_of(LaneConsumerState::block_align())
 }
 
-#[inline]
-fn ring_offset<T>(consumer_slots: usize) -> Option<usize> {
-    consumer_state_offset()
-        .checked_add(LaneConsumerState::block_size(consumer_slots)?)?
-        .checked_next_multiple_of(align_of::<T>())
-}
-
-impl<T> ProducerLane<T> {
-    /// Bytes needed for one lane block of `capacity` payload cells and
-    /// `consumer_slots` consumer slots.
-    pub(crate) fn block_size(capacity: u32, consumer_slots: usize) -> Option<usize> {
-        ring_offset::<T>(consumer_slots)?
-            .checked_add((capacity as usize).checked_mul(size_of::<T>())?)
+pub(crate) fn ring_offset_for_payload(
+    consumer_slots: usize,
+    payload_align: usize,
+) -> Option<usize> {
+    if payload_align == 0
+        || !payload_align.is_power_of_two()
+        || payload_align > ProducerLane::block_align()
+    {
+        return None;
     }
 
-    /// Required alignment of a lane block: the `LaneHeader`'s alignment.
-    ///
-    /// The block starts with the `LaneHeader`; the trailing `[T]` ring is aligned
-    /// by its offset within the block (`ring_offset` is a multiple of
-    /// `align_of::<T>()`), so the block itself only needs the header's alignment —
-    /// as long as `T`'s alignment divides it, which holds for any normal payload
-    /// (alignment ≤ 64). Asserted so an over-aligned `T` is a clear compile error.
+    consumer_state_offset()
+        .checked_add(LaneConsumerState::block_size(consumer_slots)?)?
+        .checked_next_multiple_of(payload_align)
+}
+
+pub(crate) fn block_size_for_payload(
+    capacity: u32,
+    consumer_slots: usize,
+    payload_size: usize,
+    payload_align: usize,
+) -> Option<usize> {
+    ring_offset_for_payload(consumer_slots, payload_align)?
+        .checked_add((capacity as usize).checked_mul(payload_size)?)
+}
+
+impl ProducerLane {
     pub(crate) const fn block_align() -> usize {
-        const {
-            assert!(
-                align_of::<T>() <= align_of::<LaneHeader>(),
-                "payload alignment exceeds the lane header alignment",
-            );
-        }
         align_of::<LaneHeader>()
     }
 
@@ -85,8 +86,9 @@ impl<T> ProducerLane<T> {
     /// published, and read only after).
     ///
     /// # Safety
-    /// - `block` must point at a [`Self::block_size`] region for `(capacity,
-    ///   consumer_slots)` and be initialized at most once.
+    /// - `block` must point at a [`block_size_for_payload`] region for the
+    ///   queue's `(capacity, consumer_slots, payload_size, payload_align)` and
+    ///   be initialized at most once.
     pub(crate) unsafe fn init(block: NonNull<u8>, consumer_slots: usize) {
         // SAFETY: `block` begins with a `LaneHeader`.
         unsafe {
@@ -106,11 +108,14 @@ impl<T> ProducerLane<T> {
     ///
     /// # Safety
     /// - `block` must reference a block initialized by [`Self::init`] with the
-    ///   same `consumer_slots`, sized for `capacity`, alive for the view's use.
+    ///   same `consumer_slots`, sized for `(capacity, payload_size,
+    ///   payload_align)`, alive for the view's use.
     pub(crate) unsafe fn from_block(
         block: NonNull<u8>,
         capacity: u32,
         consumer_slots: usize,
+        payload_size: usize,
+        payload_align: usize,
     ) -> Self {
         debug_assert!(capacity.is_power_of_two());
 
@@ -127,14 +132,17 @@ impl<T> ProducerLane<T> {
         // SAFETY: `block` is an initialized region - it must be large enough
         //         for ring data to fit (if init succeeded).
         let ring = unsafe {
-            block.byte_add(ring_offset::<T>(consumer_slots).expect("validated_lane layout"))
-        }
-        .cast();
+            block.byte_add(
+                ring_offset_for_payload(consumer_slots, payload_align)
+                    .expect("validated_lane layout"),
+            )
+        };
 
         Self {
             header,
             consumer_state,
             ring,
+            payload_size,
             mask: (capacity as usize).wrapping_sub(1),
         }
     }
@@ -158,9 +166,11 @@ impl<T> ProducerLane<T> {
     /// Pointer to the ring cell holding `sequence` — used by the producer to
     /// write a reserved cell and by consumers to read a published one.
     #[inline]
-    pub(crate) fn payload_ptr(&self, sequence: usize) -> NonNull<T> {
-        // SAFETY: `sequence & mask < capacity`; the ring has `capacity` cells.
-        unsafe { self.ring.add(sequence & self.mask) }
+    pub(crate) fn payload_ptr(&self, sequence: usize) -> NonNull<u8> {
+        let offset = (sequence & self.mask).wrapping_mul(self.payload_size);
+        // SAFETY: `sequence & mask < capacity`; the ring has `capacity` cells of
+        // `payload_size` bytes. Zero-sized payloads always point at the ring base.
+        unsafe { self.ring.byte_add(offset) }
     }
 
     /// Claims the lane for a producer. Returns `false` if already owned.
@@ -270,30 +280,36 @@ mod tests {
     type Payload = u64;
 
     /// Allocates and initializes a standalone lane block.
-    fn lane(
-        capacity: u32,
-        consumer_slots: usize,
-    ) -> (std::sync::Arc<Region>, ProducerLane<Payload>) {
-        let size = ProducerLane::<Payload>::block_size(capacity, consumer_slots).unwrap();
+    fn lane(capacity: u32, consumer_slots: usize) -> (std::sync::Arc<Region>, ProducerLane) {
+        let size = block_size_for_payload(
+            capacity,
+            consumer_slots,
+            size_of::<Payload>(),
+            align_of::<Payload>(),
+        )
+        .unwrap();
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
         // SAFETY: freshly allocated block, initialized once.
-        unsafe { ProducerLane::<Payload>::init(region.addr(), consumer_slots) };
+        unsafe { ProducerLane::init(region.addr(), consumer_slots) };
         // SAFETY: just initialized with these parameters.
-        let lane =
-            unsafe { ProducerLane::<Payload>::from_block(region.addr(), capacity, consumer_slots) };
+        let lane = unsafe {
+            ProducerLane::from_block(
+                region.addr(),
+                capacity,
+                consumer_slots,
+                size_of::<Payload>(),
+                align_of::<Payload>(),
+            )
+        };
         (region, lane)
     }
 
-    fn read(lane: &ProducerLane<Payload>, sequence: usize) -> Payload {
+    fn read(lane: &ProducerLane, sequence: usize) -> Payload {
         // SAFETY: `sequence` was published, so its cell is initialized.
-        unsafe { lane.payload_ptr(sequence).as_ptr().read() }
+        unsafe { lane.payload_ptr(sequence).cast::<Payload>().as_ptr().read() }
     }
 
-    fn join_consumer(
-        lane: &ProducerLane<Payload>,
-        consumer_index: usize,
-        from_backlog: bool,
-    ) -> usize {
+    fn join_consumer(lane: &ProducerLane, consumer_index: usize, from_backlog: bool) -> usize {
         let consumer_state = lane.consumer_state();
         consumer_state.join(consumer_index, from_backlog, lane.published(), || {
             lane.reserved()
@@ -301,13 +317,18 @@ mod tests {
     }
 
     /// Reserves, writes, and publishes one value; `false` on backpressure.
-    fn publish_value(lane: &mut ProducerLane<Payload>, value: Payload) -> bool {
+    fn publish_value(lane: &mut ProducerLane, value: Payload) -> bool {
         let one = NonZeroUsize::new(1).unwrap();
         let Some(start) = lane.try_reserve(one) else {
             return false;
         };
         // SAFETY: the cell is reserved and not yet published.
-        unsafe { lane.payload_ptr(start).as_ptr().write(value) };
+        unsafe {
+            lane.payload_ptr(start)
+                .cast::<Payload>()
+                .as_ptr()
+                .write(value)
+        };
         lane.publish(start, one);
         true
     }
@@ -345,6 +366,7 @@ mod tests {
             // SAFETY: each cell in the batch is reserved and unpublished.
             unsafe {
                 lane.payload_ptr(start.wrapping_add(offset))
+                    .cast::<Payload>()
                     .as_ptr()
                     .write((offset as u64) + 1)
             };

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -90,14 +90,14 @@ impl ProducerLane {
     ///   queue's `(capacity, consumer_slots, payload_size, payload_align)` and
     ///   be initialized at most once.
     pub(crate) unsafe fn init(block: NonNull<u8>, consumer_slots: usize) {
+        let header = LaneHeader {
+            state: AtomicU64::new(LANE_FREE),
+            producer_reservation: CacheAlignedAtomicSize::default(),
+            producer_publication: CacheAlignedAtomicSize::default(),
+        };
+        let header_ptr = block.cast::<LaneHeader>().as_ptr();
         // SAFETY: `block` begins with a `LaneHeader`.
-        unsafe {
-            block.cast::<LaneHeader>().as_ptr().write(LaneHeader {
-                state: AtomicU64::new(LANE_FREE),
-                producer_reservation: CacheAlignedAtomicSize::default(),
-                producer_publication: CacheAlignedAtomicSize::default(),
-            });
-        }
+        unsafe { header_ptr.write(header) };
         // SAFETY: layout reserves `consumer_slots` aligned slots here.
         let consumer_state = unsafe { block.byte_add(consumer_state_offset()) };
         // SAFETY: freshly initialized lane block; consumer slots are initialized once.
@@ -122,21 +122,17 @@ impl ProducerLane {
         let header = block.cast();
         // SAFETY: `block` is an initialized region - it must be large enough
         //         for consumer state to fit (if init succeeded).
+        let consumer_state_block = unsafe { block.byte_add(consumer_state_offset()) };
+        // SAFETY: `block` is an initialized region - it must be large enough
+        //         for consumer state to fit (if init succeeded).
         let consumer_state = unsafe {
-            LaneConsumerState::from_block(
-                block.byte_add(consumer_state_offset()),
-                consumer_slots,
-                capacity as usize,
-            )
+            LaneConsumerState::from_block(consumer_state_block, consumer_slots, capacity as usize)
         };
+        let ring_offset =
+            ring_offset_for_payload(consumer_slots, payload_align).expect("validated_lane layout");
         // SAFETY: `block` is an initialized region - it must be large enough
         //         for ring data to fit (if init succeeded).
-        let ring = unsafe {
-            block.byte_add(
-                ring_offset_for_payload(consumer_slots, payload_align)
-                    .expect("validated_lane layout"),
-            )
-        };
+        let ring = unsafe { block.byte_add(ring_offset) };
 
         Self {
             header,

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -2,6 +2,7 @@
 //! ownership state, its reserve/publication cursors, the per-consumer reserve
 //! limits, and the ring of payloads. See [`ProducerLane`].
 
+use core::alloc::Layout;
 use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
@@ -52,28 +53,24 @@ const fn consumer_state_offset() -> usize {
 
 pub(crate) fn ring_offset_for_payload(
     consumer_slots: usize,
-    payload_align: usize,
+    payload_layout: Layout,
 ) -> Option<usize> {
-    if payload_align == 0
-        || !payload_align.is_power_of_two()
-        || payload_align > ProducerLane::block_align()
-    {
+    if payload_layout.align() > ProducerLane::block_align() {
         return None;
     }
 
     consumer_state_offset()
         .checked_add(LaneConsumerState::block_size(consumer_slots)?)?
-        .checked_next_multiple_of(payload_align)
+        .checked_next_multiple_of(payload_layout.align())
 }
 
 pub(crate) fn block_size_for_payload(
     capacity: u32,
     consumer_slots: usize,
-    payload_size: usize,
-    payload_align: usize,
+    payload_layout: Layout,
 ) -> Option<usize> {
-    ring_offset_for_payload(consumer_slots, payload_align)?
-        .checked_add((capacity as usize).checked_mul(payload_size)?)
+    ring_offset_for_payload(consumer_slots, payload_layout)?
+        .checked_add((capacity as usize).checked_mul(payload_layout.size())?)
 }
 
 impl ProducerLane {
@@ -87,8 +84,8 @@ impl ProducerLane {
     ///
     /// # Safety
     /// - `block` must point at a [`block_size_for_payload`] region for the
-    ///   queue's `(capacity, consumer_slots, payload_size, payload_align)` and
-    ///   be initialized at most once.
+    ///   queue's `(capacity, consumer_slots, payload_layout)` and be initialized
+    ///   at most once.
     pub(crate) unsafe fn init(block: NonNull<u8>, consumer_slots: usize) {
         let header = LaneHeader {
             state: AtomicU64::new(LANE_FREE),
@@ -108,14 +105,13 @@ impl ProducerLane {
     ///
     /// # Safety
     /// - `block` must reference a block initialized by [`Self::init`] with the
-    ///   same `consumer_slots`, sized for `(capacity, payload_size,
-    ///   payload_align)`, alive for the view's use.
+    ///   same `consumer_slots`, sized for `(capacity, payload_layout)`, alive
+    ///   for the view's use.
     pub(crate) unsafe fn from_block(
         block: NonNull<u8>,
         capacity: u32,
         consumer_slots: usize,
-        payload_size: usize,
-        payload_align: usize,
+        payload_layout: Layout,
     ) -> Self {
         debug_assert!(capacity.is_power_of_two());
 
@@ -129,7 +125,7 @@ impl ProducerLane {
             LaneConsumerState::from_block(consumer_state_block, consumer_slots, capacity as usize)
         };
         let ring_offset =
-            ring_offset_for_payload(consumer_slots, payload_align).expect("validated_lane layout");
+            ring_offset_for_payload(consumer_slots, payload_layout).expect("validated_lane layout");
         // SAFETY: `block` is an initialized region - it must be large enough
         //         for ring data to fit (if init succeeded).
         let ring = unsafe { block.byte_add(ring_offset) };
@@ -138,7 +134,7 @@ impl ProducerLane {
             header,
             consumer_state,
             ring,
-            payload_size,
+            payload_size: payload_layout.size(),
             mask: (capacity as usize).wrapping_sub(1),
         }
     }
@@ -277,25 +273,14 @@ mod tests {
 
     /// Allocates and initializes a standalone lane block.
     fn lane(capacity: u32, consumer_slots: usize) -> (std::sync::Arc<Region>, ProducerLane) {
-        let size = block_size_for_payload(
-            capacity,
-            consumer_slots,
-            size_of::<Payload>(),
-            align_of::<Payload>(),
-        )
-        .unwrap();
+        let payload_layout = Layout::new::<Payload>();
+        let size = block_size_for_payload(capacity, consumer_slots, payload_layout).unwrap();
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).unwrap();
         // SAFETY: freshly allocated block, initialized once.
         unsafe { ProducerLane::init(region.addr(), consumer_slots) };
         // SAFETY: just initialized with these parameters.
         let lane = unsafe {
-            ProducerLane::from_block(
-                region.addr(),
-                capacity,
-                consumer_slots,
-                size_of::<Payload>(),
-                align_of::<Payload>(),
-            )
+            ProducerLane::from_block(region.addr(), capacity, consumer_slots, payload_layout)
         };
         (region, lane)
     }


### PR DESCRIPTION
### Problem
- An intended use-case of this is to serialize events (google-flatbuffers) and have slowlana read them w/o re-compiling.
	- slowlana does not know the size/align if it doesn't re-compile


### Solution
- Store size/slign of T in the header
- Add SliceConsumer that allows consuming by slice of runtime-length instead of a T 