### PR TITLE
spsc: make reads and teardown destructor-safe

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -242,20 +242,14 @@ fn run_spsc_consumer(
 ) {
     let wait_timeout = Duration::from_millis(10);
     run_consumer_loop(exit, move || {
-        match consumer.read_ptr_timeout(wait_timeout) {
-            Ok(_item) => {}
+        let batch = match consumer.reserve_read_batch_timeout(SYNC_CADENCE, wait_timeout) {
+            Ok(batch) => batch,
             Err(WaitError::Timeout) => {
                 consumer_reserve_failures.fetch_add(1, Ordering::Relaxed);
                 return;
             }
-        }
-
-        for _ in 1..SYNC_CADENCE.get() {
-            if consumer.try_read_ptr().is_none() {
-                break;
-            }
-        }
-        consumer.finalize();
+        };
+        let _ = batch.len();
     });
 }
 

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -256,7 +256,7 @@ fn run_spsc_consumer(
         }
 
         for _ in 1..SYNC_CADENCE.get() {
-            if consumer.try_read().is_none() {
+            if consumer.try_read_ptr().is_none() {
                 break;
             }
         }

--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -220,21 +220,16 @@ fn run_spsc_producer(
         verbose.then(|| "Producer".to_string()),
         total_items_produced,
         move || {
-            producer.sync();
+            let mut batch = producer.write_batch();
             let mut produced = 0;
             for _ in 0..SYNC_CADENCE.get() {
-                // SAFETY: reserve() yields a valid write slot.
-                let Some(mut spot) = (unsafe { producer.reserve() }) else {
+                if batch.try_write(Item { data: [42u8; _] }).is_ok() {
+                    produced += 1;
+                } else {
                     producer_reserve_failures.fetch_add(1, Ordering::Relaxed);
                     break;
-                };
-                // SAFETY: the reserved slot can be fully initialized.
-                unsafe {
-                    spot.as_mut().data.fill(42);
                 }
-                produced += 1;
             }
-            producer.commit();
             (produced > 0).then_some(produced)
         },
     );

--- a/examples/shared/common.rs
+++ b/examples/shared/common.rs
@@ -10,6 +10,7 @@ use std::{
 
 #[derive(Clone, Copy)]
 pub struct Item {
+    #[allow(unused)]
     pub data: [u8; 512],
 }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1428,6 +1428,33 @@ impl<T: Copy> ReadBatch<'_, T> {
         // cursor.
         unsafe { ptr.read() }
     }
+
+    /// Returns the values in logical read order as two slices.
+    ///
+    /// The second slice is empty unless the batch wraps around the end of the
+    /// lane's ring buffer. This borrows the values without consuming the batch.
+    pub fn as_slices(&self) -> (&[T], &[T])
+    where
+        T: Sync,
+    {
+        let lane = self.consumer.lane(self.lane);
+        let start = lane.mask(self.start);
+        let first_len = self.len().min(lane.capacity().wrapping_sub(start));
+        let second_len = self.len().wrapping_sub(first_len);
+
+        let first = lane.payload_ptr(self.start).cast::<T>();
+        let first = NonNull::slice_from_raw_parts(first, first_len);
+        // SAFETY: The first part of the reservation is initialized, contiguous,
+        // and remains protected from overwrite for the lifetime of the slice.
+        let first = unsafe { first.as_ref() };
+        let second = lane.payload_ptr(0).cast::<T>();
+        let second = NonNull::slice_from_raw_parts(second, second_len);
+        // SAFETY: The wrapped part of the reservation starts at the ring base,
+        // is initialized and contiguous, and remains protected from overwrite
+        // for the lifetime of the slice.
+        let second = unsafe { second.as_ref() };
+        (first, second)
+    }
 }
 
 impl<T: Copy> Drop for ReadBatch<'_, T> {
@@ -2198,6 +2225,9 @@ mod tests {
                     .try_reserve_read_batch(NonZeroUsize::new(3).unwrap())
                     .unwrap();
                 assert_eq!(batch.len(), 3);
+                let (first, second) = batch.as_slices();
+                assert_eq!(first, &[0, 1, 2]);
+                assert!(second.is_empty());
                 for index in 0..3 {
                     // SAFETY: `index < len`; `Payload` is `u64`.
                     assert_eq!(unsafe { batch.read(index) }, index as u64);
@@ -2245,6 +2275,32 @@ mod tests {
             for value in 99..103u64 {
                 assert!(p.try_write(value).is_ok());
             }
+        }
+    }
+
+    #[test]
+    fn read_batch_as_slices_supports_wrapping() {
+        for create in producer_creators() {
+            let mut p = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let mut c = p.broadcast_handle().consumer().unwrap();
+            for value in 0..4u64 {
+                assert!(p.try_write(value).is_ok());
+            }
+            assert_eq!(c.try_read(), Some(0));
+            assert_eq!(c.try_read(), Some(1));
+            assert!(p.try_write(4).is_ok());
+            assert!(p.try_write(5).is_ok());
+
+            let batch = c
+                .try_reserve_read_batch(NonZeroUsize::new(4).unwrap())
+                .unwrap();
+            let (first, second) = batch.as_slices();
+            assert_eq!(first, &[2, 3]);
+            assert_eq!(second, &[4, 5]);
         }
     }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -912,12 +912,9 @@ pub struct WriteBatch<'a, T: Copy> {
 }
 
 impl<T: Copy> WriteBatch<'_, T> {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        false
     }
 
     /// Mutable reference to the reserved cell at `index`.
@@ -1396,12 +1393,9 @@ pub struct ReadBatch<'a, T: Copy> {
 }
 
 impl<T: Copy> ReadBatch<'_, T> {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        false
     }
 
     /// Reference to the value at `index`.
@@ -1664,12 +1658,9 @@ pub struct SliceReadBatch<'a> {
 }
 
 impl SliceReadBatch<'_> {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        false
     }
 
     /// Byte length of each payload in the batch.

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -140,8 +140,13 @@ impl ProducerLane {
     }
 
     #[inline]
-    fn capacity(&self) -> usize {
+    pub(crate) fn capacity(&self) -> usize {
         self.mask.wrapping_add(1)
+    }
+
+    #[inline]
+    pub(crate) fn mask(&self, sequence: usize) -> usize {
+        sequence & self.mask
     }
 
     #[inline]
@@ -159,7 +164,7 @@ impl ProducerLane {
     /// write a reserved cell and by consumers to read a published one.
     #[inline]
     pub(crate) fn payload_ptr(&self, sequence: usize) -> NonNull<u8> {
-        let offset = (sequence & self.mask).wrapping_mul(self.payload_size);
+        let offset = self.mask(sequence).wrapping_mul(self.payload_size);
         // SAFETY: `sequence & mask < capacity`; the ring has `capacity` cells of
         // `payload_size` bytes. Zero-sized payloads always point at the ring base.
         unsafe { self.ring.byte_add(offset) }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1146,6 +1146,30 @@ impl<'a, T> ReadBatch<'a, T> {
         Some(unsafe { self.raw().get_unchecked(index) })
     }
 
+    /// Returns the values in logical read order as two slices.
+    ///
+    /// The second slice is empty unless the batch wraps around the end of the
+    /// queue buffer. This borrows the values without consuming the batch.
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        let start = self.raw.start & self.raw.buffer_mask;
+        let capacity = self.raw.buffer_mask.wrapping_add(1);
+        let first_len = self.len().min(capacity.wrapping_sub(start));
+        let second_len = self.len().wrapping_sub(first_len);
+
+        // SAFETY: `start` is within the queue buffer.
+        let first = unsafe { self.raw.buffer.add(start) };
+        let first = NonNull::slice_from_raw_parts(first, first_len);
+        // SAFETY: The first part of the reservation is initialized, contiguous,
+        // and remains reserved for the lifetime of the returned slice.
+        let first = unsafe { first.as_ref() };
+        let second = NonNull::slice_from_raw_parts(self.raw.buffer, second_len);
+        // SAFETY: The wrapped part of the reservation starts at the buffer base,
+        // is initialized and contiguous, and remains reserved for the lifetime
+        // of the returned slice.
+        let second = unsafe { second.as_ref() };
+        (first, second)
+    }
+
     /// Iterates over shared references without consuming any values.
     ///
     /// The batch reservation remains held for the iterator's lifetime.
@@ -1464,6 +1488,9 @@ mod tests {
             }
             assert_eq!(batch.get(batch.len()), None);
             assert_eq!(batch.get_owned(batch.len()), None);
+            let (first, second) = batch.as_slices();
+            assert_eq!(first, &[0, 1, 2, 3]);
+            assert!(second.is_empty());
             let mut borrowed = Vec::new();
             for value in &batch {
                 borrowed.push(*value);
@@ -1597,6 +1624,9 @@ mod tests {
             assert_eq!(batch.get_owned(3), Some(5));
             assert_eq!(batch.get_owned(0), Some(2));
             assert_eq!(batch.get_owned(3), Some(5));
+            let (first, second) = batch.as_slices();
+            assert_eq!(first, &[2, 3]);
+            assert_eq!(second, &[4, 5]);
             assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
             let mut values = Vec::new();
             for value in batch {

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -11,7 +11,7 @@ use core::{
     iter::FusedIterator,
     marker::PhantomData,
     mem::{ManuallyDrop, MaybeUninit},
-    ops::Index,
+    ops::{Index, Range},
     ptr::NonNull,
     sync::atomic::Ordering,
 };
@@ -1149,16 +1149,50 @@ impl<'a, T> ReadBatch<'a, T> {
     /// Iterates over shared references without consuming any values.
     ///
     /// The batch reservation remains held for the iterator's lifetime.
-    pub fn iter(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + FusedIterator + '_ {
-        (0..self.len()).map(|index| {
-            // SAFETY: The safe batch has not moved out any values, and the
-            // range only produces indices within the reservation.
-            unsafe { self.raw().get_unchecked(index) }
-        })
+    pub fn iter(&self) -> ReadBatchIter<'_, 'a, T> {
+        self.into_iter()
     }
 }
+
+impl<'batch, 'queue, T> IntoIterator for &'batch ReadBatch<'queue, T> {
+    type Item = &'batch T;
+    type IntoIter = ReadBatchIter<'batch, 'queue, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ReadBatchIter {
+            batch: self,
+            range: 0..self.len(),
+        }
+    }
+}
+
+/// An iterator over shared references to the values in a read batch.
+#[must_use]
+pub struct ReadBatchIter<'batch, 'queue, T> {
+    batch: &'batch ReadBatch<'queue, T>,
+    range: Range<usize>,
+}
+
+impl<'batch, T> Iterator for ReadBatchIter<'batch, '_, T> {
+    type Item = &'batch T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.batch.get(self.range.next()?)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<T> DoubleEndedIterator for ReadBatchIter<'_, '_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.batch.get(self.range.next_back()?)
+    }
+}
+
+impl<T> ExactSizeIterator for ReadBatchIter<'_, '_, T> {}
+impl<T> FusedIterator for ReadBatchIter<'_, '_, T> {}
 
 impl<'a, T> IntoIterator for ReadBatch<'a, T> {
     type Item = T;
@@ -1430,6 +1464,11 @@ mod tests {
             }
             assert_eq!(batch.get(batch.len()), None);
             assert_eq!(batch.get_owned(batch.len()), None);
+            let mut borrowed = Vec::new();
+            for value in &batch {
+                borrowed.push(*value);
+            }
+            assert_eq!(borrowed, vec![0, 1, 2, 3]);
         }
     }
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -322,7 +322,7 @@ impl<T> Consumer<T> {
     #[must_use]
     pub fn try_reserve_read_batch(&self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
         // SAFETY: ReadBatch drops all values that are not moved out through its
-        // sequential drain before the raw reservation is released.
+        // consuming iterator before the raw reservation is released.
         let raw = unsafe { self.try_reserve_read_batch_raw(max) }?;
         Some(ReadBatch { raw })
     }
@@ -1118,9 +1118,9 @@ impl<'a, T> Drop for RawReadBatch<'a, T> {
 /// A destructor-safe reservation for consecutive initialized consumer slots.
 ///
 /// The batch keeps all of its slots reserved while it lives. It may be
-/// inspected without consuming values, and [`Self::drain`] converts it into a
-/// sequential consuming iterator. Dropping the batch without draining it drops
-/// every value before releasing the reservation.
+/// inspected without consuming values or converted into a sequential consuming
+/// iterator. Dropping the batch without consuming it drops every value before
+/// releasing the reservation.
 pub struct ReadBatch<'a, T> {
     raw: RawReadBatch<'a, T>,
 }
@@ -1158,16 +1158,22 @@ impl<'a, T> ReadBatch<'a, T> {
             unsafe { self.raw().get_unchecked(index) }
         })
     }
+}
+
+impl<'a, T> IntoIterator for ReadBatch<'a, T> {
+    type Item = T;
+    type IntoIter = ReadBatchIntoIter<'a, T>;
 
     /// Converts the batch into a sequential consuming iterator.
     ///
-    /// The returned drain keeps the complete batch reservation held. Dropping
-    /// it before exhaustion drops all values that have not yet been yielded.
-    pub fn drain(self) -> ReadBatchDrain<'a, T> {
+    /// The returned iterator keeps the complete batch reservation held.
+    /// Dropping it before exhaustion drops all values that have not yet been
+    /// yielded.
+    fn into_iter(self) -> Self::IntoIter {
         let batch = ManuallyDrop::new(self);
         // SAFETY: `batch` is not dropped, so this moves its raw guard exactly once.
         let raw = unsafe { core::ptr::read(&batch.raw) };
-        ReadBatchDrain { raw, next: 0 }
+        ReadBatchIntoIter { raw, next: 0 }
     }
 }
 
@@ -1207,12 +1213,12 @@ impl<T> Drop for ReadBatch<'_, T> {
 /// This iterator keeps the complete batch reservation held until it is
 /// dropped. Dropping it before exhaustion drops the unconsumed suffix before
 /// releasing the reservation.
-pub struct ReadBatchDrain<'a, T> {
+pub struct ReadBatchIntoIter<'a, T> {
     raw: RawReadBatch<'a, T>,
     next: usize,
 }
 
-impl<T> Iterator for ReadBatchDrain<'_, T> {
+impl<T> Iterator for ReadBatchIntoIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1232,10 +1238,10 @@ impl<T> Iterator for ReadBatchDrain<'_, T> {
     }
 }
 
-impl<T> ExactSizeIterator for ReadBatchDrain<'_, T> {}
-impl<T> FusedIterator for ReadBatchDrain<'_, T> {}
+impl<T> ExactSizeIterator for ReadBatchIntoIter<'_, T> {}
+impl<T> FusedIterator for ReadBatchIntoIter<'_, T> {}
 
-impl<T> Drop for ReadBatchDrain<'_, T> {
+impl<T> Drop for ReadBatchIntoIter<'_, T> {
     fn drop(&mut self) {
         if !core::mem::needs_drop::<T>() {
             return;
@@ -1505,7 +1511,7 @@ mod tests {
     }
 
     #[test]
-    fn read_batch_drain_drop_drops_only_unconsumed_values() {
+    fn read_batch_into_iter_drop_drops_only_unconsumed_values() {
         for create_queue in test_queue_creators::<CountedItem>() {
             let drops = Arc::new(AtomicUsize::new(0));
             let (producer, consumer) = create_queue(4);
@@ -1516,15 +1522,15 @@ mod tests {
             let batch = consumer
                 .try_reserve_read_batch(NonZeroUsize::new(4).unwrap())
                 .expect("read batch");
-            let mut drain = batch.drain();
-            assert_eq!(drain.len(), 3);
-            let first = drain.next().expect("first value");
+            let mut iter = batch.into_iter();
+            assert_eq!(iter.len(), 3);
+            let first = iter.next().expect("first value");
             assert_eq!(first.value, 0);
-            assert_eq!(drain.len(), 2);
+            assert_eq!(iter.len(), 2);
             drop(first);
             assert_eq!(drops.load(Ordering::Relaxed), 1);
 
-            drop(drain);
+            drop(iter);
             assert_eq!(drops.load(Ordering::Relaxed), 3);
             assert!(consumer.try_read().is_none());
             for value in 3..7 {
@@ -1538,7 +1544,7 @@ mod tests {
     }
 
     #[test]
-    fn copy_read_batch_supports_wrapped_random_access_and_drain() {
+    fn copy_read_batch_supports_wrapped_random_access_and_into_iter() {
         for create_queue in test_queue_creators::<Item>() {
             let (producer, consumer) = create_queue(4);
             assert!(producer.try_write_slice(&[0, 1, 2]));
@@ -1553,7 +1559,11 @@ mod tests {
             assert_eq!(batch.get_owned(0), Some(2));
             assert_eq!(batch.get_owned(3), Some(5));
             assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
-            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
+            let mut values = Vec::new();
+            for value in batch {
+                values.push(value);
+            }
+            assert_eq!(values, vec![2, 3, 4, 5]);
         }
     }
 

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1002,13 +1002,9 @@ pub struct WriteBatch<'a, T> {
 }
 
 impl<'a, T> WriteBatch<'a, T> {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        // count is guaranteed to be non-zero by the type, so this batch can never be empty.
-        false
     }
 
     /// Returns a mutable reference to the reserved slot.
@@ -1070,13 +1066,9 @@ pub struct RawReadBatch<'a, T> {
 }
 
 impl<'a, T> RawReadBatch<'a, T> {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        // count is guaranteed to be non-zero by the type, so this batch can never be empty.
-        false
     }
 
     /// Returns a reference to the reserved slot.
@@ -1138,12 +1130,9 @@ impl<'a, T> ReadBatch<'a, T> {
         &self.raw
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.raw().len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        false
     }
 
     /// Returns a shared reference to the value at `index`, or `None` if it is

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -5,7 +5,13 @@ use crate::{
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
 };
-use core::{marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
+use core::{
+    iter::FusedIterator,
+    marker::PhantomData,
+    mem::{ManuallyDrop, MaybeUninit},
+    ops::Index,
+    ptr::NonNull,
+};
 use std::{
     fs::File,
     num::NonZeroUsize,
@@ -324,45 +330,39 @@ impl<T> Consumer<T> {
         self.queue.is_empty()
     }
 
-    /// Attempts to read a value from the queue.
-    /// Returns `None` if there are no values available.
-    /// Returns ownership of the value if available.
+    /// Attempts to read a value from the queue, synchronizing with the
+    /// producer first.
     ///
-    /// Call [`Self::finalize`] to release consumed capacity back to the
-    /// producer. Pending capacity is also released when the consumer is
-    /// dropped.
+    /// Returns `None` if there are no values available. Consumed capacity is
+    /// released before this method returns.
     pub fn try_read(&mut self) -> Option<T> {
-        let read_ptr = self.try_reserve_read_ptr()?;
-        // SAFETY: `read_ptr` is the initialized position just reserved by this
-        // consumer, and ownership has not previously been taken from it.
-        Some(unsafe { read_ptr.read() })
+        self.read_session().try_read()
     }
 
-    /// Attempts to reserve a value for zero-copy reading.
-    /// Returns `None` if there are no values available.
-    /// Returns a pointer to the value if available.
+    /// Starts a streaming read session.
     ///
-    /// All returned pointers must be discarded before calling
-    /// [`Self::finalize`] or dropping the consumer.
-    pub fn try_read_ptr(&mut self) -> Option<NonNull<T>>
-    where
-        T: Copy,
-    {
-        self.try_reserve_read_ptr()
+    /// The consumer synchronizes with the producer once when the session is
+    /// created. Repeated calls to [`ReadSession::try_read`] consume from that
+    /// snapshot without further synchronization. Consumed capacity is
+    /// released when the session is dropped.
+    pub fn read_session(&mut self) -> ReadSession<'_, T> {
+        self.sync();
+        ReadSession { consumer: self }
     }
 
-    /// Attempts to reserve a value for raw reading.
+    /// Attempts to reserve up to `max` values from the queue.
     ///
-    /// # Safety
-    /// Before the read position is released, every reserved non-`Copy` value
-    /// must be moved out or dropped exactly once. No reference or pointer to a
-    /// reserved value may be used after its position is released. Dropping the
-    /// consumer releases all pending read positions.
-    pub unsafe fn try_read_ptr_raw(&mut self) -> Option<NonNull<T>> {
-        self.try_reserve_read_ptr()
+    /// The consumer synchronizes with the producer before reserving. Dropping
+    /// the returned batch drops any values that were not moved out through
+    /// [`ReadBatch::drain`] and releases the complete reservation.
+    #[must_use]
+    pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
+        self.sync();
+        let reservation = self.try_reserve_read_range(max)?;
+        Some(self.read_batch_for(reservation))
     }
 
-    fn try_reserve_read_ptr(&mut self) -> Option<NonNull<T>> {
+    fn try_read_inner(&mut self) -> Option<T> {
         if self.queue.cached_read == self.queue.cached_write {
             return None; // Queue is empty
         }
@@ -372,20 +372,36 @@ impl<T> Consumer<T> {
         let read_ptr = unsafe { self.queue.buffer.add(read_index) };
         self.queue.cached_read = self.queue.cached_read.wrapping_add(1);
 
-        Some(read_ptr)
+        // SAFETY: `read_ptr` is the initialized position just reserved by this
+        // consumer, and ownership has not previously been taken from it.
+        Some(unsafe { read_ptr.read() })
     }
 
-    /// Publishes the current read position, releasing all reserved capacity
-    /// back to the producer.
-    pub fn finalize(&mut self) {
+    fn try_reserve_read_range(&mut self, max: NonZeroUsize) -> Option<(usize, NonZeroUsize)> {
+        let count = NonZeroUsize::new(self.queue.len().min(max.get()))?;
+        let start = self.queue.cached_read;
+        self.queue.cached_read = self.queue.cached_read.wrapping_add(count.get());
+        Some((start, count))
+    }
+
+    fn read_batch_for(&mut self, (start, count): (usize, NonZeroUsize)) -> ReadBatch<'_, T> {
+        ReadBatch {
+            reservation: ReadReservation {
+                consumer: self,
+                start,
+                count,
+            },
+        }
+    }
+
+    fn finalize(&mut self) {
         self.queue
             .header()
             .read
             .store(self.queue.cached_read, Ordering::Release);
     }
 
-    /// Synchronizes the consumer's cached write position with the queue's write position.
-    pub fn sync(&mut self) {
+    fn sync(&mut self) {
         self.queue.load_write();
     }
 
@@ -407,51 +423,36 @@ impl<T> Consumer<T> {
     }
 
     /// Blocks until ownership of a committed item can be taken or `timeout`
-    /// elapses.
-    ///
-    /// Call [`Self::finalize`] to release consumed capacity back to the
-    /// producer.
+    /// elapses. Consumed capacity is released before this method returns.
     pub fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
-        let read_ptr = self.reserve_read_ptr_timeout(timeout)?;
-        // SAFETY: `read_ptr` is the initialized position just reserved by this
-        // consumer, and ownership has not previously been taken from it.
-        Ok(unsafe { read_ptr.read() })
+        let batch = self.reserve_read_batch_timeout(NonZeroUsize::MIN, timeout)?;
+        Ok(batch
+            .drain()
+            .next()
+            .expect("a successful one-item reservation is non-empty"))
     }
 
-    /// Blocks until a committed item can be reserved for reading or `timeout`
-    /// elapses.
+    /// Attempts to reserve up to `max` values, waiting up to `timeout` for a
+    /// producer to publish data.
     ///
-    /// The caller must still process all returned pointers and call
-    /// [`Self::finalize`] to release consumed capacity back to the producer.
-    pub fn read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError>
-    where
-        T: Copy,
-    {
-        self.reserve_read_ptr_timeout(timeout)
-    }
-
-    /// Blocks until a committed item can be reserved for raw reading or
-    /// `timeout` elapses.
-    ///
-    /// # Safety
-    /// The caller must satisfy [`Self::try_read_ptr_raw`]'s safety contract.
-    pub unsafe fn read_ptr_raw_timeout(
+    /// Returns `Err(WaitError::Timeout)` if no values are available before the
+    /// timeout elapses. The method returns as soon as at least one value can be
+    /// reserved; it does not wait for `max` values.
+    pub fn reserve_read_batch_timeout(
         &mut self,
+        max: NonZeroUsize,
         timeout: Duration,
-    ) -> Result<NonNull<T>, WaitError> {
-        self.reserve_read_ptr_timeout(timeout)
-    }
-
-    fn reserve_read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError> {
+    ) -> Result<ReadBatch<'_, T>, WaitError> {
         let header = self.queue.header;
         // SAFETY: `header` points to this consumer's live shared queue header.
         let header = unsafe { header.as_ref() };
-        header
+        let reservation = header
             .waiters
             .wait_for(&header.write, SPIN_ATTEMPTS, timeout, || {
                 self.queue.load_write();
-                self.try_reserve_read_ptr()
-            })
+                self.try_reserve_read_range(max)
+            })?;
+        Ok(self.read_batch_for(reservation))
     }
 }
 
@@ -463,6 +464,230 @@ unsafe impl<T: Send> Send for Consumer<T> {}
 impl<T> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.finalize();
+    }
+}
+
+/// A streaming read session that releases consumed capacity on drop.
+///
+/// The session observes the producer's publication cursor once when it is
+/// created. Values published later are visible to the next session.
+#[must_use]
+pub struct ReadSession<'a, T> {
+    consumer: &'a mut Consumer<T>,
+}
+
+impl<T> ReadSession<'_, T> {
+    /// Takes ownership of the next value in this session's snapshot, or
+    /// returns `None` when the snapshot has been exhausted.
+    pub fn try_read(&mut self) -> Option<T> {
+        self.consumer.try_read_inner()
+    }
+}
+
+impl<T> Drop for ReadSession<'_, T> {
+    fn drop(&mut self) {
+        self.consumer.finalize();
+    }
+}
+
+struct ReadReservation<'a, T> {
+    consumer: &'a mut Consumer<T>,
+    start: usize,
+    count: NonZeroUsize,
+}
+
+impl<T> ReadReservation<'_, T> {
+    fn len(&self) -> usize {
+        self.count.get()
+    }
+
+    /// Returns a reference to the reserved slot.
+    ///
+    /// # Safety
+    /// - `index` must be less than [`Self::len`].
+    /// - The value at `index` must not have previously been moved out or
+    ///   dropped.
+    /// - A reference returned by this method must not be used after the value
+    ///   is moved out or dropped by any means.
+    unsafe fn get_unchecked(&self, index: usize) -> &T {
+        debug_assert!(index < self.len());
+        let position = self.start.wrapping_add(index);
+        // SAFETY: Masking the reserved position produces an index within the
+        // queue buffer.
+        let value = unsafe {
+            self.consumer
+                .queue
+                .buffer
+                .add(position & self.consumer.queue.buffer_mask)
+        };
+        // SAFETY: The position was reserved for reading and is initialized.
+        unsafe { value.as_ref() }
+    }
+
+    /// Reads the value at `index`.
+    ///
+    /// # Safety
+    /// - `index` must be less than [`Self::len`].
+    /// - The value must not have previously been moved out or dropped.
+    /// - No reference to the slot may be used after moving out its value.
+    unsafe fn get_owned_unchecked(&self, index: usize) -> T {
+        debug_assert!(index < self.len());
+        let position = self.start.wrapping_add(index);
+        // SAFETY: Masking the reserved position produces an index within the
+        // queue buffer.
+        let value = unsafe {
+            self.consumer
+                .queue
+                .buffer
+                .add(position & self.consumer.queue.buffer_mask)
+        };
+        // SAFETY: The position was reserved for reading and is initialized.
+        unsafe { value.read() }
+    }
+}
+
+impl<T> Drop for ReadReservation<'_, T> {
+    fn drop(&mut self) {
+        self.consumer.finalize();
+    }
+}
+
+/// A destructor-safe reservation for consecutive initialized consumer slots.
+///
+/// The batch keeps all of its slots reserved while it lives. It may be
+/// inspected without consuming values, and [`Self::drain`] converts it into a
+/// sequential consuming iterator. Dropping the batch without draining it drops
+/// every value before releasing the reservation.
+#[must_use]
+pub struct ReadBatch<'a, T> {
+    reservation: ReadReservation<'a, T>,
+}
+
+impl<'a, T> ReadBatch<'a, T> {
+    pub fn len(&self) -> usize {
+        self.reservation.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Returns a shared reference to the value at `index`, or `None` if it is
+    /// outside the batch.
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index >= self.len() {
+            return None;
+        }
+        // SAFETY: The bounds check establishes that the initialized slot is in
+        // the reservation, and a safe batch has not moved out any values.
+        Some(unsafe { self.reservation.get_unchecked(index) })
+    }
+
+    /// Iterates over shared references without consuming any values.
+    ///
+    /// The batch reservation remains held for the iterator's lifetime.
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + FusedIterator + '_ {
+        (0..self.len()).map(|index| {
+            // SAFETY: The safe batch has not moved out any values, and the
+            // range only produces indices within the reservation.
+            unsafe { self.reservation.get_unchecked(index) }
+        })
+    }
+
+    /// Converts the batch into a sequential consuming iterator.
+    ///
+    /// The returned drain keeps the complete batch reservation held. Dropping
+    /// it before exhaustion drops all values that have not yet been yielded.
+    pub fn drain(self) -> ReadBatchDrain<'a, T> {
+        let batch = ManuallyDrop::new(self);
+        // SAFETY: `batch` is not dropped, so this moves its reservation exactly once.
+        let reservation = unsafe { core::ptr::read(&batch.reservation) };
+        ReadBatchDrain {
+            reservation,
+            next: 0,
+        }
+    }
+}
+
+impl<T: Copy> ReadBatch<'_, T> {
+    /// Copies the value at `index`, or returns `None` if it is outside the
+    /// batch.
+    pub fn get_owned(&self, index: usize) -> Option<T> {
+        self.get(index).copied()
+    }
+}
+
+impl<T> Index<usize> for ReadBatch<'_, T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).expect("read batch index out of bounds")
+    }
+}
+
+impl<T> Drop for ReadBatch<'_, T> {
+    fn drop(&mut self) {
+        if !core::mem::needs_drop::<T>() {
+            return;
+        }
+
+        for index in 0..self.reservation.len() {
+            // SAFETY: An intact safe batch has not moved out any values.
+            let value = unsafe { self.reservation.get_owned_unchecked(index) };
+            drop(value);
+        }
+    }
+}
+
+/// A sequential consuming iterator over a reserved read batch.
+///
+/// This iterator keeps the complete batch reservation held until it is
+/// dropped. Dropping it before exhaustion drops the unconsumed suffix before
+/// releasing the reservation.
+#[must_use]
+pub struct ReadBatchDrain<'a, T> {
+    reservation: ReadReservation<'a, T>,
+    next: usize,
+}
+
+impl<T> Iterator for ReadBatchDrain<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next == self.reservation.len() {
+            return None;
+        }
+        let index = self.next;
+        // Advance before returning ownership so Drop only considers the suffix.
+        self.next += 1;
+        // SAFETY: The cursor visits every reserved index at most once.
+        Some(unsafe { self.reservation.get_owned_unchecked(index) })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.reservation.len() - self.next;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<T> ExactSizeIterator for ReadBatchDrain<'_, T> {}
+impl<T> FusedIterator for ReadBatchDrain<'_, T> {}
+
+impl<T> Drop for ReadBatchDrain<'_, T> {
+    fn drop(&mut self) {
+        if !core::mem::needs_drop::<T>() {
+            return;
+        }
+
+        while self.next < self.reservation.len() {
+            let index = self.next;
+            self.next += 1;
+            // SAFETY: The cursor visits every reserved index at most once.
+            let value = unsafe { self.reservation.get_owned_unchecked(index) };
+            drop(value);
+        }
     }
 }
 
@@ -767,7 +992,11 @@ mod tests {
     use super::*;
     #[cfg(not(miri))]
     use crate::shmem::create_temp_shmem_file;
-    use std::{sync::atomic::AtomicU64, time::Duration};
+    use std::{
+        panic::{catch_unwind, AssertUnwindSafe},
+        sync::atomic::{AtomicU64, AtomicUsize},
+        time::Duration,
+    };
 
     type CreateQueue<T> = fn(usize) -> (Producer<T>, Consumer<T>);
 
@@ -812,12 +1041,9 @@ mod tests {
             unsafe { spot.as_ref() }.store(42, Ordering::Release);
             assert!(consumer.try_read().is_none()); // not committed yet
             producer.commit();
-            assert!(consumer.try_read().is_none()); // consumer has not synced yet
-            consumer.sync();
             let item = consumer.try_read().expect("Failed to read item");
             assert_eq!(item.load(Ordering::Acquire), 42);
             assert!(consumer.try_read().is_none()); // no more items to read
-            consumer.finalize();
 
             // Ensure we can push up to the capacity.
             {
@@ -827,22 +1053,21 @@ mod tests {
                 }
                 assert!(batch.try_write(AtomicU64::new(1)).is_err());
             }
-            consumer.sync();
-            for _ in 0..BUFFER_CAPACITY {
-                let item = consumer.try_read().expect("Failed to read item");
-                assert_eq!(item.load(Ordering::Acquire), 1);
+            {
+                let mut session = consumer.read_session();
+                for _ in 0..BUFFER_CAPACITY {
+                    let item = session.try_read().expect("Failed to read item");
+                    assert_eq!(item.load(Ordering::Acquire), 1);
+                }
+                assert!(session.try_read().is_none()); // no more items to read
             }
-            assert!(consumer.try_read().is_none()); // no more items to read
-            consumer.finalize();
 
-            // Ensure we can write again after finalizing.
+            // Ensure we can write again after the session releases its reads.
             producer.try_write(AtomicU64::new(2)).unwrap();
-            consumer.sync();
             let item = consumer
                 .try_read()
-                .expect("Failed to read item after finalize");
+                .expect("Failed to read item after session");
             assert_eq!(item.load(Ordering::Acquire), 2);
-            consumer.finalize();
         }
     }
 
@@ -856,10 +1081,8 @@ mod tests {
             let mut consumer = unsafe { producer.join_as_consumer() }.expect("join failed");
 
             producer.try_write(42).unwrap();
-            consumer.sync();
             let val = consumer.try_read().expect("read failed");
             assert_eq!(val, 42);
-            consumer.finalize();
         }
     }
 
@@ -869,11 +1092,9 @@ mod tests {
         let value = Arc::new(42);
 
         producer.try_write(Arc::clone(&value)).unwrap();
-        consumer.sync();
 
         let received = consumer.try_read().expect("read failed");
         assert!(Arc::ptr_eq(&received, &value));
-        consumer.finalize();
         assert_eq!(Arc::strong_count(&value), 2);
         drop(received);
         assert_eq!(Arc::strong_count(&value), 1);
@@ -902,10 +1123,8 @@ mod tests {
             let mut producer = unsafe { consumer.join_as_producer() }.expect("join failed");
 
             producer.try_write(99).unwrap();
-            consumer.sync();
             let val = consumer.try_read().expect("read failed");
             assert_eq!(val, 99);
-            consumer.finalize();
         }
     }
 
@@ -923,10 +1142,8 @@ mod tests {
             drop(producer);
 
             // Can still read the message from the shared consumer
-            consumer.sync();
             let val = consumer.try_read().expect("read after producer drop");
             assert_eq!(val, 7);
-            consumer.finalize();
         }
     }
 
@@ -939,7 +1156,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_ptr_timeout_observes_commit() {
+    fn test_read_timeout_observes_commit() {
         for create_queue in test_queue_creators::<u64>() {
             let (mut producer, mut consumer) = create_queue(64);
 
@@ -955,13 +1172,11 @@ mod tests {
 
             producer.commit();
 
-            let ptr = match consumer.read_ptr_timeout(Duration::ZERO) {
-                Ok(ptr) => ptr,
+            let value = match consumer.read_timeout(Duration::ZERO) {
+                Ok(value) => value,
                 Err(WaitError::Timeout) => panic!("read timed out after commit"),
             };
-            // SAFETY: `ptr` points at a readable `u64`; the value is Copy.
-            assert_eq!(unsafe { ptr.read() }, 42);
-            consumer.finalize();
+            assert_eq!(value, 42);
         }
     }
 
@@ -992,19 +1207,220 @@ mod tests {
             ));
 
             assert!(matches!(
-                consumer.read_ptr_timeout(Duration::from_millis(1)),
+                consumer.read_timeout(Duration::from_millis(1)),
                 Err(WaitError::Timeout)
             ));
 
             producer.try_write(9).unwrap();
 
-            let ptr = match consumer.read_ptr_timeout(Duration::ZERO) {
-                Ok(ptr) => ptr,
+            let value = match consumer.read_timeout(Duration::ZERO) {
+                Ok(value) => value,
                 Err(WaitError::Timeout) => panic!("read timed out after commit"),
             };
-            // SAFETY: `ptr` points at a readable `u64`; the value is Copy.
-            assert_eq!(unsafe { ptr.read() }, 9);
-            consumer.finalize();
+            assert_eq!(value, 9);
+        }
+    }
+
+    #[test]
+    fn read_session_releases_consumed_prefix_on_drop() {
+        for create_queue in test_queue_creators::<u64>() {
+            let (mut producer, mut consumer) = create_queue(4);
+            for value in 0..4 {
+                producer.try_write(value).unwrap();
+            }
+
+            {
+                let mut session = consumer.read_session();
+                assert_eq!(session.try_read(), Some(0));
+                assert_eq!(session.try_read(), Some(1));
+                assert!(producer.try_write(4).is_err());
+            }
+
+            assert!(producer.try_write(4).is_ok());
+            assert_eq!(consumer.try_read(), Some(2));
+            assert_eq!(consumer.try_read(), Some(3));
+            assert_eq!(consumer.try_read(), Some(4));
+            assert_eq!(consumer.try_read(), None);
+        }
+    }
+
+    #[test]
+    fn read_session_uses_a_single_publication_snapshot() {
+        for create_queue in test_queue_creators::<u64>() {
+            let (mut producer, mut consumer) = create_queue(4);
+            producer.try_write(0).unwrap();
+
+            let mut session = consumer.read_session();
+            producer.try_write(1).unwrap();
+            assert_eq!(session.try_read(), Some(0));
+            assert_eq!(session.try_read(), None);
+            drop(session);
+
+            assert_eq!(consumer.try_read(), Some(1));
+        }
+    }
+
+    #[test]
+    fn read_batch_is_bounded_and_releases_on_drop() {
+        for create_queue in test_queue_creators::<u64>() {
+            let (mut producer, mut consumer) = create_queue(4);
+            for value in 0..4 {
+                producer.try_write(value).unwrap();
+            }
+
+            {
+                let batch = consumer
+                    .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+                    .expect("read batch");
+                assert_eq!(batch.len(), 2);
+                assert!(!batch.is_empty());
+                assert_eq!(batch.get(0), Some(&0));
+                assert_eq!(batch[1], 1);
+                assert_eq!(batch.get_owned(1), Some(1));
+                assert_eq!(batch.get(2), None);
+                assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![0, 1]);
+                assert!(producer.try_write(4).is_err());
+            }
+
+            assert!(producer.try_write(4).is_ok());
+            let batch = consumer
+                .reserve_read_batch_timeout(NonZeroUsize::new(8).unwrap(), Duration::ZERO)
+                .expect("remaining batch");
+            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![2, 3, 4]);
+        }
+    }
+
+    #[test]
+    fn read_batch_supports_wrapped_random_access() {
+        for create_queue in test_queue_creators::<u64>() {
+            let (mut producer, mut consumer) = create_queue(4);
+            for value in 0..3 {
+                producer.try_write(value).unwrap();
+            }
+            assert_eq!(consumer.try_read(), Some(0));
+            assert_eq!(consumer.try_read(), Some(1));
+            for value in 3..6 {
+                producer.try_write(value).unwrap();
+            }
+
+            let batch = consumer
+                .try_reserve_read_batch(NonZeroUsize::new(4).unwrap())
+                .expect("wrapped read batch");
+            assert_eq!(batch.get_owned(3), Some(5));
+            assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
+            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
+        }
+    }
+
+    struct CountedItem {
+        value: u64,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Drop for CountedItem {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn read_batch_drop_and_partial_drain_drop_values() {
+        for create_queue in test_queue_creators::<CountedItem>() {
+            let drops = Arc::new(AtomicUsize::new(0));
+            let (mut producer, mut consumer) = create_queue(4);
+            for value in 0..3 {
+                producer
+                    .try_write(CountedItem {
+                        value,
+                        drops: Arc::clone(&drops),
+                    })
+                    .unwrap_or_else(|_| panic!("write failed"));
+            }
+
+            let batch = consumer
+                .try_reserve_read_batch(NonZeroUsize::new(3).unwrap())
+                .expect("read batch");
+            assert_eq!(
+                batch.iter().map(|item| item.value).collect::<Vec<_>>(),
+                vec![0, 1, 2]
+            );
+            drop(batch);
+            assert_eq!(drops.load(Ordering::Relaxed), 3);
+
+            for value in 3..6 {
+                producer
+                    .try_write(CountedItem {
+                        value,
+                        drops: Arc::clone(&drops),
+                    })
+                    .unwrap_or_else(|_| panic!("write failed"));
+            }
+            let batch = consumer
+                .try_reserve_read_batch(NonZeroUsize::new(3).unwrap())
+                .expect("read batch");
+            let mut drain = batch.drain();
+            let first = drain.next().expect("first value");
+            assert_eq!(first.value, 3);
+            drop(first);
+            drop(drain);
+            assert_eq!(drops.load(Ordering::Relaxed), 6);
+        }
+    }
+
+    struct PanicOnDrop(bool);
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            assert!(!self.0, "requested drop panic");
+        }
+    }
+
+    #[test]
+    fn panicking_batch_element_drop_still_releases_reservation() {
+        let (mut producer, mut consumer) = pair(2).expect("failed to create queue");
+        producer
+            .try_write(PanicOnDrop(true))
+            .unwrap_or_else(|_| panic!("write failed"));
+        producer
+            .try_write(PanicOnDrop(false))
+            .unwrap_or_else(|_| panic!("write failed"));
+        let batch = consumer
+            .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+            .expect("read batch");
+
+        assert!(catch_unwind(AssertUnwindSafe(|| drop(batch))).is_err());
+
+        producer
+            .try_write(PanicOnDrop(false))
+            .unwrap_or_else(|_| panic!("write failed"));
+        producer
+            .try_write(PanicOnDrop(false))
+            .unwrap_or_else(|_| panic!("write failed"));
+        drop(
+            consumer
+                .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+                .expect("replacement read batch"),
+        );
+    }
+
+    #[test]
+    fn reserve_read_batch_timeout_waits_for_at_least_one_value() {
+        for create_queue in test_queue_creators::<u64>() {
+            let (mut producer, mut consumer) = create_queue(4);
+            assert!(matches!(
+                consumer.reserve_read_batch_timeout(
+                    NonZeroUsize::new(4).unwrap(),
+                    Duration::from_millis(1),
+                ),
+                Err(WaitError::Timeout)
+            ));
+
+            producer.try_write(7).unwrap();
+            let batch = consumer
+                .reserve_read_batch_timeout(NonZeroUsize::new(4).unwrap(), Duration::ZERO)
+                .expect("read batch");
+            assert_eq!(batch.len(), 1);
+            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![7]);
         }
     }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -280,22 +280,43 @@ impl<T> Consumer<T> {
 
     /// Attempts to read a value from the queue.
     /// Returns `None` if there are no values available.
-    /// Returns a reference to the value if available.
-    pub fn try_read(&mut self) -> Option<&T> {
-        // SAFETY: `try_read_ptr` returns a pointer to properly aligned
-        //         location for `T`.
-        //         IF producer properly wrote items, or T is POD, it is
-        //         safe to convert to reference here.
-        self.try_read_ptr().map(|p| unsafe { p.as_ref() })
+    /// Returns ownership of the value if available.
+    ///
+    /// Call [`Self::finalize`] to release consumed capacity back to the
+    /// producer. Pending capacity is also released when the consumer is
+    /// dropped.
+    pub fn try_read(&mut self) -> Option<T> {
+        let read_ptr = self.try_reserve_read_ptr()?;
+        // SAFETY: `read_ptr` is the initialized position just reserved by this
+        // consumer, and ownership has not previously been taken from it.
+        Some(unsafe { read_ptr.read() })
     }
 
-    /// Attempts to read a value from the queue.
+    /// Attempts to reserve a value for zero-copy reading.
     /// Returns `None` if there are no values available.
     /// Returns a pointer to the value if available.
     ///
-    /// All read items should be processed and pointers discarded before
-    /// calling `finalize`.
-    pub fn try_read_ptr(&mut self) -> Option<NonNull<T>> {
+    /// All returned pointers must be discarded before calling
+    /// [`Self::finalize`] or dropping the consumer.
+    pub fn try_read_ptr(&mut self) -> Option<NonNull<T>>
+    where
+        T: Copy,
+    {
+        self.try_reserve_read_ptr()
+    }
+
+    /// Attempts to reserve a value for raw reading.
+    ///
+    /// # Safety
+    /// Before the read position is released, every reserved non-`Copy` value
+    /// must be moved out or dropped exactly once. No reference or pointer to a
+    /// reserved value may be used after its position is released. Dropping the
+    /// consumer releases all pending read positions.
+    pub unsafe fn try_read_ptr_raw(&mut self) -> Option<NonNull<T>> {
+        self.try_reserve_read_ptr()
+    }
+
+    fn try_reserve_read_ptr(&mut self) -> Option<NonNull<T>> {
         if self.queue.cached_read == self.queue.cached_write {
             return None; // Queue is empty
         }
@@ -308,8 +329,8 @@ impl<T> Consumer<T> {
         Some(read_ptr)
     }
 
-    /// Publishes the read position, making it visible to the producer.
-    /// All previously read items MUST be processed before this is called.
+    /// Publishes the current read position, releasing all reserved capacity
+    /// back to the producer.
     pub fn finalize(&mut self) {
         self.queue
             .header()
@@ -339,18 +360,16 @@ impl<T> Consumer<T> {
             })
     }
 
-    /// Blocks until a committed item can be reserved for reading or `timeout`
+    /// Blocks until ownership of a committed item can be taken or `timeout`
     /// elapses.
     ///
-    /// The caller must still call [`Self::finalize`] to release consumed
-    /// capacity back to the producer.
-    pub fn read_timeout(&mut self, timeout: Duration) -> Result<&T, WaitError> {
-        // SAFETY: `read_ptr_timeout` returns a pointer to properly aligned
-        //         location for `T`.
-        //         IF producer properly wrote items, or T is POD, it is
-        //         safe to convert to reference here.
-        self.read_ptr_timeout(timeout)
-            .map(|p| unsafe { p.as_ref() })
+    /// Call [`Self::finalize`] to release consumed capacity back to the
+    /// producer.
+    pub fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
+        let read_ptr = self.reserve_read_ptr_timeout(timeout)?;
+        // SAFETY: `read_ptr` is the initialized position just reserved by this
+        // consumer, and ownership has not previously been taken from it.
+        Ok(unsafe { read_ptr.read() })
     }
 
     /// Blocks until a committed item can be reserved for reading or `timeout`
@@ -358,7 +377,26 @@ impl<T> Consumer<T> {
     ///
     /// The caller must still process all returned pointers and call
     /// [`Self::finalize`] to release consumed capacity back to the producer.
-    pub fn read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError> {
+    pub fn read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError>
+    where
+        T: Copy,
+    {
+        self.reserve_read_ptr_timeout(timeout)
+    }
+
+    /// Blocks until a committed item can be reserved for raw reading or
+    /// `timeout` elapses.
+    ///
+    /// # Safety
+    /// The caller must satisfy [`Self::try_read_ptr_raw`]'s safety contract.
+    pub unsafe fn read_ptr_raw_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<NonNull<T>, WaitError> {
+        self.reserve_read_ptr_timeout(timeout)
+    }
+
+    fn reserve_read_ptr_timeout(&mut self, timeout: Duration) -> Result<NonNull<T>, WaitError> {
         let header = self.queue.header;
         // SAFETY: `header` points to this consumer's live shared queue header.
         let header = unsafe { header.as_ref() };
@@ -366,7 +404,7 @@ impl<T> Consumer<T> {
             .waiters
             .wait_for(&header.write, SPIN_ATTEMPTS, timeout, || {
                 self.queue.load_write();
-                self.try_read_ptr()
+                self.try_reserve_read_ptr()
             })
     }
 }
@@ -375,6 +413,12 @@ impl<T> Consumer<T> {
 // shared buffer is synchronized by the queue protocol, so it is safe to move
 // to another thread when `T: Send`.
 unsafe impl<T: Send> Send for Consumer<T> {}
+
+impl<T> Drop for Consumer<T> {
+    fn drop(&mut self) {
+        self.finalize();
+    }
+}
 
 struct SharedQueue<T> {
     header: NonNull<SharedQueueHeader>,
@@ -733,9 +777,26 @@ mod tests {
             producer.commit();
             consumer.sync();
             let val = consumer.try_read().expect("read failed");
-            assert_eq!(*val, 42);
+            assert_eq!(val, 42);
             consumer.finalize();
         }
+    }
+
+    #[test]
+    fn test_owned_read_non_copy() {
+        let (mut producer, mut consumer) = pair(1).expect("failed to create queue");
+        let value = Arc::new(42);
+
+        producer.try_write(Arc::clone(&value)).unwrap();
+        producer.commit();
+        consumer.sync();
+
+        let received = consumer.try_read().expect("read failed");
+        assert!(Arc::ptr_eq(&received, &value));
+        consumer.finalize();
+        assert_eq!(Arc::strong_count(&value), 2);
+        drop(received);
+        assert_eq!(Arc::strong_count(&value), 1);
     }
 
     #[test]
@@ -751,7 +812,7 @@ mod tests {
             producer.commit();
             consumer.sync();
             let val = consumer.try_read().expect("read failed");
-            assert_eq!(*val, 99);
+            assert_eq!(val, 99);
             consumer.finalize();
         }
     }
@@ -773,7 +834,7 @@ mod tests {
             // Can still read the message from the shared consumer
             consumer.sync();
             let val = consumer.try_read().expect("read after producer drop");
-            assert_eq!(*val, 7);
+            assert_eq!(val, 7);
             consumer.finalize();
         }
     }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -345,22 +345,13 @@ impl<T> Consumer<T> {
     /// Returns `None` if there are no values available. Consumed capacity is
     /// released before this method returns.
     ///
-    /// When reading multiple items, prefer [`Self::read_session`] or
-    /// [`Self::try_reserve_read_batch`] to amortize synchronization and
-    /// capacity release across the batch.
+    /// When reading multiple items, prefer [`Self::try_reserve_read_batch`] to
+    /// amortize synchronization and capacity release across the batch.
     pub fn try_read(&mut self) -> Option<T> {
-        self.read_session().try_read()
-    }
-
-    /// Starts a streaming read session.
-    ///
-    /// The consumer synchronizes with the producer once when the session is
-    /// created. Repeated calls to [`ReadSession::try_read`] consume from that
-    /// snapshot without further synchronization. Consumed capacity is
-    /// released when the session is dropped.
-    pub fn read_session(&mut self) -> ReadSession<'_, T> {
         self.sync();
-        ReadSession { consumer: self }
+        let item = self.try_read_inner();
+        self.finalize();
+        item
     }
 
     /// Attempts to reserve up to `max` values from the queue.
@@ -477,29 +468,6 @@ unsafe impl<T: Send> Send for Consumer<T> {}
 impl<T> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.finalize();
-    }
-}
-
-/// A streaming read session that releases consumed capacity on drop.
-///
-/// The session observes the producer's publication cursor once when it is
-/// created. Values published later are visible to the next session.
-#[must_use]
-pub struct ReadSession<'a, T> {
-    consumer: &'a mut Consumer<T>,
-}
-
-impl<T> ReadSession<'_, T> {
-    /// Takes ownership of the next value in this session's snapshot, or
-    /// returns `None` when the snapshot has been exhausted.
-    pub fn try_read(&mut self) -> Option<T> {
-        self.consumer.try_read_inner()
-    }
-}
-
-impl<T> Drop for ReadSession<'_, T> {
-    fn drop(&mut self) {
-        self.consumer.finalize();
     }
 }
 
@@ -1064,19 +1032,22 @@ mod tests {
                 assert!(batch.try_write(AtomicU64::new(1)).is_err());
             }
             {
-                let mut session = consumer.read_session();
+                let batch = consumer
+                    .try_reserve_read_batch(NonZeroUsize::new(BUFFER_CAPACITY).unwrap())
+                    .expect("Failed to reserve read batch");
+                let mut drain = batch.drain();
                 for _ in 0..BUFFER_CAPACITY {
-                    let item = session.try_read().expect("Failed to read item");
+                    let item = drain.next().expect("Failed to read item");
                     assert_eq!(item.load(Ordering::Acquire), 1);
                 }
-                assert!(session.try_read().is_none()); // no more items to read
+                assert!(drain.next().is_none()); // no more items to read
             }
 
-            // Ensure we can write again after the session releases its reads.
+            // Ensure we can write again after the batch releases its reads.
             producer.try_write(AtomicU64::new(2)).unwrap();
             let item = consumer
                 .try_read()
-                .expect("Failed to read item after session");
+                .expect("Failed to read item after batch");
             assert_eq!(item.load(Ordering::Acquire), 2);
         }
     }
@@ -1228,45 +1199,6 @@ mod tests {
                 Err(WaitError::Timeout) => panic!("read timed out after commit"),
             };
             assert_eq!(value, 9);
-        }
-    }
-
-    #[test]
-    fn read_session_releases_consumed_prefix_on_drop() {
-        for create_queue in test_queue_creators::<u64>() {
-            let (mut producer, mut consumer) = create_queue(4);
-            for value in 0..4 {
-                producer.try_write(value).unwrap();
-            }
-
-            {
-                let mut session = consumer.read_session();
-                assert_eq!(session.try_read(), Some(0));
-                assert_eq!(session.try_read(), Some(1));
-                assert!(producer.try_write(4).is_err());
-            }
-
-            assert!(producer.try_write(4).is_ok());
-            assert_eq!(consumer.try_read(), Some(2));
-            assert_eq!(consumer.try_read(), Some(3));
-            assert_eq!(consumer.try_read(), Some(4));
-            assert_eq!(consumer.try_read(), None);
-        }
-    }
-
-    #[test]
-    fn read_session_uses_a_single_publication_snapshot() {
-        for create_queue in test_queue_creators::<u64>() {
-            let (mut producer, mut consumer) = create_queue(4);
-            producer.try_write(0).unwrap();
-
-            let mut session = consumer.read_session();
-            producer.try_write(1).unwrap();
-            assert_eq!(session.try_read(), Some(0));
-            assert_eq!(session.try_read(), None);
-            drop(session);
-
-            assert_eq!(consumer.try_read(), Some(1));
         }
     }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -9,7 +9,7 @@ use core::{
     iter::FusedIterator,
     marker::PhantomData,
     mem::{ManuallyDrop, MaybeUninit},
-    ops::Index,
+    ops::{Index, Range},
     ptr::NonNull,
 };
 use std::{
@@ -564,16 +564,50 @@ impl<'a, T> ReadBatch<'a, T> {
     /// Iterates over shared references without consuming any values.
     ///
     /// The batch reservation remains held for the iterator's lifetime.
-    pub fn iter(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = &T> + ExactSizeIterator + FusedIterator + '_ {
-        (0..self.len()).map(|index| {
-            // SAFETY: The safe batch has not moved out any values, and the
-            // range only produces indices within the reservation.
-            unsafe { self.reservation.get_unchecked(index) }
-        })
+    pub fn iter(&self) -> ReadBatchIter<'_, 'a, T> {
+        self.into_iter()
     }
 }
+
+impl<'batch, 'queue, T> IntoIterator for &'batch ReadBatch<'queue, T> {
+    type Item = &'batch T;
+    type IntoIter = ReadBatchIter<'batch, 'queue, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ReadBatchIter {
+            batch: self,
+            range: 0..self.len(),
+        }
+    }
+}
+
+/// An iterator over shared references to the values in a read batch.
+#[must_use]
+pub struct ReadBatchIter<'batch, 'queue, T> {
+    batch: &'batch ReadBatch<'queue, T>,
+    range: Range<usize>,
+}
+
+impl<'batch, T> Iterator for ReadBatchIter<'batch, '_, T> {
+    type Item = &'batch T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.batch.get(self.range.next()?)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<T> DoubleEndedIterator for ReadBatchIter<'_, '_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.batch.get(self.range.next_back()?)
+    }
+}
+
+impl<T> ExactSizeIterator for ReadBatchIter<'_, '_, T> {}
+impl<T> FusedIterator for ReadBatchIter<'_, '_, T> {}
 
 impl<'a, T> IntoIterator for ReadBatch<'a, T> {
     type Item = T;
@@ -1226,6 +1260,11 @@ mod tests {
                 assert_eq!(batch.get_owned(1), Some(1));
                 assert_eq!(batch.get(2), None);
                 assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![0, 1]);
+                let mut borrowed = Vec::new();
+                for value in &batch {
+                    borrowed.push(*value);
+                }
+                assert_eq!(borrowed, vec![0, 1]);
                 assert!(producer.try_write(4).is_err());
             }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -357,8 +357,8 @@ impl<T> Consumer<T> {
     /// Attempts to reserve up to `max` values from the queue.
     ///
     /// The consumer synchronizes with the producer before reserving. Dropping
-    /// the returned batch drops any values that were not moved out through
-    /// [`ReadBatch::drain`] and releases the complete reservation.
+    /// the returned batch drops any values that were not moved out through its
+    /// [`IntoIterator`] implementation and releases the complete reservation.
     #[must_use]
     pub fn try_reserve_read_batch(&mut self, max: NonZeroUsize) -> Option<ReadBatch<'_, T>> {
         self.sync();
@@ -431,7 +431,7 @@ impl<T> Consumer<T> {
     pub fn read_timeout(&mut self, timeout: Duration) -> Result<T, WaitError> {
         let batch = self.reserve_read_batch_timeout(NonZeroUsize::MIN, timeout)?;
         Ok(batch
-            .drain()
+            .into_iter()
             .next()
             .expect("a successful one-item reservation is non-empty"))
     }
@@ -536,9 +536,9 @@ impl<T> Drop for ReadReservation<'_, T> {
 /// A destructor-safe reservation for consecutive initialized consumer slots.
 ///
 /// The batch keeps all of its slots reserved while it lives. It may be
-/// inspected without consuming values, and [`Self::drain`] converts it into a
-/// sequential consuming iterator. Dropping the batch without draining it drops
-/// every value before releasing the reservation.
+/// inspected without consuming values or converted into a sequential consuming
+/// iterator. Dropping the batch without consuming it drops every value before
+/// releasing the reservation.
 #[must_use]
 pub struct ReadBatch<'a, T> {
     reservation: ReadReservation<'a, T>,
@@ -573,16 +573,22 @@ impl<'a, T> ReadBatch<'a, T> {
             unsafe { self.reservation.get_unchecked(index) }
         })
     }
+}
+
+impl<'a, T> IntoIterator for ReadBatch<'a, T> {
+    type Item = T;
+    type IntoIter = ReadBatchIntoIter<'a, T>;
 
     /// Converts the batch into a sequential consuming iterator.
     ///
-    /// The returned drain keeps the complete batch reservation held. Dropping
-    /// it before exhaustion drops all values that have not yet been yielded.
-    pub fn drain(self) -> ReadBatchDrain<'a, T> {
+    /// The returned iterator keeps the complete batch reservation held.
+    /// Dropping it before exhaustion drops all values that have not yet been
+    /// yielded.
+    fn into_iter(self) -> Self::IntoIter {
         let batch = ManuallyDrop::new(self);
         // SAFETY: `batch` is not dropped, so this moves its reservation exactly once.
         let reservation = unsafe { core::ptr::read(&batch.reservation) };
-        ReadBatchDrain {
+        ReadBatchIntoIter {
             reservation,
             next: 0,
         }
@@ -625,12 +631,12 @@ impl<T> Drop for ReadBatch<'_, T> {
 /// dropped. Dropping it before exhaustion drops the unconsumed suffix before
 /// releasing the reservation.
 #[must_use]
-pub struct ReadBatchDrain<'a, T> {
+pub struct ReadBatchIntoIter<'a, T> {
     reservation: ReadReservation<'a, T>,
     next: usize,
 }
 
-impl<T> Iterator for ReadBatchDrain<'_, T> {
+impl<T> Iterator for ReadBatchIntoIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -650,10 +656,10 @@ impl<T> Iterator for ReadBatchDrain<'_, T> {
     }
 }
 
-impl<T> ExactSizeIterator for ReadBatchDrain<'_, T> {}
-impl<T> FusedIterator for ReadBatchDrain<'_, T> {}
+impl<T> ExactSizeIterator for ReadBatchIntoIter<'_, T> {}
+impl<T> FusedIterator for ReadBatchIntoIter<'_, T> {}
 
-impl<T> Drop for ReadBatchDrain<'_, T> {
+impl<T> Drop for ReadBatchIntoIter<'_, T> {
     fn drop(&mut self) {
         if !core::mem::needs_drop::<T>() {
             return;
@@ -1035,12 +1041,12 @@ mod tests {
                 let batch = consumer
                     .try_reserve_read_batch(NonZeroUsize::new(BUFFER_CAPACITY).unwrap())
                     .expect("Failed to reserve read batch");
-                let mut drain = batch.drain();
+                let mut iter = batch.into_iter();
                 for _ in 0..BUFFER_CAPACITY {
-                    let item = drain.next().expect("Failed to read item");
+                    let item = iter.next().expect("Failed to read item");
                     assert_eq!(item.load(Ordering::Acquire), 1);
                 }
-                assert!(drain.next().is_none()); // no more items to read
+                assert!(iter.next().is_none()); // no more items to read
             }
 
             // Ensure we can write again after the batch releases its reads.
@@ -1227,7 +1233,7 @@ mod tests {
             let batch = consumer
                 .reserve_read_batch_timeout(NonZeroUsize::new(8).unwrap(), Duration::ZERO)
                 .expect("remaining batch");
-            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![2, 3, 4]);
+            assert_eq!(batch.into_iter().collect::<Vec<_>>(), vec![2, 3, 4]);
         }
     }
 
@@ -1249,7 +1255,7 @@ mod tests {
                 .expect("wrapped read batch");
             assert_eq!(batch.get_owned(3), Some(5));
             assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
-            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
+            assert_eq!(batch.into_iter().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
         }
     }
 
@@ -1265,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    fn read_batch_drop_and_partial_drain_drop_values() {
+    fn read_batch_drop_and_partial_iteration_drop_values() {
         for create_queue in test_queue_creators::<CountedItem>() {
             let drops = Arc::new(AtomicUsize::new(0));
             let (mut producer, mut consumer) = create_queue(4);
@@ -1299,11 +1305,11 @@ mod tests {
             let batch = consumer
                 .try_reserve_read_batch(NonZeroUsize::new(3).unwrap())
                 .expect("read batch");
-            let mut drain = batch.drain();
-            let first = drain.next().expect("first value");
+            let mut iter = batch.into_iter();
+            let first = iter.next().expect("first value");
             assert_eq!(first.value, 3);
             drop(first);
-            drop(drain);
+            drop(iter);
             assert_eq!(drops.load(Ordering::Relaxed), 6);
         }
     }
@@ -1361,7 +1367,7 @@ mod tests {
                 .reserve_read_batch_timeout(NonZeroUsize::new(4).unwrap(), Duration::ZERO)
                 .expect("read batch");
             assert_eq!(batch.len(), 1);
-            assert_eq!(batch.drain().collect::<Vec<_>>(), vec![7]);
+            assert_eq!(batch.into_iter().collect::<Vec<_>>(), vec![7]);
         }
     }
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -561,6 +561,30 @@ impl<'a, T> ReadBatch<'a, T> {
         Some(unsafe { self.reservation.get_unchecked(index) })
     }
 
+    /// Returns the values in logical read order as two slices.
+    ///
+    /// The second slice is empty unless the batch wraps around the end of the
+    /// queue buffer. This borrows the values without consuming the batch.
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        let queue = &self.reservation.consumer.queue;
+        let start = self.reservation.start & queue.buffer_mask;
+        let first_len = self.len().min(queue.capacity().wrapping_sub(start));
+        let second_len = self.len().wrapping_sub(first_len);
+
+        // SAFETY: `start` is within the queue buffer.
+        let first = unsafe { queue.buffer.add(start) };
+        let first = NonNull::slice_from_raw_parts(first, first_len);
+        // SAFETY: The first part of the reservation is initialized, contiguous,
+        // and remains reserved for the lifetime of the returned slice.
+        let first = unsafe { first.as_ref() };
+        let second = NonNull::slice_from_raw_parts(queue.buffer, second_len);
+        // SAFETY: The wrapped part of the reservation starts at the buffer base,
+        // is initialized and contiguous, and remains reserved for the lifetime
+        // of the returned slice.
+        let second = unsafe { second.as_ref() };
+        (first, second)
+    }
+
     /// Iterates over shared references without consuming any values.
     ///
     /// The batch reservation remains held for the iterator's lifetime.
@@ -1259,6 +1283,9 @@ mod tests {
                 assert_eq!(batch[1], 1);
                 assert_eq!(batch.get_owned(1), Some(1));
                 assert_eq!(batch.get(2), None);
+                let (first, second) = batch.as_slices();
+                assert_eq!(first, &[0, 1]);
+                assert!(second.is_empty());
                 assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![0, 1]);
                 let mut borrowed = Vec::new();
                 for value in &batch {
@@ -1293,6 +1320,9 @@ mod tests {
                 .try_reserve_read_batch(NonZeroUsize::new(4).unwrap())
                 .expect("wrapped read batch");
             assert_eq!(batch.get_owned(3), Some(5));
+            let (first, second) = batch.as_slices();
+            assert_eq!(first, &[2, 3]);
+            assert_eq!(second, &[4, 5]);
             assert_eq!(batch.iter().copied().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
             assert_eq!(batch.into_iter().collect::<Vec<_>>(), vec![2, 3, 4, 5]);
         }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -229,8 +229,13 @@ impl<'a, T> WriteBatch<'a, T> {
         self.producer.try_write_inner(item)
     }
 
-    /// Returns a maybe-uninit pointer to the reserved position if one is available.
-    pub fn try_as_mut(&mut self) -> Option<&mut MaybeUninit<T>> {
+    /// Returns a mutable reference to the next reserved position if one is available.
+    ///
+    /// # Safety
+    /// If this returns `Some`, the caller must initialize the reserved slot with a
+    /// valid `T` before the batch is dropped and publishes it. This requirement
+    /// also applies if control exits by unwinding.
+    pub unsafe fn try_as_mut(&mut self) -> Option<&mut MaybeUninit<T>> {
         // SAFETY: The reserved slot belongs exclusively to this producer.
         let mut reserved = unsafe { self.producer.reserve() }?.cast();
         // SAFETY: The mutable reference is tied to the borrow of this batch.

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -570,12 +570,9 @@ pub struct ReadBatch<'a, T> {
 }
 
 impl<'a, T> ReadBatch<'a, T> {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.reservation.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        false
     }
 
     /// Returns a shared reference to the value at `index`, or `None` if it is
@@ -1279,7 +1276,6 @@ mod tests {
                     .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
                     .expect("read batch");
                 assert_eq!(batch.len(), 2);
-                assert!(!batch.is_empty());
                 assert_eq!(batch.get(0), Some(&0));
                 assert_eq!(batch[1], 1);
                 assert_eq!(batch.get_owned(1), Some(1));

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -148,6 +148,9 @@ impl<T> Producer<T> {
     }
 
     /// Writes item into the queue or returns it if there is not enough space.
+    ///
+    /// When writing multiple items, prefer [`Self::write_batch`] to amortize
+    /// synchronization and publication across the batch.
     pub fn try_write(&mut self, item: T) -> Result<(), T> {
         self.sync();
         self.try_write_inner(item)?;
@@ -341,6 +344,10 @@ impl<T> Consumer<T> {
     ///
     /// Returns `None` if there are no values available. Consumed capacity is
     /// released before this method returns.
+    ///
+    /// When reading multiple items, prefer [`Self::read_session`] or
+    /// [`Self::try_reserve_read_batch`] to amortize synchronization and
+    /// capacity release across the batch.
     pub fn try_read(&mut self) -> Option<T> {
         self.read_session().try_read()
     }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -34,8 +34,8 @@ pub const fn minimum_region_size<T>(capacity: usize) -> usize {
 
 /// Creates a new in-process SPSC queue pair backed by a heap allocation.
 ///
-/// Values left buffered when the queue is dropped may be leaked instead of
-/// having their destructors run.
+/// Buffered values are dropped with the last endpoint. Values in uncommitted
+/// writes may be leaked.
 pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Error> {
     let region_size = minimum_region_size::<T>(capacity);
     let region = Region::alloc(NonZeroUsize::new(region_size).ok_or(Error::InvalidBufferSize)?)?;
@@ -43,8 +43,9 @@ pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Erro
     let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
     // SAFETY: `header` was just created in `region`, so it is valid for the queue.
     let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;
-    // SAFETY: `header` was just created in `region`, so it is valid for the queue.
-    let consumer = unsafe { Consumer::from_header(region, header) }?;
+    // SAFETY: The region is fresh and has no other consumer.
+    let consumer = unsafe { producer.join_as_consumer() }?;
+
     Ok((producer, consumer))
 }
 
@@ -99,8 +100,9 @@ impl<T> Producer<T> {
     /// # Safety
     /// - The caller must ensure this is the unique Consumer for this queue.
     pub unsafe fn join_as_consumer(&self) -> Result<Consumer<T>, Error> {
-        // SAFETY: caller guarantees uniqueness of the consumer role.
-        unsafe { Consumer::from_header(Arc::clone(&self.queue.region), self.queue.header) }
+        Ok(Consumer {
+            queue: SharedQueue::from_shared(Arc::clone(&self.queue.shared)),
+        })
     }
 
     /// # Safety
@@ -244,8 +246,9 @@ impl<T> Consumer<T> {
     /// # Safety
     /// - The caller must ensure this is the unique Producer for this queue.
     pub unsafe fn join_as_producer(&self) -> Result<Producer<T>, Error> {
-        // SAFETY: caller guarantees uniqueness of the producer role.
-        unsafe { Producer::from_header(Arc::clone(&self.queue.region), self.queue.header) }
+        Ok(Producer {
+            queue: SharedQueue::from_shared(Arc::clone(&self.queue.shared)),
+        })
     }
 
     /// # Safety
@@ -421,12 +424,15 @@ impl<T> Drop for Consumer<T> {
 }
 
 struct SharedQueue<T> {
-    header: NonNull<SharedQueueHeader>,
-    buffer: NonNull<T>,
-
-    buffer_mask: usize,
     cached_write: usize,
     cached_read: usize,
+    shared: Arc<SharedQueueInner<T>>,
+}
+
+struct SharedQueueInner<T> {
+    header: NonNull<SharedQueueHeader>,
+    buffer: NonNull<T>,
+    buffer_mask: usize,
     // `NonNull<T>` is covariant, but paired endpoints must not be independently
     // coerced to different payload lifetimes. The function input/output marker
     // makes `T` invariant without affecting layout or auto traits.
@@ -435,6 +441,35 @@ struct SharedQueue<T> {
     // NB: Region must be declared last so it is dropped last ensuring `header` and
     // `buffer` remain valid for their entire lifetime.
     region: Arc<Region>,
+}
+
+impl<T> core::ops::Deref for SharedQueue<T> {
+    type Target = SharedQueueInner<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared
+    }
+}
+
+impl<T> Drop for SharedQueueInner<T> {
+    fn drop(&mut self) {
+        if !self.region.is_heap() || !core::mem::needs_drop::<T>() {
+            return;
+        }
+
+        // SharedQueueInner is dropped by its Arc after both endpoints
+        // disappear, so the published cursors are final.
+        let header = unsafe { self.header.as_ref() };
+        let mut position = header.read.load(Ordering::Acquire);
+        let write = header.write.load(Ordering::Acquire);
+
+        while position != write {
+            // SAFETY: Published positions not yet released by the consumer
+            // contain initialized values still in the queue.
+            unsafe { self.buffer.add(position & self.buffer_mask).drop_in_place() };
+            position = position.wrapping_add(1);
+        }
+    }
 }
 
 impl<T> SharedQueue<T> {
@@ -460,20 +495,28 @@ impl<T> SharedQueue<T> {
         //         of sufficient size.
         let buffer = unsafe { Self::buffer_from_header(header) };
 
-        let mut queue = Self {
+        let shared = Arc::new(SharedQueueInner {
             region,
             header,
             buffer,
             buffer_mask: size - 1,
+            _invariant: PhantomData,
+        });
+
+        Ok(Self::from_shared(shared))
+    }
+
+    fn from_shared(shared: Arc<SharedQueueInner<T>>) -> Self {
+        let mut queue = Self {
             cached_write: 0,
             cached_read: 0,
-            _invariant: PhantomData,
+            shared,
         };
 
         queue.load_write();
         queue.load_read();
 
-        Ok(queue)
+        queue
     }
 
     /// Gets a pointer to the buffer following the header.
@@ -796,6 +839,20 @@ mod tests {
         consumer.finalize();
         assert_eq!(Arc::strong_count(&value), 2);
         drop(received);
+        assert_eq!(Arc::strong_count(&value), 1);
+    }
+
+    #[test]
+    fn test_heap_pair_drops_buffered_value_with_last_endpoint() {
+        let value = Arc::new(());
+        let (mut producer, consumer) = pair(1).expect("failed to create queue");
+
+        producer.try_write(Arc::clone(&value)).unwrap();
+        producer.commit();
+        drop(producer);
+        assert_eq!(Arc::strong_count(&value), 2);
+
+        drop(consumer);
         assert_eq!(Arc::strong_count(&value), 1);
     }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -217,6 +217,7 @@ impl<T> Producer<T> {
 unsafe impl<T: Send> Send for Producer<T> {}
 
 /// A batch of writes published on drop.
+#[must_use]
 pub struct WriteBatch<'a, T> {
     producer: &'a mut Producer<T>,
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -5,7 +5,7 @@ use crate::{
     shmem::Region,
     CacheAlignedAtomicSize, VERSION,
 };
-use core::{marker::PhantomData, ptr::NonNull};
+use core::{marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
 use std::{
     fs::File,
     num::NonZeroUsize,
@@ -135,8 +135,23 @@ impl<T> Producer<T> {
         self.queue.is_empty()
     }
 
+    /// Start a batched write.
+    pub fn write_batch(&mut self) -> WriteBatch<'_, T> {
+        self.sync();
+        WriteBatch { producer: self }
+    }
+
     /// Writes item into the queue or returns it if there is not enough space.
     pub fn try_write(&mut self, item: T) -> Result<(), T> {
+        self.sync();
+        self.try_write_inner(item)?;
+        self.commit();
+        Ok(())
+    }
+
+    /// Writes item into the queue or returns it if there is not enough space.
+    /// Does not perform synchronization of cached cursors.
+    fn try_write_inner(&mut self, item: T) -> Result<(), T> {
         // SAFETY: pointer is written below if successfully reserved.
         match unsafe { self.reserve() } {
             Some(p) => {
@@ -156,7 +171,7 @@ impl<T> Producer<T> {
     /// # Safety
     /// All reserved positions must be fully initialized before calling `commit`.
     /// Pointers should be dropped before calling `commit`.
-    pub unsafe fn reserve(&mut self) -> Option<NonNull<T>> {
+    unsafe fn reserve(&mut self) -> Option<NonNull<T>> {
         // If write is > read + buffer_mask, the queue is written one iteration
         // ahead of the consumer, and we cannot reserve more space.
         if self.queue.cached_write.wrapping_sub(self.queue.cached_read) > self.queue.buffer_mask {
@@ -172,7 +187,7 @@ impl<T> Producer<T> {
     }
 
     /// Commits the reserved position, making it visible to the consumer.
-    pub fn commit(&self) {
+    fn commit(&self) {
         let header = self.queue.header();
         // Release publication; `wake` supplies the fence that pairs it with
         // a registering waiter and must be called unconditionally; see the
@@ -185,7 +200,7 @@ impl<T> Producer<T> {
 
     /// Synchronize the producer's cached read position with the queue's read
     /// position.
-    pub fn sync(&mut self) {
+    fn sync(&mut self) {
         self.queue.load_read();
     }
 }
@@ -194,6 +209,34 @@ impl<T> Producer<T> {
 // shared buffer is synchronized by the queue protocol, so it is safe to move
 // to another thread when `T: Send`.
 unsafe impl<T: Send> Send for Producer<T> {}
+
+/// A batch of writes published on drop.
+pub struct WriteBatch<'a, T> {
+    producer: &'a mut Producer<T>,
+}
+
+impl<'a, T> WriteBatch<'a, T> {
+    /// If the next sequence number is available, writes the item and returns Ok(()).
+    /// Otherwise, returns an error with the item.
+    pub fn try_write(&mut self, item: T) -> Result<(), T> {
+        self.producer.try_write_inner(item)
+    }
+
+    /// Returns a maybe-uninit pointer to the reserved position if one is available.
+    pub fn try_as_mut(&mut self) -> Option<&mut MaybeUninit<T>> {
+        // SAFETY: The reserved slot belongs exclusively to this producer.
+        let mut reserved = unsafe { self.producer.reserve() }?.cast();
+        // SAFETY: The mutable reference is tied to the borrow of this batch.
+        Some(unsafe { reserved.as_mut() })
+    }
+}
+
+impl<'a, T> Drop for WriteBatch<'a, T> {
+    fn drop(&mut self) {
+        // Commit any written items
+        self.producer.commit();
+    }
+}
 
 /// Consumer side of the SPSC shared queue.
 pub struct Consumer<T> {
@@ -458,15 +501,19 @@ impl<T> Drop for SharedQueueInner<T> {
         }
 
         // SharedQueueInner is dropped by its Arc after both endpoints
-        // disappear, so the published cursors are final.
+        // disappear, so the published cursors are final. `header` remains
+        // valid because `region` is still alive and is dropped last.
+        // SAFETY: `header` points into the live region for this queue.
         let header = unsafe { self.header.as_ref() };
         let mut position = header.read.load(Ordering::Acquire);
         let write = header.write.load(Ordering::Acquire);
 
         while position != write {
+            // SAFETY: Masking the position produces an index within the buffer.
+            let value = unsafe { self.buffer.add(position & self.buffer_mask) };
             // SAFETY: Published positions not yet released by the consumer
             // contain initialized values still in the queue.
-            unsafe { self.buffer.add(position & self.buffer_mask).drop_in_place() };
+            unsafe { value.drop_in_place() };
             position = position.wrapping_add(1);
         }
     }
@@ -771,18 +818,15 @@ mod tests {
             assert_eq!(item.load(Ordering::Acquire), 42);
             assert!(consumer.try_read().is_none()); // no more items to read
             consumer.finalize();
-            producer.sync();
 
             // Ensure we can push up to the capacity.
-            for _ in 0..BUFFER_CAPACITY {
-                // SAFETY: single producer over the queue.
-                let spot = unsafe { producer.reserve() }.expect("Failed to reserve");
-                // SAFETY: spot is a valid reserved slot.
-                unsafe { spot.as_ref() }.store(1, Ordering::Release);
+            {
+                let mut batch = producer.write_batch();
+                for _ in 0..BUFFER_CAPACITY {
+                    assert!(batch.try_write(AtomicU64::new(1)).is_ok());
+                }
+                assert!(batch.try_write(AtomicU64::new(1)).is_err());
             }
-            // SAFETY: single producer; buffer is full so reserve yields None.
-            assert!(unsafe { producer.reserve() }.is_none()); // buffer is full, we cannot reserve more
-            producer.commit();
             consumer.sync();
             for _ in 0..BUFFER_CAPACITY {
                 let item = consumer.try_read().expect("Failed to read item");
@@ -790,14 +834,9 @@ mod tests {
             }
             assert!(consumer.try_read().is_none()); // no more items to read
             consumer.finalize();
-            producer.sync();
 
-            // Ensure we can reserve again after finalizing/sync.
-            // SAFETY: single producer over the queue after finalize.
-            let spot = unsafe { producer.reserve() }.expect("Failed to reserve after finalize");
-            // SAFETY: spot is a valid reserved slot.
-            unsafe { spot.as_ref() }.store(2, Ordering::Release);
-            producer.commit();
+            // Ensure we can write again after finalizing.
+            producer.try_write(AtomicU64::new(2)).unwrap();
             consumer.sync();
             let item = consumer
                 .try_read()
@@ -817,7 +856,6 @@ mod tests {
             let mut consumer = unsafe { producer.join_as_consumer() }.expect("join failed");
 
             producer.try_write(42).unwrap();
-            producer.commit();
             consumer.sync();
             let val = consumer.try_read().expect("read failed");
             assert_eq!(val, 42);
@@ -831,7 +869,6 @@ mod tests {
         let value = Arc::new(42);
 
         producer.try_write(Arc::clone(&value)).unwrap();
-        producer.commit();
         consumer.sync();
 
         let received = consumer.try_read().expect("read failed");
@@ -848,7 +885,6 @@ mod tests {
         let (mut producer, consumer) = pair(1).expect("failed to create queue");
 
         producer.try_write(Arc::clone(&value)).unwrap();
-        producer.commit();
         drop(producer);
         assert_eq!(Arc::strong_count(&value), 2);
 
@@ -866,7 +902,6 @@ mod tests {
             let mut producer = unsafe { consumer.join_as_producer() }.expect("join failed");
 
             producer.try_write(99).unwrap();
-            producer.commit();
             consumer.sync();
             let val = consumer.try_read().expect("read failed");
             assert_eq!(val, 99);
@@ -885,7 +920,6 @@ mod tests {
 
             // Write a message then drop.
             producer.try_write(7).unwrap();
-            producer.commit();
             drop(producer);
 
             // Can still read the message from the shared consumer
@@ -937,7 +971,6 @@ mod tests {
             let (mut producer, mut consumer) = create_queue(64);
 
             producer.try_write(1).unwrap();
-            producer.commit();
 
             // `Duration::MAX` overflows `Instant`; the deadline must saturate
             // instead of panicking. Data is already committed so this returns
@@ -964,7 +997,6 @@ mod tests {
             ));
 
             producer.try_write(9).unwrap();
-            producer.commit();
 
             let ptr = match consumer.read_ptr_timeout(Duration::ZERO) {
                 Ok(ptr) => ptr,


### PR DESCRIPTION
### Problem
- spsc queues do not transfer ownership correctly for non-copy values
- heap-backed queues did not drop buffered items during tear-down

### Summary of Changes
- change read fns to move value out of queue (taking ownership)
- drop buffered values during final heap teardown