### PR TITLE
fix: make typed queue endpoints invariant over payloads

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -494,6 +494,7 @@ pub struct Producer<T> {
     lane: ProducerLane,
     index: usize,
     _marker: PhantomData<T>,
+    _invariant: PhantomData<fn(T) -> T>,
 }
 
 impl<T> Producer<T> {
@@ -531,6 +532,7 @@ impl<T> Producer<T> {
             lane,
             index,
             _marker: PhantomData,
+            _invariant: PhantomData,
         })
     }
 
@@ -569,6 +571,7 @@ impl<T> Producer<T> {
             lane,
             index,
             _marker: PhantomData,
+            _invariant: PhantomData,
         })
     }
 
@@ -999,6 +1002,7 @@ unsafe impl Send for ConsumerCore {}
 pub struct Consumer<T> {
     core: ConsumerCore,
     _marker: PhantomData<T>,
+    _invariant: PhantomData<fn(T) -> T>,
 }
 
 impl<T> Consumer<T> {
@@ -1042,6 +1046,7 @@ impl<T> Consumer<T> {
         Ok(Self {
             core: ConsumerCore::from_queue(queue, from_backlog)?,
             _marker: PhantomData,
+            _invariant: PhantomData,
         })
     }
 
@@ -1074,6 +1079,7 @@ impl<T> Consumer<T> {
         Ok(Self {
             core: ConsumerCore::recover_in_queue(queue, index)?,
             _marker: PhantomData,
+            _invariant: PhantomData,
         })
     }
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -427,6 +427,10 @@ struct SharedQueue<T> {
     header: NonNull<SharedQueueHeader>,
     buffer: NonNull<T>,
     buffer_mask: usize,
+    // `NonNull<T>` is covariant, but paired endpoints must not be independently
+    // coerced to different payload lifetimes. The function input/output marker
+    // makes `T` invariant without affecting layout or auto traits.
+    _invariant: PhantomData<fn(T) -> T>,
 
     // NB: Region must be declared last so it is dropped last ensuring `header` and
     // `buffer` remain valid for their entire lifetime.
@@ -439,6 +443,7 @@ impl<T> Clone for SharedQueue<T> {
             header: self.header,
             buffer: self.buffer,
             buffer_mask: self.buffer_mask,
+            _invariant: PhantomData,
             region: Arc::clone(&self.region),
         }
     }
@@ -565,8 +570,9 @@ impl<T> SharedQueue<T> {
         Ok(Self {
             header,
             buffer,
-            region,
             buffer_mask,
+            _invariant: PhantomData,
+            region,
         })
     }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -5,7 +5,7 @@ use crate::{
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
 };
-use core::ptr::NonNull;
+use core::{marker::PhantomData, ptr::NonNull};
 use std::{
     fs::File,
     num::NonZeroUsize,
@@ -375,6 +375,10 @@ struct SharedQueue<T> {
     buffer_mask: usize,
     cached_write: usize,
     cached_read: usize,
+    // `NonNull<T>` is covariant, but paired endpoints must not be independently
+    // coerced to different payload lifetimes. The function input/output marker
+    // makes `T` invariant without affecting layout or auto traits.
+    _invariant: PhantomData<fn(T) -> T>,
 
     // NB: Region must be declared last so it is dropped last ensuring `header` and
     // `buffer` remain valid for their entire lifetime.
@@ -411,6 +415,7 @@ impl<T> SharedQueue<T> {
             buffer_mask: size - 1,
             cached_write: 0,
             cached_read: 0,
+            _invariant: PhantomData,
         };
 
         queue.load_write();


### PR DESCRIPTION
### Problem
- Typed queue endpoints are covariant, allowing mismatched payload lifetimes and dangling references. Something like this is allowed:

<details>
<summary>Example</summary>

```rust
  use shaq::mpmc::{pair, Producer};

  fn shorten<'a>(
      producer: Producer<&'static u64>,
      _value: &'a u64,
  ) -> Producer<&'a u64> {
      producer
  }

  fn make_dangling() -> &'static u64 {
      let (producer, consumer) = pair::<&'static u64>(1).unwrap();

      let local = 42;
      let producer = shorten(producer, &local);

      producer.try_write(&local).unwrap();

      // The consumer still treats the payload as &'static u64.
      consumer.try_read().unwrap()
  }

  fn main() {
      let dangling = make_dangling();

      // `local` has left scope, so this dereferences invalid stack memory.
      println!("{}", *dangling);
  }
```

</details>

### Summary of Changes
- Made spsc, mpmc, and broadcast typed endpoints invariant over T using a marker