### PR TITLE
fix: broadcast consumer join and recovery race

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -11,8 +11,9 @@
 //! `*_timeout` variants that park on the queue's futex when idle. A consumer
 //! joins at each lane's reservation frontier, skipping values that were already
 //! reserved. After a crash, a lane or consumer index can be taken over with
-//! `recover` (resuming where the dead owner was) or returned to the pool with
-//! `force_release`.
+//! `recover` or returned to the pool with `force_release`. A fully joined
+//! consumer resumes where the dead owner was; an interrupted join restarts at
+//! each lane's current reservation frontier.
 //!
 //! Typed payloads require `T: Copy`, which ensures that `T` cannot implement
 //! [`Drop`] and therefore does not require a destructor when a cell is
@@ -48,7 +49,7 @@ use crate::futex::{Waiters, SPIN_ATTEMPTS};
 use crate::shmem::Region;
 use crate::{CacheAlignedAtomicSize, VERSION};
 
-use consumer_state::ConsumerState;
+use consumer_state::{ConsumerRecoveryMode, ConsumerState};
 use producer_lane::ProducerLane;
 
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqcast");
@@ -415,15 +416,20 @@ impl SharedQueue {
         self.consumer_state.acquire()
     }
 
+    /// Marks a consumer index active after every lane cursor is installed.
+    fn activate_consumer_index(&self, index: usize) {
+        self.consumer_state.activate(index);
+    }
+
     /// Releases a consumer index back to free.
     fn release_consumer_index(&self, index: usize) {
         self.consumer_state.release(index);
     }
 
-    /// Force-owns a consumer index whose previous owner died (no CAS). The
-    /// caller guarantees that owner is dead and no live handle uses the index.
-    fn recover_consumer_index(&self, index: usize) {
-        self.consumer_state.recover(index);
+    /// Determines whether recovery can resume complete lane cursors or must
+    /// restart an interrupted join.
+    fn begin_consumer_recovery(&self, index: usize) -> ConsumerRecoveryMode {
+        self.consumer_state.begin_recovery(index)
     }
 
     /// Maps `file`, initializing it as a broadcast queue.
@@ -824,6 +830,7 @@ impl ConsumerCore {
             .iter()
             .map(|lane| Self::join_lane(lane, index))
             .collect();
+        queue.activate_consumer_index(index);
         Ok(Self {
             queue,
             index,
@@ -837,15 +844,24 @@ impl ConsumerCore {
         if index >= queue.consumer_slots() {
             return Err(Error::InvalidIndex);
         }
-        queue.recover_consumer_index(index);
-        // Resume each lane at the dead owner's recorded position.
+        let recovery_mode = queue.begin_consumer_recovery(index);
         let lanes: Box<[ProducerLane]> = (0..queue.producer_slots())
             .map(|lane| queue.lane(lane))
             .collect();
-        let next_by_lane = lanes
-            .iter()
-            .map(|lane| Self::recover_lane(lane, index))
-            .collect();
+        let next_by_lane = match recovery_mode {
+            ConsumerRecoveryMode::Resume => lanes
+                .iter()
+                .map(|lane| Self::recover_lane(lane, index))
+                .collect(),
+            ConsumerRecoveryMode::RestartJoin => {
+                let next_by_lane = lanes
+                    .iter()
+                    .map(|lane| Self::join_lane(lane, index))
+                    .collect();
+                queue.activate_consumer_index(index);
+                next_by_lane
+            }
+        };
         Ok(Self {
             queue,
             index,
@@ -1027,11 +1043,12 @@ impl<T: Copy> Consumer<T> {
         self.core.index()
     }
 
-    /// Takes over a consumer index whose owner died, without the usual ownership
-    /// handshake, **resuming where the dead owner left off** on each lane — its
-    /// unread items are still pinned by its reserve limit, so they are delivered.
-    /// To instead restart fresh, [`force_release`](Self::force_release) the index
-    /// and `join` it however you like.
+    /// Takes over a consumer index whose owner died. A fully joined consumer
+    /// **resumes where the dead owner left off** on each lane — its unread items
+    /// are still pinned by its reserve limit, so they are delivered. If the
+    /// owner died before joining every lane, recovery instead restarts every
+    /// lane at its current reservation frontier. To unconditionally restart
+    /// fresh, [`force_release`](Self::force_release) the index and `join` it.
     ///
     /// # Safety
     /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
@@ -1295,8 +1312,10 @@ impl SliceConsumer {
         self.core.payload_size()
     }
 
-    /// Takes over a consumer index whose owner died, resuming where the dead
-    /// owner left off on each lane.
+    /// Takes over a consumer index whose owner died. A fully joined consumer
+    /// resumes where the dead owner left off on each lane. If the owner died
+    /// before joining every lane, recovery instead restarts every lane at its
+    /// current reservation frontier.
     ///
     /// # Safety
     /// - All of [`Self::join`]'s requirements, plus: the consumer that owned
@@ -2248,6 +2267,7 @@ mod tests {
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
         ConsumerCore::join_lane(&lane, index);
+        queue.activate_consumer_index(index);
 
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
@@ -2265,6 +2285,37 @@ mod tests {
     }
 
     #[test]
+    fn recover_consumer_restarts_an_interrupted_join() {
+        let config = BroadcastConfig {
+            capacity: 4,
+            producer_slots: 1,
+            consumer_slots: 1,
+        };
+        let queue = recovery_queue(&config);
+        let index = queue.acquire_consumer_index().unwrap();
+        let lane = queue.lane(0);
+        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+
+        // The consumer sampled reservation 0, then the producer filled the ring
+        // before the consumer published its initial limit. Simulate a crash after
+        // that initial limit store but before the second reservation sample. The
+        // global ownership slot deliberately remains JOINING.
+        for value in 0..4u64 {
+            assert!(producer.try_write(value).is_ok());
+        }
+        lane.consumer_state().set_cursor(index, 0);
+
+        // Recovery must restart the incomplete join at reservation 4 rather than
+        // interpreting the temporary limit as a completed cursor at sequence 0.
+        let mut recovered = Consumer::recover_in_queue(queue.clone(), index).unwrap();
+        assert_eq!(recovered.try_read(), None);
+
+        assert!(producer.try_write(99).is_ok());
+        assert_eq!(recovered.try_read(), Some(99));
+        assert_eq!(recovered.try_read(), None);
+    }
+
+    #[test]
     fn force_release_consumer_frees_the_index_for_a_fresh_join() {
         let config = BroadcastConfig {
             capacity: 8,
@@ -2278,6 +2329,7 @@ mod tests {
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
         ConsumerCore::join_lane(&lane, index);
+        queue.activate_consumer_index(index);
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -9,10 +9,10 @@
 //! [`WriteGuard`], or a [`WriteBatch`]; [`Consumer`] reads via
 //! [`Consumer::try_read`], a [`ReadGuard`], or a [`ReadBatch`], with blocking
 //! `*_timeout` variants that park on the queue's futex when idle. A consumer
-//! joins at the current frontier, or with the `*_from_backlog` variants up to one
-//! ring behind it to also read data published before it joined. After a crash, a
-//! lane or consumer index can be taken over with `recover` (resuming where the
-//! dead owner was) or returned to the pool with `force_release`.
+//! joins at each lane's reservation frontier, skipping values that were already
+//! reserved. After a crash, a lane or consumer index can be taken over with
+//! `recover` (resuming where the dead owner was) or returned to the pool with
+//! `force_release`.
 //!
 //! Typed payloads require `T: Copy`, which ensures that `T` cannot implement
 //! [`Drop`] and therefore does not require a destructor when a cell is
@@ -598,17 +598,10 @@ impl<T: Copy> Producer<T> {
     }
 
     /// Joins the same queue as a consumer (sharing the mapping). The consumer
-    /// starts at each lane's current publication, so it only observes items
-    /// published after it joins.
+    /// starts at each lane's reservation frontier, skipping values that were
+    /// already reserved.
     pub fn join_as_consumer(&self) -> Result<Consumer<T>, Error> {
-        Consumer::from_queue(self.queue.clone(), false)
-    }
-
-    /// Like [`Self::join_as_consumer`], but starts up to one ring behind the
-    /// frontier so the consumer reads data published before it joined (see
-    /// [`Consumer::join_from_backlog`]).
-    pub fn join_as_consumer_from_backlog(&self) -> Result<Consumer<T>, Error> {
-        Consumer::from_queue(self.queue.clone(), true)
+        Consumer::from_queue(self.queue.clone())
     }
 
     /// Joins the same queue as an untyped consumer. The consumer discovers the
@@ -618,16 +611,7 @@ impl<T: Copy> Producer<T> {
     /// - The payload must satisfy [`SliceConsumer`]'s full-byte initialization
     ///   requirement.
     pub unsafe fn join_as_slice_consumer(&self) -> Result<SliceConsumer, Error> {
-        SliceConsumer::from_queue(self.queue.clone(), false)
-    }
-
-    /// Like [`Self::join_as_slice_consumer`], but starts up to one ring behind
-    /// the frontier so the consumer reads data published before it joined.
-    ///
-    /// # Safety
-    /// - Same as [`Self::join_as_slice_consumer`].
-    pub unsafe fn join_as_slice_consumer_from_backlog(&self) -> Result<SliceConsumer, Error> {
-        SliceConsumer::from_queue(self.queue.clone(), true)
+        SliceConsumer::from_queue(self.queue.clone())
     }
 
     /// Publishes one value, or returns it on backpressure (the slowest consumer
@@ -829,16 +813,16 @@ struct ConsumerCore {
 }
 
 impl ConsumerCore {
-    fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
+    fn from_queue(queue: SharedQueue) -> Result<Self, Error> {
         let index = queue.acquire_consumer_index()?;
-        // Cache a view per lane (independent of `queue`), and join each at the
-        // frontier, or up to one ring behind it when `from_backlog`.
+        // Cache a view per lane (independent of `queue`) and join each at its
+        // reservation frontier.
         let lanes: Box<[ProducerLane]> = (0..queue.producer_slots())
             .map(|lane| queue.lane(lane))
             .collect();
         let next_by_lane = lanes
             .iter()
-            .map(|lane| Self::join_lane(lane, index, from_backlog))
+            .map(|lane| Self::join_lane(lane, index))
             .collect();
         Ok(Self {
             queue,
@@ -882,14 +866,14 @@ impl ConsumerCore {
         Ok(())
     }
 
-    fn join_lane(lane: &ProducerLane, index: usize, from_backlog: bool) -> usize {
+    fn join_lane(lane: &ProducerLane, index: usize) -> usize {
         let consumer_state = lane.consumer_state();
-        consumer_state.join(index, from_backlog, lane.published(), || lane.reserved())
+        consumer_state.join(index, || lane.reserved())
     }
 
     fn recover_lane(lane: &ProducerLane, index: usize) -> usize {
         let consumer_state = lane.consumer_state();
-        consumer_state.recover(index, lane.published(), || lane.reserved())
+        consumer_state.recover(index, || lane.reserved())
     }
 
     fn index(&self) -> usize {
@@ -994,8 +978,9 @@ impl Drop for ConsumerCore {
 // may be moved between threads.
 unsafe impl Send for ConsumerCore {}
 
-/// A consumer: owns one consumer index and reads every lane round-robin. Reads
-/// only items published after it joins. Single-threaded use (`&mut self`).
+/// A consumer: owns one consumer index and reads every lane round-robin,
+/// starting at each lane's reservation frontier. Single-threaded use (`&mut
+/// self`).
 pub struct Consumer<T: Copy> {
     core: ConsumerCore,
     _marker: PhantomData<T>,
@@ -1013,36 +998,24 @@ impl<T: Copy> Consumer<T> {
     pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
         // SAFETY: caller guarantees this mapping is initialized exactly once.
         let queue = unsafe { SharedQueue::create::<T>(file, &config) }?;
-        Self::from_queue(queue, false)
+        Self::from_queue(queue)
     }
 
-    /// Joins an existing broadcast queue in `file` as a consumer, starting at the
-    /// current frontier (only items published after the join).
+    /// Joins an existing broadcast queue in `file` as a consumer, starting at
+    /// each lane's reservation frontier. Values already reserved are skipped,
+    /// even if they have not yet been published.
     ///
     /// # Safety
     /// - Same as [`Producer::join`]: live queue, same `T` across all handles.
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::join::<T>(file) }?;
-        Self::from_queue(queue, false)
+        Self::from_queue(queue)
     }
 
-    /// Like [`Self::join`], but starts up to one ring behind the frontier so the
-    /// consumer reads data published before it joined. Best for slow queues; on a
-    /// fast one that has already lapped, it falls back to the frontier (see
-    /// [`Self::join`]).
-    ///
-    /// # Safety
-    /// - Same as [`Self::join`].
-    pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
-        // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join::<T>(file) }?;
-        Self::from_queue(queue, true)
-    }
-
-    fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
+    fn from_queue(queue: SharedQueue) -> Result<Self, Error> {
         Ok(Self {
-            core: ConsumerCore::from_queue(queue, from_backlog)?,
+            core: ConsumerCore::from_queue(queue)?,
             _marker: PhantomData,
             _invariant: PhantomData,
         })
@@ -1082,10 +1055,9 @@ impl<T: Copy> Consumer<T> {
     }
 
     /// Force-releases a consumer index whose owner died, returning it to the free
-    /// pool: the lanes are un-wedged and a later [`join`](Self::join) /
-    /// [`join_from_backlog`](Self::join_from_backlog) can reclaim it fresh. Use this
-    /// (rather than [`recover`](Self::recover)) when you want to drop the dead
-    /// consumer's backlog and choose a new start position.
+    /// pool: the lanes are un-wedged and a later [`join`](Self::join) can reclaim
+    /// it fresh. Use this (rather than [`recover`](Self::recover)) when you want
+    /// to drop the dead consumer's unread values and choose a new start position.
     ///
     /// # Safety
     /// - As [`Self::join`], plus: the consumer that owned `index` must be dead and
@@ -1291,7 +1263,8 @@ pub struct SliceConsumer {
 
 impl SliceConsumer {
     /// Joins an existing broadcast queue in `file` as an untyped consumer,
-    /// starting at the current frontier.
+    /// starting at each lane's reservation frontier. Values already reserved
+    /// are skipped, even if they have not yet been published.
     ///
     /// # Safety
     /// - `file` must refer to a live broadcast queue, not resized while joined.
@@ -1302,23 +1275,12 @@ impl SliceConsumer {
     pub unsafe fn join(file: &File) -> Result<Self, Error> {
         // SAFETY: validated against the stored header.
         let queue = unsafe { SharedQueue::join_untyped(file) }?;
-        Self::from_queue(queue, false)
+        Self::from_queue(queue)
     }
 
-    /// Like [`Self::join`], but starts up to one ring behind the frontier so the
-    /// consumer reads data published before it joined.
-    ///
-    /// # Safety
-    /// - Same as [`Self::join`].
-    pub unsafe fn join_from_backlog(file: &File) -> Result<Self, Error> {
-        // SAFETY: validated against the stored header.
-        let queue = unsafe { SharedQueue::join_untyped(file) }?;
-        Self::from_queue(queue, true)
-    }
-
-    fn from_queue(queue: SharedQueue, from_backlog: bool) -> Result<Self, Error> {
+    fn from_queue(queue: SharedQueue) -> Result<Self, Error> {
         Ok(Self {
-            core: ConsumerCore::from_queue(queue, from_backlog)?,
+            core: ConsumerCore::from_queue(queue)?,
         })
     }
 
@@ -2088,7 +2050,7 @@ mod tests {
             for value in 0..3u64 {
                 assert!(p.try_write(value).is_ok());
             }
-            // Joins at the current publication (3), so it sees only later items.
+            // Joins at the current reservation (3), so it sees only later items.
             let mut c = p.join_as_consumer().unwrap();
             assert!(p.try_write(99).is_ok());
             assert_eq!(c.try_read(), Some(99));
@@ -2097,7 +2059,7 @@ mod tests {
     }
 
     #[test]
-    fn consumer_joining_during_unpublished_reservation_waits_for_publication() {
+    fn consumer_joining_during_unpublished_reservation_skips_it() {
         let config = BroadcastConfig {
             capacity: 4,
             producer_slots: 1,
@@ -2108,39 +2070,17 @@ mod tests {
 
         // SAFETY: the reserved slot is initialized before the guard is dropped.
         let mut guard = unsafe { producer.try_reserve_write() }.unwrap();
-        let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
+        let mut consumer = Consumer::from_queue(queue.clone()).unwrap();
 
         assert!(consumer.try_reserve_read().is_none());
         guard.as_mut().write(42);
         drop(guard);
 
-        assert_eq!(consumer.try_read(), Some(42));
         assert_eq!(consumer.try_read(), None);
-    }
 
-    #[test]
-    fn from_backlog_consumer_reads_old_data_on_a_slow_queue() {
-        for create in producer_creators() {
-            // The queue has capacity to spare and has not wrapped, so the backlog
-            // is fully retained.
-            let mut p = create(BroadcastConfig {
-                capacity: 8,
-                producer_slots: 1,
-                consumer_slots: 1,
-            });
-            for value in 0..3u64 {
-                assert!(p.try_write(value).is_ok());
-            }
-            // A from-backlog join starts at the oldest retained item (sequence 0),
-            // so it reads data published before it joined, then keeps up.
-            let mut c = p.join_as_consumer_from_backlog().unwrap();
-            for value in 0..3u64 {
-                assert_eq!(c.try_read(), Some(value));
-            }
-            assert!(p.try_write(99).is_ok());
-            assert_eq!(c.try_read(), Some(99));
-            assert_eq!(c.try_read(), None);
-        }
+        assert!(producer.try_write(99).is_ok());
+        assert_eq!(consumer.try_read(), Some(99));
+        assert_eq!(consumer.try_read(), None);
     }
 
     #[test]
@@ -2240,7 +2180,7 @@ mod tests {
             consumer_slots: 1,
         };
         let queue = recovery_queue(&config);
-        let mut consumer = Consumer::from_queue(queue.clone(), false).unwrap();
+        let mut consumer = Consumer::from_queue(queue.clone()).unwrap();
 
         // A producer publishes two items, then its process "crashes". A clean
         // drop would free the lane, so re-mark it ACTIVE to mimic a dead owner
@@ -2307,7 +2247,7 @@ mod tests {
         // the index, join, record the cursor) so nothing releases the slot.
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        ConsumerCore::join_lane(&lane, index, false);
+        ConsumerCore::join_lane(&lane, index);
 
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
@@ -2315,7 +2255,7 @@ mod tests {
         }
         lane.consumer_state().set_cursor(index, 1);
 
-        // Recovery resumes at the recorded position: it reads the unread backlog
+        // Recovery resumes at the recorded position: it reads the unread values
         // (items 1, 2), never re-reading item 0.
         let mut recovered = Consumer::recover_in_queue(queue.clone(), index).unwrap();
         assert_eq!(recovered.index(), index);
@@ -2337,7 +2277,7 @@ mod tests {
         // its owner "crashes" (no release).
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        ConsumerCore::join_lane(&lane, index, false);
+        ConsumerCore::join_lane(&lane, index);
         let mut producer = Producer::from_queue(queue.clone()).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());
@@ -2346,21 +2286,22 @@ mod tests {
 
         // A fresh join can't proceed — the index is still owned.
         assert!(matches!(
-            Consumer::<Payload>::from_queue(queue.clone(), false),
+            Consumer::<Payload>::from_queue(queue.clone()),
             Err(Error::ConsumerSlotsExhausted)
         ));
 
-        // Force-release frees it (clear limits + free the index); a catch-up join
-        // then reclaims it and reads the still-present backlog from the start.
+        // Force-release frees it (clear limits + free the index); a fresh join
+        // then reclaims it at the current reservation frontier.
         for lane in 0..queue.producer_slots() {
             queue.lane(lane).consumer_state().release(index);
         }
         queue.release_consumer_index(index);
-        let mut fresh = Consumer::from_queue(queue.clone(), true).unwrap();
+        let mut fresh = Consumer::from_queue(queue.clone()).unwrap();
         assert_eq!(fresh.index(), index);
-        for value in 0..3u64 {
-            assert_eq!(fresh.try_read(), Some(value));
-        }
+        assert_eq!(fresh.try_read(), None);
+
+        assert!(producer.try_write(99).is_ok());
+        assert_eq!(fresh.try_read(), Some(99));
         assert_eq!(fresh.try_read(), None);
     }
 

--- a/src/broadcast/consumer_state.rs
+++ b/src/broadcast/consumer_state.rs
@@ -182,56 +182,35 @@ impl LaneConsumerState {
             .unwrap_or(UNCLAIMED)
     }
 
-    /// Joins `consumer_index` to this lane and returns the sequence it starts
-    /// reading from.
+    /// Joins `consumer_index` to this lane at the current reservation frontier.
     ///
     /// The caller must already own `consumer_index` through the broadcast's
     /// global consumer-ownership state, so this slot has a single writer (the
     /// owning consumer): no CAS is needed — a release store publishes the limit.
     ///
-    /// The start is normally the lane's **current publication**: the next value
-    /// to become visible after this join. With `from_backlog`, the start is
-    /// instead up to one ring behind the publication (the oldest published item
-    /// still guaranteed to be in the ring, floored at the first sequence), so a
-    /// consumer on a slow queue can read data published before it joined. If the
-    /// producer has already lapped that point, the handshake below fast-forwards
-    /// to the reservation frontier — you cannot read cells already being
-    /// recycled.
-    ///
-    /// The limit is published with a single release store, so the slot never
-    /// passes through [`UNCLAIMED`]. This also makes the call usable for
-    /// recovery: re-joining a dead owner's index overwrites its stale limit
-    /// directly, never dropping this consumer's backpressure mid-claim.
-    pub(crate) fn join(
-        &self,
-        consumer_index: usize,
-        from_backlog: bool,
-        published: usize,
-        read_reserved: impl FnOnce() -> usize,
-    ) -> usize {
-        let start = if from_backlog {
-            // Up to one ring behind the frontier (floored at the first
-            // sequence): the oldest item still guaranteed to be in the ring.
-            published.saturating_sub(self.capacity)
-        } else {
-            published
-        };
+    /// The first reservation sample supplies an initial limit that permits a
+    /// full ring of producer progress. After publishing that limit, the consumer
+    /// fences and samples the reservation again. The producer either observes
+    /// the initial limit or the second sample observes its previously committed
+    /// frontier. A reservation racing after the second sample starts at that
+    /// frontier, so it is future data for this consumer rather than an overwrite
+    /// of a cell the consumer may read.
+    pub(crate) fn join(&self, consumer_index: usize, read_reserved: impl Fn() -> usize) -> usize {
+        let initial_start = read_reserved();
+        let initial_limit = initial_start.wrapping_add(self.capacity);
+        debug_assert!(initial_limit != UNCLAIMED);
+        self.limit(consumer_index)
+            .store(initial_limit, Ordering::Release);
+
+        // Consumer half of the join handshake: order the initial limit before
+        // re-reading the reservation frontier. This pairs with the producer's
+        // fence before it reads reserve limits.
+        fence(Ordering::SeqCst);
+
+        let start = read_reserved();
         let limit = start.wrapping_add(self.capacity);
         debug_assert!(limit != UNCLAIMED);
         self.limit(consumer_index).store(limit, Ordering::Release);
-
-        // Consumer half of the join handshake: order publishing this limit
-        // before re-reading the producer reservation. This pairs with the
-        // producer's matching fence before it reads the reserve limit, so one
-        // side observes the other's advance.
-        fence(Ordering::SeqCst);
-
-        let reserved = read_reserved();
-        if reserved > limit {
-            self.limit(consumer_index)
-                .store(reserved.wrapping_add(self.capacity), Ordering::Release);
-            return reserved;
-        }
         start
     }
 
@@ -256,16 +235,16 @@ impl LaneConsumerState {
     /// surviving reserve limit (`next_to_read + capacity`), so it resumes where
     /// the dead owner left off — those unread cells are still pinned by the
     /// limit. This only reads the slot, so this consumer's backpressure is never
-    /// dropped. If the slot was never claimed, start fresh at the frontier.
+    /// dropped. If the slot was never claimed, start fresh at the reservation
+    /// frontier.
     pub(crate) fn recover(
         &self,
         consumer_index: usize,
-        published: usize,
-        read_reserved: impl FnOnce() -> usize,
+        read_reserved: impl Fn() -> usize,
     ) -> usize {
         let limit = self.limit(consumer_index).load(Ordering::Acquire);
         if limit == UNCLAIMED {
-            self.join(consumer_index, false, published, read_reserved)
+            self.join(consumer_index, read_reserved)
         } else {
             limit.wrapping_sub(self.capacity)
         }
@@ -292,6 +271,7 @@ impl LaneConsumerState {
 mod tests {
     use super::*;
     use crate::shmem::Region;
+    use std::cell::Cell;
     use std::num::NonZeroUsize;
 
     fn consumer_state(slot_count: usize) -> (std::sync::Arc<Region>, ConsumerState) {
@@ -357,13 +337,13 @@ mod tests {
 
         assert_eq!(state.reserve_limit(), UNCLAIMED);
 
-        assert_eq!(state.join(0, false, 10, || 10), 10);
+        assert_eq!(state.join(0, || 10), 10);
         assert_eq!(state.reserve_limit(), 14);
 
         state.set_cursor(0, 12);
         assert_eq!(state.reserve_limit(), 16);
 
-        assert_eq!(state.join(1, false, 10, || 10), 10);
+        assert_eq!(state.join(1, || 10), 10);
         assert_eq!(state.reserve_limit(), 14);
 
         state.release(1);
@@ -374,10 +354,24 @@ mod tests {
     }
 
     #[test]
-    fn lane_consumer_state_backlog_join_fast_forwards_when_lapped() {
+    fn lane_consumer_state_join_resamples_reservation_frontier() {
         let (_region, state) = lane_consumer_state(1, 4);
+        let samples = [10, 13];
+        let sample_index = Cell::new(0);
 
-        assert_eq!(state.join(0, true, 10, || 13), 13);
+        assert_eq!(
+            state.join(0, || {
+                let index = sample_index.get();
+                sample_index.set(index + 1);
+                let sample = samples[index];
+                if sample == 13 {
+                    assert_eq!(state.reserve_limit(), 14);
+                }
+                sample
+            }),
+            13
+        );
+        assert_eq!(sample_index.get(), 2);
         assert_eq!(state.reserve_limit(), 17);
     }
 
@@ -387,7 +381,7 @@ mod tests {
 
         state.set_cursor(0, 7);
         assert_eq!(
-            state.recover(0, 99, || panic!("claimed slot should not rejoin")),
+            state.recover(0, || panic!("claimed slot should not rejoin")),
             7
         );
         assert_eq!(state.reserve_limit(), 11);
@@ -397,7 +391,7 @@ mod tests {
     fn lane_consumer_state_recover_unclaimed_slot_joins_frontier() {
         let (_region, state) = lane_consumer_state(1, 4);
 
-        assert_eq!(state.recover(0, 12, || 12), 12);
+        assert_eq!(state.recover(0, || 12), 12);
         assert_eq!(state.reserve_limit(), 16);
     }
 }

--- a/src/broadcast/consumer_state.rs
+++ b/src/broadcast/consumer_state.rs
@@ -12,6 +12,20 @@ use crate::CacheAlignedAtomicSize;
 
 const CONSUMER_FREE: u64 = 0;
 const CONSUMER_ACTIVE: u64 = 1;
+const CONSUMER_JOINING: u64 = 2;
+
+pub(crate) enum ConsumerRecoveryMode {
+    /// The global ownership slot was active, which proves the previous join
+    /// installed a final cursor on every lane. Recovery can reconstruct those
+    /// cursors from the surviving reserve limits and continue from them.
+    Resume,
+
+    /// The global ownership slot was free or still joining, so its per-lane
+    /// limits may be absent or may only be provisional handshake values.
+    /// Recovery must join every lane again at its reservation frontier before
+    /// marking the consumer active.
+    RestartJoin,
+}
 
 /// Value stored in a lane consumer slot that no consumer owns.
 ///
@@ -23,8 +37,8 @@ const UNCLAIMED: usize = usize::MAX;
 
 /// Global consumer-index ownership table.
 ///
-/// The table is a contiguous `[AtomicU64; consumer_slots]` block. It only tracks
-/// whether a consumer index is owned.
+/// The table is a contiguous `[AtomicU64; consumer_slots]` block. Each slot is
+/// free, joining its lanes, or active.
 #[derive(Clone, Copy)]
 pub(crate) struct ConsumerState {
     slots: NonNull<AtomicU64>,
@@ -72,14 +86,15 @@ impl ConsumerState {
         self.slot_count
     }
 
-    /// Claims a free consumer index in the global ownership table.
+    /// Claims a free consumer index in the global ownership table. The index
+    /// remains in the joining phase until every lane has installed its cursor.
     pub(crate) fn acquire(&self) -> Result<usize, Error> {
         for index in 0..self.slot_count {
             if self
                 .slot(index)
                 .compare_exchange(
                     CONSUMER_FREE,
-                    CONSUMER_ACTIVE,
+                    CONSUMER_JOINING,
                     Ordering::AcqRel,
                     Ordering::Acquire,
                 )
@@ -91,15 +106,31 @@ impl ConsumerState {
         Err(Error::ConsumerSlotsExhausted)
     }
 
+    /// Marks a joining consumer active after all of its lane cursors have been
+    /// installed.
+    pub(crate) fn activate(&self, index: usize) {
+        self.slot(index).store(CONSUMER_ACTIVE, Ordering::Release);
+    }
+
     /// Releases a consumer index back to free.
     pub(crate) fn release(&self, index: usize) {
         self.slot(index).store(CONSUMER_FREE, Ordering::Release);
     }
 
-    /// Force-owns a consumer index whose previous owner died (no CAS). The
-    /// caller guarantees that owner is dead and no live handle uses the index.
-    pub(crate) fn recover(&self, index: usize) {
-        self.slot(index).store(CONSUMER_ACTIVE, Ordering::Release);
+    /// Begins recovery of an index whose previous owner died. An active consumer
+    /// has complete lane cursors and can resume them. A free or joining index is
+    /// kept in the joining phase so recovery can restart every lane safely.
+    ///
+    /// The caller guarantees that no live handle uses the index and serializes
+    /// recovery with joins, drops, and other recovery operations.
+    pub(crate) fn begin_recovery(&self, index: usize) -> ConsumerRecoveryMode {
+        let slot = self.slot(index);
+        if slot.load(Ordering::Acquire) == CONSUMER_ACTIVE {
+            ConsumerRecoveryMode::Resume
+        } else {
+            slot.store(CONSUMER_JOINING, Ordering::Release);
+            ConsumerRecoveryMode::RestartJoin
+        }
     }
 
     /// The global ownership word for consumer index `index`.
@@ -309,11 +340,24 @@ mod tests {
             Err(Error::ConsumerSlotsExhausted)
         ));
 
+        assert!(matches!(
+            state.begin_recovery(0),
+            ConsumerRecoveryMode::RestartJoin
+        ));
+        state.activate(0);
+        assert!(matches!(
+            state.begin_recovery(0),
+            ConsumerRecoveryMode::Resume
+        ));
+
         state.release(0);
         assert_eq!(state.acquire().unwrap(), 0);
 
         state.release(1);
-        state.recover(1);
+        assert!(matches!(
+            state.begin_recovery(1),
+            ConsumerRecoveryMode::RestartJoin
+        ));
         assert!(matches!(
             state.acquire(),
             Err(Error::ConsumerSlotsExhausted)

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -226,8 +226,12 @@ impl ProducerLane {
         }
         let start = self.header().producer_reservation.load(Ordering::Acquire);
         // Producer half of the join handshake: order the previous reserve's
-        // `producer_reservation` store before this reserve's limit loads, so a
-        // racing consumer join either sees our advance or we see its limit.
+        // `producer_reservation` store before this reserve's limit loads. A
+        // racing consumer publishes a limit from its first reservation sample,
+        // fences, then samples again. Either this reserve observes that limit or
+        // the consumer observes our committed frontier. If both race with this
+        // reserve's later store, the consumer starts at `start`, making this
+        // reservation future data rather than an overwrite.
         fence(Ordering::SeqCst);
         // Each slot already stores `next_to_read + capacity`, so the gate is a
         // plain comparison: rejecting once the batch would reach a sequence a
@@ -289,11 +293,9 @@ mod tests {
         unsafe { lane.payload_ptr(sequence).cast().read() }
     }
 
-    fn join_consumer(lane: &ProducerLane, consumer_index: usize, from_backlog: bool) -> usize {
+    fn join_consumer(lane: &ProducerLane, consumer_index: usize) -> usize {
         let consumer_state = lane.consumer_state();
-        consumer_state.join(consumer_index, from_backlog, lane.published(), || {
-            lane.reserved()
-        })
+        consumer_state.join(consumer_index, || lane.reserved())
     }
 
     /// Reserves, writes, and publishes one value; `false` on backpressure.
@@ -383,7 +385,7 @@ mod tests {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
         // Join consumer 0; nothing published yet, so it starts at sequence 0.
-        assert_eq!(join_consumer(&lane, 0, false), 0);
+        assert_eq!(join_consumer(&lane, 0), 0);
 
         // Fill the ring; the consumer has read nothing, so the next reserve laps.
         for value in 0..4u64 {
@@ -408,7 +410,7 @@ mod tests {
     fn released_consumer_no_longer_constrains() {
         let (_region, mut lane) = lane(4, 1);
         assert!(lane.try_acquire());
-        assert_eq!(join_consumer(&lane, 0, false), 0);
+        assert_eq!(join_consumer(&lane, 0), 0);
         for value in 0..4u64 {
             assert!(publish_value(&mut lane, value));
         }


### PR DESCRIPTION
### Problem
- Backlog joining allowed a producer reservation and consumer join to race across independent atomics
- Producer could observe old UNCLAIMED limit while consumer observed the old reservation
	- this would allow both to treat same ring cell as safe

### Summary of Changes
- Remove backlog-joining APIs and semantics
- Start new consuemrs at reservation frontier, skipping all previously reserved values, inclduing unpublished reservations
- Use double-sampled join handshake:
	- load reservation frontier
	- publish initial reserve limit
	- fence
	- re sample reservation and install final limit
- Above changes introduced a recovery issue where if consumer dies after publishing initial limit but before completing join
- Track global consumer ownership ass FREE, JOINING, ACTIVE 
	- recovery resumes ACTIVE consumers, but restarts JOINING or FREE consumers 