### PR TITLE
mpmc: MaybeUninit interface. consistent naming

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -359,7 +359,7 @@ fn run_mpmc_producer(
         for index in 0..batch.len() {
             // SAFETY: reserve_batch() yields valid contiguous slots.
             unsafe {
-                batch.as_mut(index).data.fill(42);
+                batch.as_mut(index).write(Item { data: [42u8; _] });
             }
         }
         Some(batch.len())
@@ -492,7 +492,7 @@ fn run_broadcast_producer(
         };
         for index in 0..batch.len() {
             // SAFETY: `index < len`; the reserved cell is ours to initialize.
-            unsafe { batch.as_mut_ref(index).write(Item { data: [42; 512] }) };
+            unsafe { batch.as_mut(index).write(Item { data: [42; 512] }) };
         }
         Some(batch.len())
     });

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -622,13 +622,15 @@ pub struct WriteGuard<'a, T> {
     start: usize,
 }
 
-impl<T> WriteGuard<'_, T> {
+impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
     /// Mutable reference to the reserved cell.
-    pub fn as_mut_ref(&mut self) -> &mut MaybeUninit<T> {
+    fn as_mut(&mut self) -> &mut MaybeUninit<T> {
         // SAFETY: forwarded; the cell is reserved for this producer.
         unsafe { &mut *self.producer.lane.payload_ptr(self.start).as_ptr().cast() }
     }
+}
 
+impl<T> WriteGuard<'_, T> {
     /// Writes `value` into the reserved cell; the guard publishes it on drop.
     pub fn write(self, value: T) {
         // SAFETY: the cell is reserved and not yet published; `T` is moved in.
@@ -671,7 +673,7 @@ impl<T> WriteBatch<'_, T> {
     ///
     /// # Safety
     /// - `index < len`.
-    pub unsafe fn as_mut_ref(&mut self, index: usize) -> &mut MaybeUninit<T> {
+    pub unsafe fn as_mut(&mut self, index: usize) -> &mut MaybeUninit<T> {
         debug_assert!(index < self.count.get());
         let ptr = self
             .producer
@@ -688,7 +690,7 @@ impl<T> WriteBatch<'_, T> {
     /// - `index < len`.
     pub unsafe fn write(&mut self, index: usize, value: T) {
         // SAFETY: forwarded; `index < len` and the cell is reserved.
-        unsafe { self.as_mut_ref(index).write(value) };
+        unsafe { self.as_mut(index).write(value) };
     }
 }
 
@@ -1101,26 +1103,19 @@ impl<T> ReadBatch<'_, T> {
         false
     }
 
-    /// Pointer to the value at `index`.
-    ///
-    /// # Safety
-    /// - `index < len`.
-    pub unsafe fn as_ptr(&self, index: usize) -> *const T {
-        debug_assert!(index < self.count.get());
-        self.consumer
-            .lane(self.lane)
-            .payload_ptr(self.start.wrapping_add(index))
-            .as_ptr()
-    }
-
     /// Reference to the value at `index`.
     ///
     /// # Safety
     /// - `index < len`
     pub unsafe fn as_ref(&self, index: usize) -> &T {
+        debug_assert!(index < self.count.get());
         // SAFETY: the cell is published and held by this consumer's
         // cursor.
-        unsafe { &*self.as_ptr(index) }
+        unsafe {
+            &*self.consumer.lanes[self.lane]
+                .payload_ptr(self.start.wrapping_add(index))
+                .as_ptr()
+        }
     }
 
     /// Copies the value at `index` out.
@@ -1131,9 +1126,15 @@ impl<T> ReadBatch<'_, T> {
     where
         T: Copy,
     {
-        // SAFETY: forwarded; the cell is published and held by this consumer's
-        // cursor until the batch is dropped.
-        unsafe { self.as_ptr(index).read() }
+        debug_assert!(index < self.count.get());
+        // SAFETY: the cell is published and held by this consumer's
+        // cursor.
+        unsafe {
+            self.consumer.lanes[self.lane]
+                .payload_ptr(self.start.wrapping_add(index))
+                .as_ptr()
+                .read()
+        }
     }
 }
 
@@ -1501,7 +1502,7 @@ mod tests {
             {
                 // SAFETY: the reserved slot is initialized before `guard` is dropped.
                 let mut guard = unsafe { p.try_reserve_write() }.unwrap();
-                guard.as_mut_ref().write(42);
+                guard.as_mut().write(42);
             }
             // `write` consumes the guard and publishes on drop too.
             // SAFETY: `write` initializes the reserved slot before publishing.
@@ -1616,7 +1617,7 @@ mod tests {
         let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
 
         assert!(consumer.try_reserve_read().is_none());
-        guard.as_mut_ref().write(42);
+        guard.as_mut().write(42);
         drop(guard);
 
         assert_eq!(consumer.try_read(), Some(42));

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -7,7 +7,7 @@ use crate::{
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
 };
-use core::{marker::PhantomData, ptr::NonNull, sync::atomic::Ordering};
+use core::{marker::PhantomData, mem::MaybeUninit, ptr::NonNull, sync::atomic::Ordering};
 use std::{
     fs::File,
     num::NonZeroUsize,
@@ -800,20 +800,15 @@ pub struct WriteGuard<'a, T> {
     _marker: PhantomData<&'a mut T>,
 }
 
-impl<'a, T> WriteGuard<'a, T> {
-    /// Returns a mutable reference to the slot.
-    ///
-    /// # Safety
-    /// - T must be be valid for any bytes.
-    pub unsafe fn as_mut_ref(&mut self) -> &mut T {
+impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
+    /// Mutable reference to the reserved cell.
+    fn as_mut(&mut self) -> &mut MaybeUninit<T> {
         // SAFETY: The cell was reserved for writing.
-        unsafe { self.cell.as_mut() }
+        unsafe { &mut *self.cell.as_ptr().cast() }
     }
+}
 
-    pub fn as_mut_ptr(&mut self) -> *mut T {
-        self.cell.as_ptr()
-    }
-
+impl<'a, T> WriteGuard<'a, T> {
     pub fn write(self, value: T) {
         // SAFETY: The cell was reserved for writing.
         unsafe { self.cell.as_ptr().write(value) };
@@ -842,11 +837,6 @@ pub struct ReadGuard<'a, T> {
 }
 
 impl<'a, T> ReadGuard<'a, T> {
-    pub fn as_ptr(&self) -> *const T {
-        // SAFETY: The cell was reserved for reading.
-        self.cell.as_ptr()
-    }
-
     pub fn read(self) -> T {
         // SAFETY: The cell was reserved for reading and holds an initialized value.
         unsafe { self.cell.as_ptr().read() }
@@ -900,23 +890,11 @@ impl<'a, T> WriteBatch<'a, T> {
     /// - The slot is uninitialized; caller must fully initialize `T`.
     /// - `index < count`
     /// - `T` must be valid for any bytes.
-    pub unsafe fn as_mut(&mut self, index: usize) -> &mut T {
+    pub unsafe fn as_mut(&mut self, index: usize) -> &mut MaybeUninit<T> {
         debug_assert!(index < self.count.get());
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for writing.
-        unsafe { self.buffer.add(position & self.buffer_mask).as_mut() }
-    }
-
-    /// Returns a mutable pointer to the reserved slot.
-    ///
-    /// # Safety
-    /// - The slot is uninitialized; caller must fully initialize `T`.
-    /// - `index < count`
-    pub unsafe fn as_mut_ptr(&mut self, index: usize) -> *mut T {
-        debug_assert!(index < self.count.get());
-        let position = self.start.wrapping_add(index);
-        // SAFETY: The position was reserved for writing.
-        unsafe { self.buffer.add(position & self.buffer_mask).as_ptr() }
+        unsafe { self.buffer.add(position & self.buffer_mask).cast().as_mut() }
     }
 
     /// Writes a value into the slot at index.
@@ -969,17 +947,6 @@ impl<'a, T> ReadBatch<'a, T> {
         let position = self.start.wrapping_add(index);
         // SAFETY: The position was reserved for reading and is initialized.
         unsafe { self.buffer.add(position & self.buffer_mask).as_ref() }
-    }
-
-    /// Returns a pointer to the reserved slot.
-    ///
-    /// # Safety
-    /// - `index` must be less than `self.len()`
-    pub unsafe fn as_ptr(&self, index: usize) -> *const T {
-        debug_assert!(index < self.count.get());
-        let position = self.start.wrapping_add(index);
-        // SAFETY: The position was reserved for reading.
-        unsafe { self.buffer.add(position & self.buffer_mask).as_ptr() }
     }
 
     /// Read the value at index
@@ -1124,16 +1091,12 @@ mod tests {
             let (producer, consumer) = create_queue(BUFFER_CAPACITY);
 
             let mut guard = unsafe { producer.try_reserve_write() }.expect("reserve failed");
-            unsafe {
-                *guard.as_mut_ptr() = 42;
-            }
+            guard.as_mut().write(42);
             drop(guard);
 
             let guard = consumer.try_reserve_read().expect("try_read_ptr failed");
-            unsafe {
-                assert_eq!(*guard.as_ptr(), 42);
-            }
             assert_eq!(*guard.as_ref(), 42);
+            assert_eq!(guard.read(), 42);
         }
     }
 
@@ -1147,7 +1110,7 @@ mod tests {
                 .expect("reserve_batch failed");
             for index in 0..batch.len() {
                 unsafe {
-                    *batch.as_mut_ptr(index) = index as u64;
+                    batch.as_mut(index).write(index as u64);
                 }
             }
             drop(batch);
@@ -1157,7 +1120,7 @@ mod tests {
                 .expect("try_read_batch failed");
             for index in 0..batch.len() {
                 unsafe {
-                    assert_eq!(*batch.as_ptr(index), index as u64);
+                    assert_eq!(*batch.as_ref(index), index as u64);
                 }
                 assert_eq!(unsafe { batch.read(index) }, index as u64);
             }
@@ -1185,7 +1148,7 @@ mod tests {
             for index in 0..batch.len() {
                 // SAFETY: `batch` has exactly 4 readable items.
                 unsafe {
-                    assert_eq!(*batch.as_ptr(index), index as u64);
+                    assert_eq!(*batch.as_ref(index), index as u64);
                 }
             }
         }
@@ -1392,9 +1355,7 @@ mod tests {
             producer.try_write(10).unwrap();
 
             let mut guard = unsafe { producer.try_reserve_write() }.expect("reserve write");
-            unsafe {
-                guard.as_mut_ptr().write(99);
-            }
+            guard.as_mut().write(99);
             core::mem::forget(guard);
 
             unsafe {


### PR DESCRIPTION
### Problem
- Interface and naming between mpmc/broadcast guards is inconsistent

### Summary of Changes
- Guard interfaces/naming symmetry for broadcast/mpmc


Fixes #87 