### PR TITLE
refactor: remove manual as_ref/as_mut/as_ptr

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -717,8 +717,9 @@ pub struct WriteGuard<'a, T> {
 impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
     /// Mutable reference to the reserved cell.
     fn as_mut(&mut self) -> &mut MaybeUninit<T> {
+        let mut ptr = self.producer.lane.payload_ptr(self.start).cast();
         // SAFETY: forwarded; the cell is reserved for this producer.
-        unsafe { &mut *self.producer.lane.payload_ptr(self.start).as_ptr().cast() }
+        unsafe { ptr.as_mut() }
     }
 }
 
@@ -767,14 +768,13 @@ impl<T> WriteBatch<'_, T> {
     /// - `index < len`.
     pub unsafe fn as_mut(&mut self, index: usize) -> &mut MaybeUninit<T> {
         debug_assert!(index < self.count.get());
-        let ptr = self
+        let mut ptr = self
             .producer
             .lane
             .payload_ptr(self.start.wrapping_add(index))
-            .cast::<T>()
-            .as_ptr();
+            .cast();
         // SAFETY: forwarded; the cell is reserved for this producer.
-        unsafe { &mut *ptr.cast() }
+        unsafe { ptr.as_mut() }
     }
 
     /// Writes `value` into the reserved cell at `index`.
@@ -1247,11 +1247,10 @@ impl<T> ReadBatch<'_, T> {
         debug_assert!(index < self.count.get());
         let ptr = self.consumer.lanes[self.lane]
             .payload_ptr(self.start.wrapping_add(index))
-            .as_ptr()
             .cast();
         // SAFETY: the cell is published and held by this consumer's
         // cursor.
-        unsafe { &*ptr }
+        unsafe { ptr.as_ref() }
     }
 
     /// Copies the value at `index` out.

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -36,7 +36,6 @@ use core::marker::PhantomData;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
-use core::slice;
 use core::sync::atomic::{AtomicU64, Ordering};
 use std::fs::File;
 use std::mem::MaybeUninit;
@@ -102,9 +101,8 @@ impl SharedQueueHeader {
             waiters: Waiters::default(),
             wake_seq: CacheAlignedAtomicSize::default(),
         };
-        let header_ptr = header.as_ptr();
         // SAFETY: caller guarantees valid, uniquely-owned storage for the header.
-        unsafe { header_ptr.write(value) };
+        unsafe { header.write(value) };
 
         // Publish initialization last.
         // SAFETY: the header was initialized by the write above.
@@ -318,7 +316,7 @@ impl SharedQueue {
 
         // Header initialization publishes the queue, so it runs after every
         // other region section is initialized.
-        let header = base.cast::<SharedQueueHeader>();
+        let header = base.cast();
         // SAFETY: region is page-aligned, large enough for the header, uniquely
         // initialized here, and all non-header sections are initialized above.
         unsafe { SharedQueueHeader::init(header, layout) };
@@ -326,7 +324,7 @@ impl SharedQueue {
 
     fn from_region(region: Arc<Region>, layout: QueueLayout) -> Self {
         let base = region.addr();
-        let header = base.cast::<SharedQueueHeader>();
+        let header = base.cast();
         // SAFETY: offsets lie within the region.
         let consumer_state_block = unsafe { base.byte_add(layout.consumer_state_offset) };
         // SAFETY: offsets lie within the region.
@@ -726,12 +724,7 @@ impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
 impl<T> WriteGuard<'_, T> {
     /// Writes `value` into the reserved cell; the guard publishes it on drop.
     pub fn write(self, value: T) {
-        let ptr = self
-            .producer
-            .lane
-            .payload_ptr(self.start)
-            .cast::<T>()
-            .as_ptr();
+        let ptr = self.producer.lane.payload_ptr(self.start).cast();
         // SAFETY: the cell is reserved and not yet published; `T` is moved in.
         unsafe { ptr.write(value) };
     }
@@ -1105,7 +1098,7 @@ impl<T> Consumer<T> {
         // SAFETY: `sequence < publication`, so the cell is published (initialized);
         // this consumer's cursor still protects it from being overwritten until we
         // advance below. The copy happens before the cursor advances.
-        let value = unsafe { payload.cast::<T>().as_ptr().read() };
+        let value = unsafe { payload.cast().read() };
         self.core.advance(readable.lane, NonZeroUsize::MIN);
         Some(value)
     }
@@ -1200,7 +1193,7 @@ impl<T> ReadGuard<'_, T> {
         T: Copy,
     {
         // SAFETY: the cell is published and held by this consumer's cursor.
-        unsafe { self.payload.as_ptr().read() }
+        unsafe { self.payload.read() }
     }
 }
 
@@ -1264,8 +1257,7 @@ impl<T> ReadBatch<'_, T> {
         debug_assert!(index < self.count.get());
         let ptr = self.consumer.lanes[self.lane]
             .payload_ptr(self.start.wrapping_add(index))
-            .as_ptr()
-            .cast::<T>();
+            .cast();
         // SAFETY: the cell is published and held by this consumer's
         // cursor.
         unsafe { ptr.read() }
@@ -1459,8 +1451,9 @@ impl SliceReadGuard<'_> {
 
     /// Returns the payload bytes.
     pub fn as_slice(&self) -> &[u8] {
+        let payload = NonNull::slice_from_raw_parts(self.payload, self.len);
         // SAFETY: the cell is published and held by this consumer's cursor.
-        unsafe { slice::from_raw_parts(self.payload.as_ptr(), self.len) }
+        unsafe { payload.as_ref() }
     }
 }
 
@@ -1506,14 +1499,14 @@ impl SliceReadBatch<'_> {
     /// - `index < len`.
     pub unsafe fn as_slice(&self, index: usize) -> &[u8] {
         debug_assert!(index < self.count.get());
-        let ptr = self
+        let payload = self
             .consumer
             .lane(self.lane)
-            .payload_ptr(self.start.wrapping_add(index))
-            .as_ptr();
+            .payload_ptr(self.start.wrapping_add(index));
+        let payload = NonNull::slice_from_raw_parts(payload, self.payload_size);
         // SAFETY: forwarded; the cell is published and held by this consumer's
         // cursor until the batch is dropped.
-        unsafe { slice::from_raw_parts(ptr, self.payload_size) }
+        unsafe { payload.as_ref() }
     }
 }
 

--- a/src/broadcast/consumer_state.rs
+++ b/src/broadcast/consumer_state.rs
@@ -5,7 +5,6 @@
 
 use core::mem::{align_of, size_of, MaybeUninit};
 use core::ptr::NonNull;
-use core::slice;
 use core::sync::atomic::{fence, AtomicU64, AtomicUsize, Ordering};
 
 use crate::error::Error;
@@ -47,11 +46,11 @@ impl ConsumerState {
     /// - `block` must point at a [`Self::block_size`] region for `slot_count`
     ///   slots and be initialized at most once.
     pub(crate) unsafe fn init(block: NonNull<u8>, slot_count: usize) {
+        let mut slots =
+            NonNull::slice_from_raw_parts(block.cast::<MaybeUninit<AtomicU64>>(), slot_count);
         // SAFETY: layout reserves `slot_count` AtomicU64s here; init runs once
         // with no other handle joined, so &mut is exclusive.
-        let slots: &mut [MaybeUninit<AtomicU64>] = unsafe {
-            slice::from_raw_parts_mut(block.cast::<MaybeUninit<AtomicU64>>().as_ptr(), slot_count)
-        };
+        let slots = unsafe { slots.as_mut() };
         for slot in slots {
             slot.write(AtomicU64::new(CONSUMER_FREE));
         }
@@ -140,14 +139,13 @@ impl LaneConsumerState {
     /// - `block` must point at a [`Self::block_size`] region for `slot_count`
     ///   slots and be initialized at most once.
     pub(crate) unsafe fn init(block: NonNull<u8>, slot_count: usize) {
+        let mut slots = NonNull::slice_from_raw_parts(
+            block.cast::<MaybeUninit<CacheAlignedAtomicSize>>(),
+            slot_count,
+        );
         // SAFETY: layout reserves `slot_count` aligned slots here; init runs
         // once with no other handle joined, so &mut is exclusive.
-        let slots: &mut [MaybeUninit<CacheAlignedAtomicSize>] = unsafe {
-            slice::from_raw_parts_mut(
-                block.cast::<MaybeUninit<CacheAlignedAtomicSize>>().as_ptr(),
-                slot_count,
-            )
-        };
+        let slots = unsafe { slots.as_mut() };
         for slot in slots {
             slot.write(CacheAlignedAtomicSize {
                 inner: AtomicUsize::new(UNCLAIMED),
@@ -275,8 +273,9 @@ impl LaneConsumerState {
 
     #[inline]
     fn limits(&self) -> &[CacheAlignedAtomicSize] {
+        let limits = NonNull::slice_from_raw_parts(self.limits, self.slot_count);
         // SAFETY: layout reserves `slot_count` aligned slots here.
-        unsafe { slice::from_raw_parts(self.limits.as_ptr(), self.slot_count) }
+        unsafe { limits.as_ref() }
     }
 
     /// The slot holding consumer `consumer_index`'s reserve limit

--- a/src/broadcast/consumer_state.rs
+++ b/src/broadcast/consumer_state.rs
@@ -108,7 +108,7 @@ impl ConsumerState {
     fn slot(&self, index: usize) -> &AtomicU64 {
         debug_assert!(index < self.slot_count);
         // SAFETY: `index < slot_count`; the slot was initialized.
-        unsafe { &*self.slots.add(index).as_ptr() }
+        unsafe { self.slots.add(index).as_ref() }
     }
 }
 
@@ -285,7 +285,7 @@ impl LaneConsumerState {
     fn limit(&self, consumer_index: usize) -> &CacheAlignedAtomicSize {
         debug_assert!(consumer_index < self.slot_count);
         // SAFETY: `consumer_index < slot_count`; the slot was initialized.
-        unsafe { &*self.limits.add(consumer_index).as_ptr() }
+        unsafe { self.limits.add(consumer_index).as_ref() }
     }
 }
 

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -92,9 +92,8 @@ impl ProducerLane {
             producer_reservation: CacheAlignedAtomicSize::default(),
             producer_publication: CacheAlignedAtomicSize::default(),
         };
-        let header_ptr = block.cast::<LaneHeader>().as_ptr();
         // SAFETY: `block` begins with a `LaneHeader`.
-        unsafe { header_ptr.write(header) };
+        unsafe { block.cast().write(header) };
         // SAFETY: layout reserves `consumer_slots` aligned slots here.
         let consumer_state = unsafe { block.byte_add(consumer_state_offset()) };
         // SAFETY: freshly initialized lane block; consumer slots are initialized once.
@@ -287,7 +286,7 @@ mod tests {
 
     fn read(lane: &ProducerLane, sequence: usize) -> Payload {
         // SAFETY: `sequence` was published, so its cell is initialized.
-        unsafe { lane.payload_ptr(sequence).cast::<Payload>().as_ptr().read() }
+        unsafe { lane.payload_ptr(sequence).cast().read() }
     }
 
     fn join_consumer(lane: &ProducerLane, consumer_index: usize, from_backlog: bool) -> usize {
@@ -304,12 +303,7 @@ mod tests {
             return false;
         };
         // SAFETY: the cell is reserved and not yet published.
-        unsafe {
-            lane.payload_ptr(start)
-                .cast::<Payload>()
-                .as_ptr()
-                .write(value)
-        };
+        unsafe { lane.payload_ptr(start).cast().write(value) };
         lane.publish(start, one);
         true
     }
@@ -347,8 +341,7 @@ mod tests {
             // SAFETY: each cell in the batch is reserved and unpublished.
             unsafe {
                 lane.payload_ptr(start.wrapping_add(offset))
-                    .cast::<Payload>()
-                    .as_ptr()
+                    .cast()
                     .write((offset as u64) + 1)
             };
         }

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -221,7 +221,7 @@ mod imp {
     /// Only the kernel reads through this pointer; never materialize an
     /// `&AtomicU32` over the cursor in Rust code (see module docs).
     fn futex_word(cursor: &AtomicUsize) -> *mut u32 {
-        let ptr = cursor.as_ptr().cast::<u32>();
+        let ptr = cursor.as_ptr().cast();
         // The low half lives at byte offset 4 on big-endian targets.
         #[cfg(target_endian = "big")]
         // SAFETY: in bounds; the low half of the 8-byte cursor is at offset 4.

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -643,7 +643,7 @@ impl SharedQueueHeader {
     /// - This function must be called at most once for a given `region`.
     unsafe fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
-        let header = region.addr().cast::<Self>();
+        let header = region.addr().cast();
         // SAFETY: The header is non-null and aligned properly.
         //         Alignment is guaranteed because mmap ensures that the
         //         memory is aligned to the page size, which is sufficient for the
@@ -812,7 +812,7 @@ impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
 impl<'a, T> WriteGuard<'a, T> {
     pub fn write(self, value: T) {
         // SAFETY: The cell was reserved for writing.
-        unsafe { self.cell.as_ptr().write(value) };
+        unsafe { self.cell.write(value) };
     }
 }
 
@@ -840,7 +840,7 @@ pub struct ReadGuard<'a, T> {
 impl<'a, T> ReadGuard<'a, T> {
     pub fn read(self) -> T {
         // SAFETY: The cell was reserved for reading and holds an initialized value.
-        unsafe { self.cell.as_ptr().read() }
+        unsafe { self.cell.read() }
     }
 }
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -803,8 +803,9 @@ pub struct WriteGuard<'a, T> {
 impl<T> core::convert::AsMut<MaybeUninit<T>> for WriteGuard<'_, T> {
     /// Mutable reference to the reserved cell.
     fn as_mut(&mut self) -> &mut MaybeUninit<T> {
+        let mut cell = self.cell.cast();
         // SAFETY: The cell was reserved for writing.
-        unsafe { &mut *self.cell.as_ptr().cast() }
+        unsafe { cell.as_mut() }
     }
 }
 

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -29,7 +29,7 @@ impl Region {
             NonNull::new(addr).ok_or(Error::Allocation(layout))?
         };
 
-        assert_eq!(addr.as_ptr().align_offset(MINIMUM_REGION_ALIGNMENT), 0);
+        assert_eq!(addr.align_offset(MINIMUM_REGION_ALIGNMENT), 0);
 
         Ok(Arc::new(Self {
             addr,
@@ -73,7 +73,7 @@ unsafe impl Send for Region {}
 unsafe impl Sync for Region {}
 
 fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
-    let actual = addr.as_ptr().align_offset(MINIMUM_REGION_ALIGNMENT);
+    let actual = addr.align_offset(MINIMUM_REGION_ALIGNMENT);
     if actual != 0 {
         return Err(Error::InvalidRegionAlignment {
             minimum: MINIMUM_REGION_ALIGNMENT,
@@ -218,26 +218,14 @@ mod tests {
             .expect("set len");
 
         let region = Region::map_file(&file, MINIMUM_REGION_ALIGNMENT).expect("map file");
-        assert_eq!(
-            region
-                .addr()
-                .as_ptr()
-                .align_offset(MINIMUM_REGION_ALIGNMENT),
-            0
-        );
+        assert_eq!(region.addr().align_offset(MINIMUM_REGION_ALIGNMENT), 0);
     }
 
     #[test]
     fn test_alloc_region_is_4096_aligned() {
         let region = Region::alloc(NonZeroUsize::new(MINIMUM_REGION_ALIGNMENT * 2).unwrap())
             .expect("allocation failed");
-        assert_eq!(
-            region
-                .addr()
-                .as_ptr()
-                .align_offset(MINIMUM_REGION_ALIGNMENT),
-            0
-        );
+        assert_eq!(region.addr().align_offset(MINIMUM_REGION_ALIGNMENT), 0);
         assert_eq!(region.size(), MINIMUM_REGION_ALIGNMENT * 2);
     }
 
@@ -245,13 +233,7 @@ mod tests {
     fn test_alloc_region_accepts_non_4096_multiple() {
         let region = Region::alloc(NonZeroUsize::new(MINIMUM_REGION_ALIGNMENT + 1).unwrap())
             .expect("allocation failed");
-        assert_eq!(
-            region
-                .addr()
-                .as_ptr()
-                .align_offset(MINIMUM_REGION_ALIGNMENT),
-            0
-        );
+        assert_eq!(region.addr().align_offset(MINIMUM_REGION_ALIGNMENT), 0);
         assert_eq!(region.size(), MINIMUM_REGION_ALIGNMENT + 1);
     }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -506,7 +506,7 @@ impl SharedQueueHeader {
     /// - This function must be called at most once for a given `region`.
     unsafe fn create_in_region<T>(region: &Arc<Region>) -> Result<NonNull<Self>, Error> {
         let buffer_size_in_items = Self::calculate_buffer_size_in_items::<T>(region.size())?;
-        let header = region.addr().cast::<Self>();
+        let header = region.addr().cast();
         // SAFETY: The header is non-null and aligned properly.
         //         Alignment is guaranteed because mmap ensures that the
         //         memory is aligned to the page size, which is sufficient for the
@@ -791,7 +791,7 @@ mod tests {
                 Err(WaitError::Timeout) => panic!("read timed out after commit"),
             };
             // SAFETY: `ptr` points at a readable `u64`; the value is Copy.
-            assert_eq!(unsafe { *ptr.as_ptr() }, 42);
+            assert_eq!(unsafe { ptr.read() }, 42);
             consumer.finalize();
         }
     }
@@ -836,7 +836,7 @@ mod tests {
                 Err(WaitError::Timeout) => panic!("read timed out after commit"),
             };
             // SAFETY: `ptr` points at a readable `u64`; the value is Copy.
-            assert_eq!(unsafe { *ptr.as_ptr() }, 9);
+            assert_eq!(unsafe { ptr.read() }, 9);
             consumer.finalize();
         }
     }


### PR DESCRIPTION
### Problem
- We have NonNull which has `as_ref()/as_mut()`, yet in a few places we `&*(x.as_ptr())` which is weird
- We have NonNull and use .as_ptr and cast unnecessarily in several places

### Summary of Changes
- Use the fns of NonNull instead of doing it ourselves!
- Stop using as_ptr unless necessary
- Stop adding explicit casting types unless necessary