### PR TITLE
feat: add producer metadata to lanes

### DIFF
--- a/examples/enqueue_dequeue.rs
+++ b/examples/enqueue_dequeue.rs
@@ -8,6 +8,7 @@ use common::{
 use shaq::{
     broadcast::{
         Broadcast, BroadcastConfig, Consumer as BroadcastConsumer, Producer as BroadcastProducer,
+        ProducerId,
     },
     error::WaitError,
     mpmc::{Consumer as MpmcConsumer, Producer as MpmcProducer},
@@ -437,9 +438,11 @@ fn run_broadcast(producers: usize, consumers: usize, verbose: bool) {
                         core_affinity::set_for_current(core_id);
                     }
 
+                    let producer_id = ProducerId::new(idx as u64 + 1);
+
                     // Each thread mints its own producer lane from the one
                     // shared `Broadcast` handle created above.
-                    let producer = broadcast.producer().unwrap();
+                    let producer = broadcast.producer(producer_id).unwrap();
                     run_broadcast_producer(
                         producer,
                         exit,

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -31,6 +31,16 @@
 //! per-lane state always describes a single producer. Replacing producers
 //! means recreating the queue.
 //!
+//! Each lane carries metadata: a caller-supplied [`ProducerId`] and a counter
+//! of items rejected by backpressure. The producer ID is permanently associated
+//! with its lane, including after the producer is dropped. Shaq treats IDs as
+//! opaque values and does not enforce uniqueness; callers requiring distinct
+//! producer attribution must provide unique IDs on producer creation.
+//!
+//! A read guard exposes the publishing lane's metadata via
+//! [`ReadGuard::lane_metadata`]. To poll metadata by lane index, borrow
+//! [`LaneMetadata`] with [`Broadcast::lane_metadata`].
+//!
 //! Typed payloads require `T: Copy`, which ensures that `T` cannot implement
 //! [`Drop`] and therefore does not require a destructor when a cell is
 //! duplicated or reused. File-backed typed construction remains unsafe because
@@ -49,6 +59,8 @@
 mod consumer_state;
 mod producer_lane;
 
+pub use producer_lane::LaneMetadata;
+
 use core::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::size_of;
@@ -66,7 +78,7 @@ use crate::shmem::Region;
 use crate::{CacheAlignedAtomicSize, VERSION};
 
 use consumer_state::{ConsumerRecoveryMode, ConsumerState};
-use producer_lane::ProducerLane;
+use producer_lane::{LaneHeader, ProducerLane};
 
 const MAGIC: u64 = u64::from_be_bytes(*b"shaqcast");
 
@@ -142,8 +154,8 @@ where
     }
 
     /// Creates a new [`Producer`] if there is a free producer slot.
-    pub fn producer(&self) -> Result<Producer<T>, Error> {
-        Producer::from_queue(self.shared_queue.clone())
+    pub fn producer(&self, producer_id: ProducerId) -> Result<Producer<T>, Error> {
+        Producer::from_queue(self.shared_queue.clone(), producer_id)
     }
 
     /// Creates a new [`Consumer`] if there is a free consumer slot.
@@ -211,7 +223,7 @@ impl Broadcast<UnknownType> {
     /// from a broadcast that is joined untyped.
     ///
     /// ```compile_fail
-    /// # use shaq::broadcast::{Broadcast, BroadcastConfig, UnknownType};
+    /// # use shaq::broadcast::{Broadcast, BroadcastConfig, ProducerId, UnknownType};
     /// # use std::fs::OpenOptions;
     /// # let path = std::env::temp_dir().join(format!("shaq-doctest-{}-producer", std::process::id()));
     /// # let file = OpenOptions::new().read(true).write(true).create(true).truncate(true).open(&path).unwrap();
@@ -219,7 +231,7 @@ impl Broadcast<UnknownType> {
     /// # unsafe { Broadcast::<u64>::create(&file, config) }.unwrap();
     /// #
     /// let broadcast = unsafe { Broadcast::join_untyped(&file) }.unwrap();
-    /// let _ = broadcast.producer(); // Untyped broadcast can not create typed producer
+    /// let _ = broadcast.producer(ProducerId::new(1)); // Untyped broadcast can not create typed producer
     /// ```
     ///
     /// ```compile_fail
@@ -292,6 +304,67 @@ impl<T> Broadcast<T> {
     ///   as [`Self::recover_consumer`]/[`Self::recover_slice_consumer`].
     pub unsafe fn force_release(&self, index: usize) -> Result<(), Error> {
         ConsumerCore::force_release(&self.shared_queue, index)
+    }
+
+    /// Number of producer lanes on the queue
+    pub fn producer_slots(&self) -> usize {
+        self.shared_queue.producer_slots()
+    }
+
+    /// Returns borrowed [`LaneMetadata`] for the lane at `lane_index`.
+    ///
+    /// Returns [`None`] if the index is out of range or no producer has
+    /// completed acquisition of the lane. Once acquired, a lane retains its
+    /// metadata after retirement.
+    pub fn lane_metadata(&self, lane_index: usize) -> Option<LaneMetadata<'_>> {
+        self.shared_queue.lane_metadata(lane_index)
+    }
+}
+
+/// An advisory identifier for [`Producer`]s.
+///
+/// ### Warning ⚠️
+/// **A [`ProducerId`] is not guaranteed to be unique** across lanes. The
+/// values chosen for producer ids are chosen by callers with no uniqueness enforcement
+/// by shaq.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ProducerId(u64);
+
+impl ProducerId {
+    /// Callers of this constructor are responsible for choosing unique IDs
+    /// if producer-level attribution is desired.
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy)]
+struct UnverifiedLane;
+#[derive(Clone, Copy)]
+struct InitializedLane;
+
+#[derive(Clone, Copy)]
+struct LaneIndex<State> {
+    index: usize,
+    _state: PhantomData<State>,
+}
+
+impl LaneIndex<UnverifiedLane> {
+    fn new(index: usize) -> Self {
+        Self {
+            index,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<State> LaneIndex<State> {
+    fn get(self) -> usize {
+        self.index
     }
 }
 
@@ -585,24 +658,48 @@ impl SharedQueue {
         self.producer_slots
     }
 
-    /// A view over producer lane `lane`.
-    fn lane(&self, lane: usize) -> ProducerLane {
+    /// Pointer to producer lane block `lane`.
+    fn lane_block(&self, lane: usize) -> NonNull<u8> {
         debug_assert!(lane < self.producer_slots);
         // SAFETY: `lane < producer_slots`; blocks are `block_stride` apart.
-        let block = unsafe {
+        unsafe {
             self.producer_blocks
                 .byte_add(lane.wrapping_mul(self.block_stride))
-        };
+        }
+    }
+
+    /// Borrows the header at producer lane `lane`.
+    fn lane_header(&self, lane: usize) -> &LaneHeader {
+        let block = self.lane_block(lane);
+        // SAFETY: every producer block begins with an initialized `LaneHeader`,
+        // and the returned reference is tied to `&self`, whose `Arc<Region>`
+        // keeps the mapping alive.
+        unsafe { block.cast::<LaneHeader>().as_ref() }
+    }
+
+    /// A view over producer lane `lane`.
+    fn lane(&self, lane: usize) -> ProducerLane {
+        let block = self.lane_block(lane);
         // SAFETY: the block was initialized with these parameters.
         unsafe {
             ProducerLane::from_block(block, self.capacity, self.consumer_slots(), self.payload)
         }
     }
 
+    /// Borrows metadata for the given `lane_index`.
+    /// Returns [`None`] if `lane_index` is out of range or no producer has completed
+    /// an acquisition of that lane.
+    fn lane_metadata(&self, lane_index: usize) -> Option<LaneMetadata<'_>> {
+        if lane_index >= self.producer_slots() {
+            return None;
+        }
+        LaneMetadata::try_new(self.lane_header(lane_index), LaneIndex::new(lane_index))
+    }
+
     /// Claims a free producer lane, returning its index.
-    fn acquire_producer_lane(&self) -> Result<usize, Error> {
+    fn acquire_producer_lane(&self, producer_id: ProducerId) -> Result<usize, Error> {
         for lane in 0..self.producer_slots {
-            if self.lane(lane).try_acquire() {
+            if self.lane(lane).try_acquire(producer_id) {
                 return Ok(lane);
             }
         }
@@ -734,6 +831,7 @@ pub struct Producer<T: Copy> {
     queue: SharedQueue,
     lane: ProducerLane,
     index: usize,
+    producer_id: ProducerId,
     _marker: PhantomData<T>,
     _invariant: PhantomData<fn(T) -> T>,
 }
@@ -747,10 +845,14 @@ impl<T: Copy> Producer<T> {
     /// - Every participant must use the same `T` and layout, and each queued
     ///   value must be valid in every process that reads it. The `Copy` bound
     ///   does not make embedded pointers or references process-portable.
-    pub unsafe fn create(file: &File, config: BroadcastConfig) -> Result<Self, Error> {
+    pub unsafe fn create(
+        file: &File,
+        config: BroadcastConfig,
+        producer_id: ProducerId,
+    ) -> Result<Self, Error> {
         // SAFETY: the caller upholds the Broadcast::create requirements.
         let broadcast = unsafe { Broadcast::<T>::create(file, config) }?;
-        broadcast.producer()
+        broadcast.producer(producer_id)
     }
 
     /// Joins an existing broadcast queue in `file` as a producer.
@@ -758,10 +860,10 @@ impl<T: Copy> Producer<T> {
     /// # Safety
     /// - `file` must refer to a live broadcast queue (not resized while joined),
     ///   with the same `T` as every other handle (see [`Self::create`]).
-    pub unsafe fn join(file: &File) -> Result<Self, Error> {
+    pub unsafe fn join(file: &File, producer_id: ProducerId) -> Result<Self, Error> {
         // SAFETY: the caller upholds the Broadcast::join requirements.
         let broadcast = unsafe { Broadcast::<T>::join(file) }?;
-        broadcast.producer()
+        broadcast.producer(producer_id)
     }
 
     /// Returns a lane-free handle that shares this producer's queue mapping.
@@ -769,23 +871,28 @@ impl<T: Copy> Producer<T> {
         Broadcast::from_queue(self.queue.clone())
     }
 
-    fn from_queue(queue: SharedQueue) -> Result<Self, Error> {
-        let index = queue.acquire_producer_lane()?;
+    fn from_queue(queue: SharedQueue, producer_id: ProducerId) -> Result<Self, Error> {
+        let index = queue.acquire_producer_lane(producer_id)?;
         let lane = queue.lane(index);
+
         Ok(Self {
             queue,
             lane,
             index,
+            producer_id,
             _marker: PhantomData,
             _invariant: PhantomData,
         })
     }
 
-    /// The lane this producer owns. A lane binds to at most one producer for
-    /// the queue's lifetime, so the index uniquely identifies this producer to
-    /// consumers.
+    /// The lane this producer owns.
     pub fn index(&self) -> usize {
         self.index
+    }
+
+    /// The [`ProducerId`] of this producer.
+    pub fn producer_id(&self) -> ProducerId {
+        self.producer_id
     }
 
     /// Publishes one value, or returns it on backpressure (the slowest consumer
@@ -955,12 +1062,29 @@ impl<T: Copy> Drop for WriteBatch<'_, T> {
 /// [`ConsumerCore::advance`] for the lane.
 #[derive(Clone, Copy)]
 struct ReadableLane {
-    lane: usize,
+    lane: LaneIndex<InitializedLane>,
     sequence: usize,
     published: usize,
 }
 
 impl ReadableLane {
+    /// Builds a readable lane from the publication load that proved the lane
+    /// has an initialized, published value at `sequence`.
+    fn try_new(lane: LaneIndex<UnverifiedLane>, sequence: usize, published: usize) -> Option<Self> {
+        if published <= sequence {
+            return None;
+        }
+
+        Some(Self {
+            lane: LaneIndex {
+                index: lane.get(),
+                _state: PhantomData,
+            },
+            sequence,
+            published,
+        })
+    }
+
     /// Number of consecutive published values to read starting at `sequence`,
     /// bounded by `max`.
     fn count(&self, max: NonZeroUsize) -> NonZeroUsize {
@@ -1065,6 +1189,12 @@ impl ConsumerCore {
         self.queue.payload.size()
     }
 
+    /// Returns metadata for a lane containing a published value.
+    #[inline]
+    fn lane_metadata(&self, lane: LaneIndex<InitializedLane>) -> LaneMetadata<'_> {
+        self.lane(lane.get()).metadata(lane)
+    }
+
     #[inline]
     fn lane(&self, lane: usize) -> &ProducerLane {
         debug_assert!(lane < self.lanes.len());
@@ -1098,13 +1228,12 @@ impl ConsumerCore {
         for _ in 0..producer_slots {
             let sequence = self.next_for_lane(lane);
             let published = self.lane(lane).published();
-            // Cursor wrap is not supported - simple comparison works here.
-            if published > sequence {
-                return Some(ReadableLane {
-                    lane,
-                    sequence,
-                    published,
-                });
+            // Cursor wrap is not supported - simple comparison works here. An
+            // observed publication also proves that lane acquisition completed.
+            let lane_index = LaneIndex::new(lane);
+
+            if let Some(readable) = ReadableLane::try_new(lane_index, sequence, published) {
+                return Some(readable);
             }
             lane = lane.wrapping_add(1);
             if lane == producer_slots {
@@ -1116,21 +1245,23 @@ impl ConsumerCore {
 
     /// Pointer to the published cell at `readable`'s next unread sequence.
     fn payload_ptr(&self, readable: ReadableLane) -> NonNull<u8> {
-        self.lane(readable.lane).payload_ptr(readable.sequence)
+        self.lane(readable.lane.get())
+            .payload_ptr(readable.sequence)
     }
 
     /// Advances this consumer's cursor on `lane` by `count` consumed values,
     /// publishing the progress and rotating the scan start. The consumer is the
     /// sole reader of its own cursor (`&mut self`), so the cursor only moves here
     /// and advancing is a plain increment.
-    fn advance(&mut self, lane: usize, count: NonZeroUsize) {
-        let next = self.next_for_lane(lane).wrapping_add(count.get());
-        self.set_next_for_lane(lane, next);
-        self.lane(lane)
+    fn advance(&mut self, lane: LaneIndex<InitializedLane>, count: NonZeroUsize) {
+        let lane_index = lane.get();
+        let next = self.next_for_lane(lane_index).wrapping_add(count.get());
+        self.set_next_for_lane(lane_index, next);
+        self.lane(lane_index)
             .consumer_state()
             .set_cursor(self.index, next);
         // `lane < producer_slots`, so the wrap is a conditional subtract.
-        let mut scan_start_lane = lane.wrapping_add(1);
+        let mut scan_start_lane = lane_index.wrapping_add(1);
         if scan_start_lane == self.queue.producer_slots() {
             scan_start_lane = 0;
         }
@@ -1354,11 +1485,16 @@ unsafe impl<T: Copy + Send> Send for Consumer<T> {}
 #[must_use]
 pub struct ReadGuard<'a, T: Copy> {
     consumer: &'a mut ConsumerCore,
-    lane: usize,
+    lane: LaneIndex<InitializedLane>,
     payload: NonNull<T>,
 }
 
 impl<T: Copy> ReadGuard<'_, T> {
+    /// Metadata for the producer lane this value was published on.
+    pub fn lane_metadata(&self) -> LaneMetadata<'_> {
+        self.consumer.lane_metadata(self.lane)
+    }
+
     /// Copies the value out; the guard advances past it on drop.
     pub fn read(self) -> T {
         // SAFETY: the cell is published and held by this consumer's cursor.
@@ -1386,13 +1522,18 @@ impl<T: Copy> Drop for ReadGuard<'_, T> {
 #[must_use]
 pub struct ReadBatch<'a, T: Copy> {
     consumer: &'a mut ConsumerCore,
-    lane: usize,
+    lane: LaneIndex<InitializedLane>,
     start: usize,
     count: NonZeroUsize,
     _marker: PhantomData<T>,
 }
 
 impl<T: Copy> ReadBatch<'_, T> {
+    /// Metadata for the producer lane every value in this batch was published on.
+    pub fn lane_metadata(&self) -> LaneMetadata<'_> {
+        self.consumer.lane_metadata(self.lane)
+    }
+
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
@@ -1407,7 +1548,7 @@ impl<T: Copy> ReadBatch<'_, T> {
         T: Sync,
     {
         debug_assert!(index < self.count.get());
-        let ptr = self.consumer.lanes[self.lane]
+        let ptr = self.consumer.lanes[self.lane.get()]
             .payload_ptr(self.start.wrapping_add(index))
             .cast();
         // SAFETY: the cell is published and held by this consumer's
@@ -1421,7 +1562,7 @@ impl<T: Copy> ReadBatch<'_, T> {
     /// - `index < len`
     pub unsafe fn read(&self, index: usize) -> T {
         debug_assert!(index < self.count.get());
-        let ptr = self.consumer.lanes[self.lane]
+        let ptr = self.consumer.lanes[self.lane.get()]
             .payload_ptr(self.start.wrapping_add(index))
             .cast();
         // SAFETY: the cell is published and held by this consumer's
@@ -1437,7 +1578,7 @@ impl<T: Copy> ReadBatch<'_, T> {
     where
         T: Sync,
     {
-        let lane = self.consumer.lane(self.lane);
+        let lane = self.consumer.lane(self.lane.get());
         let start = lane.mask(self.start);
         let first_len = self.len().min(lane.capacity().wrapping_sub(start));
         let second_len = self.len().wrapping_sub(first_len);
@@ -1639,12 +1780,17 @@ unsafe impl Send for SliceConsumer {}
 #[must_use]
 pub struct SliceReadGuard<'a> {
     consumer: &'a mut ConsumerCore,
-    lane: usize,
+    lane: LaneIndex<InitializedLane>,
     payload: NonNull<u8>,
     len: usize,
 }
 
 impl SliceReadGuard<'_> {
+    /// Metadata for the producer lane this payload was published on.
+    pub fn lane_metadata(&self) -> LaneMetadata<'_> {
+        self.consumer.lane_metadata(self.lane)
+    }
+
     /// Byte length of the payload.
     pub fn len(&self) -> usize {
         self.len
@@ -1678,13 +1824,18 @@ impl Drop for SliceReadGuard<'_> {
 #[must_use]
 pub struct SliceReadBatch<'a> {
     consumer: &'a mut ConsumerCore,
-    lane: usize,
+    lane: LaneIndex<InitializedLane>,
     start: usize,
     count: NonZeroUsize,
     payload_size: usize,
 }
 
 impl SliceReadBatch<'_> {
+    /// Metadata for the producer lane every payload in this batch was published on.
+    pub fn lane_metadata(&self) -> LaneMetadata<'_> {
+        self.consumer.lane_metadata(self.lane)
+    }
+
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.count.get()
@@ -1703,7 +1854,7 @@ impl SliceReadBatch<'_> {
         debug_assert!(index < self.count.get());
         let payload = self
             .consumer
-            .lane(self.lane)
+            .lane(self.lane.get())
             .payload_ptr(self.start.wrapping_add(index));
         let payload = NonNull::slice_from_raw_parts(payload, self.payload_size);
         // SAFETY: forwarded; the cell is published and held by this consumer's
@@ -1725,24 +1876,47 @@ mod tests {
     use crate::shmem::create_temp_shmem_file;
 
     type Payload = u64;
-    type CreateProducer = fn(BroadcastConfig) -> Producer<Payload>;
 
-    /// In-process (heap-backed) producer. The `Producer` keeps the region alive
-    /// via its `SharedQueue`'s `Arc<Region>`.
-    fn create_heap_producer(config: BroadcastConfig) -> Producer<Payload> {
+    /// Placeholder id for tests that don't assert on producer metadata.
+    const BOGUS_ID: ProducerId = ProducerId::new(1111);
+
+    type CreateProducer = fn(BroadcastConfig) -> Producer<Payload>;
+    type CreateIdentifiedProducer = fn(BroadcastConfig, ProducerId) -> Producer<Payload>;
+
+    /// In-process (heap-backed) producer with a caller-chosen id. The
+    /// `Producer` keeps the region alive via its `SharedQueue`'s `Arc<Region>`.
+    fn create_identified_heap_producer(
+        config: BroadcastConfig,
+        id: ProducerId,
+    ) -> Producer<Payload> {
         let size = QueueLayout::new::<Payload>(&config).expect("layout").total;
         let region = Region::alloc(NonZeroUsize::new(size).unwrap()).expect("alloc");
         // SAFETY: freshly allocated region, initialized exactly once here.
         let queue = unsafe { SharedQueue::create_in_region::<Payload>(&region, &config) }.unwrap();
-        Producer::from_queue(queue).unwrap()
+        Producer::from_queue(queue, id).unwrap()
     }
 
-    /// File-backed producer (mmap). Not run under miri (no mmap).
+    /// Heap-backed producer with a placeholder id.
+    fn create_heap_producer(config: BroadcastConfig) -> Producer<Payload> {
+        create_identified_heap_producer(config, BOGUS_ID)
+    }
+
+    /// File-backed producer (mmap) with a caller-chosen id. Not run
+    /// under miri (no mmap).
     #[cfg(not(miri))]
-    fn create_file_backed_producer(config: BroadcastConfig) -> Producer<Payload> {
+    fn create_identified_file_backed_producer(
+        config: BroadcastConfig,
+        id: ProducerId,
+    ) -> Producer<Payload> {
         let file = create_temp_shmem_file().expect("temp file");
         // SAFETY: a fresh temp file, initialized exactly once here.
-        unsafe { Producer::create(&file, config) }.expect("create")
+        unsafe { Producer::create(&file, config, id) }.expect("create")
+    }
+
+    /// File-backed producer with a placeholder id.
+    #[cfg(not(miri))]
+    fn create_file_backed_producer(config: BroadcastConfig) -> Producer<Payload> {
+        create_identified_file_backed_producer(config, BOGUS_ID)
     }
 
     /// Every behavioral test runs against both backings (heap always; file-backed
@@ -1752,6 +1926,15 @@ mod tests {
             create_heap_producer,
             #[cfg(not(miri))]
             create_file_backed_producer,
+        ]
+    }
+
+    /// Backings for tests that pin a specific producer id at creation.
+    fn identified_producer_creators() -> &'static [CreateIdentifiedProducer] {
+        &[
+            create_identified_heap_producer,
+            #[cfg(not(miri))]
+            create_identified_file_backed_producer,
         ]
     }
 
@@ -1766,15 +1949,15 @@ mod tests {
             let broadcast = p0.broadcast_handle();
             // Two lanes total: the original plus one binding from a cloned
             // broadcast exhausts them.
-            let p1 = broadcast.producer().unwrap();
+            let p1 = broadcast.producer(BOGUS_ID).unwrap();
             assert!(matches!(
-                broadcast.producer(),
+                broadcast.producer(BOGUS_ID),
                 Err(Error::ProducerSlotsExhausted)
             ));
             drop(p1);
             // The dropped lane is retired, not returned to the pool.
             assert!(matches!(
-                broadcast.producer(),
+                broadcast.producer(BOGUS_ID),
                 Err(Error::ProducerSlotsExhausted)
             ));
         }
@@ -1994,7 +2177,7 @@ mod tests {
         };
         let file = create_temp_shmem_file().expect("temp file");
         // SAFETY: a fresh temp file, initialized exactly once here.
-        let mut producer = unsafe { Producer::<Payload>::create(&file, config) }.unwrap();
+        let mut producer = unsafe { Producer::<Payload>::create(&file, config, BOGUS_ID) }.unwrap();
         // SAFETY: the file now contains a live broadcast queue.
         let mut consumer = unsafe { SliceConsumer::join(&file) }.unwrap();
         assert_eq!(consumer.payload_size(), size_of::<Payload>());
@@ -2331,7 +2514,7 @@ mod tests {
             consumer_slots: 1,
         };
         let queue = recovery_queue(&config);
-        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+        let mut producer = Producer::from_queue(queue.clone(), BOGUS_ID).unwrap();
 
         // SAFETY: the reserved slot is initialized before the guard is dropped.
         let mut guard = unsafe { producer.try_reserve_write() }.unwrap();
@@ -2428,6 +2611,464 @@ mod tests {
         }
     }
 
+    #[test]
+    fn broadcast_reports_the_configured_lane_count() {
+        for create in producer_creators() {
+            let producer = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 2,
+                consumer_slots: 1,
+            });
+
+            let producer_slots = producer.broadcast_handle().producer_slots();
+
+            assert_eq!(producer_slots, 2);
+        }
+    }
+
+    #[test]
+    fn producer_reports_its_configured_id() {
+        for create in identified_producer_creators() {
+            let producer_id = ProducerId::new(42);
+            let producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 1,
+                    consumer_slots: 1,
+                },
+                producer_id,
+            );
+
+            let reported_id = producer.producer_id();
+
+            assert_eq!(reported_id, producer_id);
+        }
+    }
+
+    #[test]
+    fn owned_lane_metadata_reports_the_producer_id() {
+        for create in identified_producer_creators() {
+            let producer_id = ProducerId::new(42);
+            let producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 1,
+                    consumer_slots: 1,
+                },
+                producer_id,
+            );
+            let broadcast = producer.broadcast_handle();
+
+            let metadata = broadcast
+                .lane_metadata(producer.index())
+                .expect("owned lane has metadata");
+
+            assert_eq!(producer_id, metadata.producer_id());
+        }
+    }
+
+    #[test]
+    fn owned_lane_metadata_reports_the_lane() {
+        for create in identified_producer_creators() {
+            let producer_id = ProducerId::new(42);
+            let producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 1,
+                    consumer_slots: 1,
+                },
+                producer_id,
+            );
+            let broadcast = producer.broadcast_handle();
+            let producer_lane = producer.index();
+
+            let metadata = broadcast
+                .lane_metadata(producer.index())
+                .expect("owned lane has metadata");
+
+            assert_eq!(metadata.lane(), producer_lane);
+        }
+    }
+
+    #[test]
+    fn owned_lane_metadata_starts_with_no_rejected_items() {
+        for create in producer_creators() {
+            let producer = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let broadcast = producer.broadcast_handle();
+
+            let rejected_items = broadcast
+                .lane_metadata(producer.index())
+                .expect("owned lane has metadata")
+                .rejected_items();
+
+            assert_eq!(rejected_items, 0);
+        }
+    }
+
+    #[test]
+    fn never_owned_lane_has_no_metadata() {
+        for create in producer_creators() {
+            let producer = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 2,
+                consumer_slots: 1,
+            });
+            let broadcast = producer.broadcast_handle();
+
+            let metadata = broadcast.lane_metadata(1 - producer.index());
+
+            assert!(metadata.is_none());
+        }
+    }
+
+    #[test]
+    fn rejected_items_count_writes_refused_by_backpressure() {
+        for create in producer_creators() {
+            let mut producer = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let broadcast = producer.broadcast_handle();
+            let _consumer = broadcast.consumer().unwrap();
+            for value in 0..4u64 {
+                producer.try_write(value).expect("ring has capacity");
+            }
+
+            let _ = producer.try_write(99);
+            let _ = producer.try_write_slice(&[1, 2]);
+
+            assert_eq!(
+                broadcast
+                    .lane_metadata(producer.index())
+                    .unwrap()
+                    .rejected_items(),
+                3
+            );
+        }
+    }
+
+    #[test]
+    fn read_guard_reports_the_source_lane() {
+        for create in identified_producer_creators() {
+            let idle_producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 2,
+                    consumer_slots: 1,
+                },
+                ProducerId::new(41),
+            );
+            let broadcast = idle_producer.broadcast_handle();
+            let mut publishing_producer = broadcast.producer(ProducerId::new(42)).unwrap();
+            let mut consumer = broadcast.consumer().unwrap();
+            publishing_producer.try_write(7).expect("ring has capacity");
+
+            let guard = consumer.try_reserve_read().expect("readable");
+            let source_lane = guard.lane_metadata().lane();
+            drop(guard);
+
+            assert_eq!(source_lane, publishing_producer.index());
+        }
+    }
+
+    #[test]
+    fn read_guard_reports_the_source_producer_id() {
+        for create in identified_producer_creators() {
+            let idle_producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 2,
+                    consumer_slots: 1,
+                },
+                ProducerId::new(41),
+            );
+            let broadcast = idle_producer.broadcast_handle();
+            let mut publishing_producer = broadcast.producer(ProducerId::new(42)).unwrap();
+            let mut consumer = broadcast.consumer().unwrap();
+            publishing_producer.try_write(7).expect("ring has capacity");
+
+            let guard = consumer.try_reserve_read().expect("readable");
+            let source_producer_id = guard.lane_metadata().producer_id();
+            drop(guard);
+
+            assert_eq!(source_producer_id, publishing_producer.producer_id());
+        }
+    }
+
+    #[test]
+    fn lane_metadata_is_none_for_an_out_of_range_index() {
+        for create in producer_creators() {
+            let producer = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 2,
+                consumer_slots: 1,
+            });
+            let broadcast = producer.broadcast_handle();
+
+            let metadata = broadcast.lane_metadata(2);
+
+            assert!(metadata.is_none());
+        }
+    }
+
+    #[test]
+    fn lane_metadata_remains_available_after_producer_drop() {
+        for create in identified_producer_creators() {
+            let producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 1,
+                    consumer_slots: 1,
+                },
+                ProducerId::new(42),
+            );
+            let broadcast = producer.broadcast_handle();
+            let lane = producer.index();
+
+            drop(producer);
+
+            assert!(broadcast.lane_metadata(lane).is_some());
+        }
+    }
+
+    #[test]
+    fn borrowed_lane_metadata_keeps_the_producer_id_after_drop() {
+        for create in identified_producer_creators() {
+            let producer_id = ProducerId::new(42);
+            let producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 1,
+                    consumer_slots: 1,
+                },
+                producer_id,
+            );
+            let broadcast = producer.broadcast_handle();
+            let metadata = broadcast
+                .lane_metadata(producer.index())
+                .expect("owned lane has metadata");
+
+            drop(producer);
+
+            assert_eq!(metadata.producer_id(), producer_id);
+        }
+    }
+
+    #[test]
+    fn retired_lane_metadata_keeps_the_rejected_items_count() {
+        for create in producer_creators() {
+            let mut producer = create(BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            });
+            let broadcast = producer.broadcast_handle();
+            let _consumer = broadcast.consumer().unwrap();
+            for value in 0..4u64 {
+                producer.try_write(value).expect("ring has capacity");
+            }
+            let _ = producer.try_write(99);
+            let lane = producer.index();
+
+            drop(producer);
+
+            let metadata = broadcast
+                .lane_metadata(lane)
+                .expect("retired lane retains metadata");
+            assert_eq!(metadata.rejected_items(), 1);
+        }
+    }
+
+    #[test]
+    fn borrowed_lane_metadata_remains_usable_after_a_read() {
+        for create in identified_producer_creators() {
+            let idle_producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 2,
+                    consumer_slots: 1,
+                },
+                ProducerId::new(41),
+            );
+            let broadcast = idle_producer.broadcast_handle();
+            let mut publishing_producer = broadcast.producer(ProducerId::new(42)).unwrap();
+            let mut consumer = broadcast.consumer().unwrap();
+            let metadata = broadcast
+                .lane_metadata(publishing_producer.index())
+                .expect("owned lane has metadata");
+            publishing_producer.try_write(7).expect("ring has capacity");
+
+            let guard = consumer.try_reserve_read().expect("readable");
+            drop(guard);
+
+            assert_eq!(metadata.producer_id(), publishing_producer.producer_id());
+        }
+    }
+
+    #[test]
+    fn read_batch_reports_the_source_lane() {
+        for create in identified_producer_creators() {
+            let idle_producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 2,
+                    consumer_slots: 1,
+                },
+                ProducerId::new(41),
+            );
+            let broadcast = idle_producer.broadcast_handle();
+            let mut publishing_producer = broadcast.producer(ProducerId::new(42)).unwrap();
+            let mut consumer = broadcast.consumer().unwrap();
+            let _ = publishing_producer.try_write_slice(&[8, 9]);
+
+            let batch = consumer
+                .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+                .expect("readable batch");
+            let source_lane = batch.lane_metadata().lane();
+            drop(batch);
+
+            assert_eq!(source_lane, publishing_producer.index());
+        }
+    }
+
+    #[test]
+    fn read_batch_reports_the_source_producer_id() {
+        for create in identified_producer_creators() {
+            let idle_producer = create(
+                BroadcastConfig {
+                    capacity: 4,
+                    producer_slots: 2,
+                    consumer_slots: 1,
+                },
+                ProducerId::new(41),
+            );
+            let broadcast = idle_producer.broadcast_handle();
+            let mut publishing_producer = broadcast.producer(ProducerId::new(42)).unwrap();
+            let mut consumer = broadcast.consumer().unwrap();
+            let _ = publishing_producer.try_write_slice(&[8, 9]);
+
+            let batch = consumer
+                .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+                .expect("readable batch");
+            let source_producer_id = batch.lane_metadata().producer_id();
+            drop(batch);
+
+            assert_eq!(source_producer_id, publishing_producer.producer_id());
+        }
+    }
+
+    #[test]
+    fn untyped_broadcast_exposes_lane_metadata() {
+        let producer = create_identified_heap_producer(
+            BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            },
+            ProducerId::new(42),
+        );
+        // SAFETY: `Payload` is `u64`, whose entire representation is initialized.
+        let consumer = unsafe { producer.broadcast_handle().slice_consumer() }.unwrap();
+        let broadcast: Broadcast<UnknownType> = consumer.broadcast_handle();
+
+        let metadata = broadcast.lane_metadata(producer.index());
+
+        assert!(metadata.is_some());
+    }
+
+    #[test]
+    fn slice_read_guard_reports_the_source_lane() {
+        let mut producer = create_identified_heap_producer(
+            BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            },
+            ProducerId::new(42),
+        );
+        // SAFETY: `Payload` is `u64`, whose entire representation is initialized.
+        let mut consumer = unsafe { producer.broadcast_handle().slice_consumer() }.unwrap();
+        producer.try_write(1).expect("ring has capacity");
+
+        let guard = consumer.try_read().expect("readable");
+        let source_lane = guard.lane_metadata().lane();
+        drop(guard);
+
+        assert_eq!(source_lane, producer.index());
+    }
+
+    #[test]
+    fn slice_read_guard_reports_the_source_producer_id() {
+        let mut producer = create_identified_heap_producer(
+            BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            },
+            ProducerId::new(42),
+        );
+        // SAFETY: `Payload` is `u64`, whose entire representation is initialized.
+        let mut consumer = unsafe { producer.broadcast_handle().slice_consumer() }.unwrap();
+        producer.try_write(1).expect("ring has capacity");
+
+        let guard = consumer.try_read().expect("readable");
+        let source_producer_id = guard.lane_metadata().producer_id();
+        drop(guard);
+
+        assert_eq!(source_producer_id, producer.producer_id());
+    }
+
+    #[test]
+    fn slice_read_batch_reports_the_source_lane() {
+        let mut producer = create_identified_heap_producer(
+            BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            },
+            ProducerId::new(42),
+        );
+        // SAFETY: `Payload` is `u64`, whose entire representation is initialized.
+        let mut consumer = unsafe { producer.broadcast_handle().slice_consumer() }.unwrap();
+        let _ = producer.try_write_slice(&[2, 3]);
+
+        let batch = consumer
+            .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+            .expect("readable batch");
+        let source_lane = batch.lane_metadata().lane();
+        drop(batch);
+
+        assert_eq!(source_lane, producer.index());
+    }
+
+    #[test]
+    fn slice_read_batch_reports_the_source_producer_id() {
+        let mut producer = create_identified_heap_producer(
+            BroadcastConfig {
+                capacity: 4,
+                producer_slots: 1,
+                consumer_slots: 1,
+            },
+            ProducerId::new(42),
+        );
+        // SAFETY: `Payload` is `u64`, whose entire representation is initialized.
+        let mut consumer = unsafe { producer.broadcast_handle().slice_consumer() }.unwrap();
+        let _ = producer.try_write_slice(&[2, 3]);
+
+        let batch = consumer
+            .try_reserve_read_batch(NonZeroUsize::new(2).unwrap())
+            .expect("readable batch");
+        let source_producer_id = batch.lane_metadata().producer_id();
+        drop(batch);
+
+        assert_eq!(source_producer_id, producer.producer_id());
+    }
+
     /// Allocates a heap-backed queue and returns the shared handle (recovery
     /// tests need the queue directly to simulate a crashed handle).
     fn recovery_queue(config: &BroadcastConfig) -> SharedQueue {
@@ -2449,14 +3090,14 @@ mod tests {
 
         // A producer publishes two items and drops, retiring its lane.
         {
-            let mut producer = Producer::from_queue(queue.clone()).unwrap();
+            let mut producer = Producer::from_queue(queue.clone(), BOGUS_ID).unwrap();
             assert!(producer.try_write(1).is_ok());
             assert!(producer.try_write(2).is_ok());
         }
 
         // The retired lane is never handed to a new producer.
         assert!(matches!(
-            Producer::<Payload>::from_queue(queue.clone()),
+            Producer::<Payload>::from_queue(queue.clone(), BOGUS_ID),
             Err(Error::ProducerSlotsExhausted)
         ));
 
@@ -2483,7 +3124,7 @@ mod tests {
         ConsumerCore::join_lane(&lane, index);
         queue.activate_consumer_index(index);
 
-        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+        let mut producer = Producer::from_queue(queue.clone(), BOGUS_ID).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());
         }
@@ -2508,7 +3149,7 @@ mod tests {
         let queue = recovery_queue(&config);
         let index = queue.acquire_consumer_index().unwrap();
         let lane = queue.lane(0);
-        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+        let mut producer = Producer::from_queue(queue.clone(), BOGUS_ID).unwrap();
 
         // The consumer sampled reservation 0, then the producer filled the ring
         // before the consumer published its initial limit. Simulate a crash after
@@ -2544,7 +3185,7 @@ mod tests {
         let lane = queue.lane(0);
         ConsumerCore::join_lane(&lane, index);
         queue.activate_consumer_index(index);
-        let mut producer = Producer::from_queue(queue.clone()).unwrap();
+        let mut producer = Producer::from_queue(queue.clone(), BOGUS_ID).unwrap();
         for value in 0..3u64 {
             assert!(producer.try_write(value).is_ok());
         }
@@ -2597,12 +3238,12 @@ mod tests {
         // SAFETY: a fresh temp file, initialized exactly once here.
         let creator = unsafe { Broadcast::<Payload>::create(&file, config) }.unwrap();
 
-        let mut p0 = creator.producer().unwrap();
+        let mut p0 = creator.producer(ProducerId::new(1)).unwrap();
         // SAFETY: the file now holds a live queue with the same `T` and layout.
         let joiner = unsafe { Broadcast::<Payload>::join(&file) }.unwrap();
-        let mut p1 = joiner.producer().unwrap();
+        let mut p1 = joiner.producer(ProducerId::new(2)).unwrap();
         assert!(matches!(
-            creator.producer(),
+            creator.producer(ProducerId::new(3)),
             Err(Error::ProducerSlotsExhausted)
         ));
 
@@ -2621,7 +3262,7 @@ mod tests {
             consumer_slots: 2,
         });
         let mut consumer = p0.broadcast_handle().consumer().unwrap();
-        let mut p1 = consumer.broadcast_handle().producer().unwrap();
+        let mut p1 = consumer.broadcast_handle().producer(BOGUS_ID).unwrap();
         // SAFETY: `Payload` is `u64`, whose entire representation is initialized.
         let mut slice_consumer = unsafe { p1.broadcast_handle().slice_consumer() }.unwrap();
 

--- a/src/broadcast/producer_lane.rs
+++ b/src/broadcast/producer_lane.rs
@@ -7,20 +7,27 @@ use core::mem::{align_of, size_of};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::sync::atomic::{fence, AtomicU64, Ordering};
+use std::marker::PhantomData;
 
+use crate::broadcast::{InitializedLane, LaneIndex, ProducerId, UnverifiedLane};
 use crate::CacheAlignedAtomicSize;
 
 use super::consumer_state::LaneConsumerState;
 
 const LANE_FREE: u64 = 0;
-const LANE_ACTIVE: u64 = 1;
-const LANE_RETIRED: u64 = 2;
+const LANE_CLAIMING: u64 = 1;
+const LANE_ACTIVE: u64 = 2;
+const LANE_RETIRED: u64 = 3;
 
 /// Fixed-size head of a producer-lane block.
 #[repr(C)]
-struct LaneHeader {
-    /// Lane ownership: `LANE_FREE`, `LANE_ACTIVE`, or `LANE_RETIRED`.
+pub(super) struct LaneHeader {
+    /// Lane ownership: `LANE_FREE`, `LANE_CLAIMING`, `LANE_ACTIVE`, or `LANE_RETIRED`.
     state: AtomicU64,
+    /// Supplied [`ProducerId`], meaningful once the lane is active or retired.
+    producer_id: AtomicU64,
+    /// Count of messages refused by backpressure.
+    rejected_items: AtomicU64,
     /// Claimed-up-to sequence: advanced before a ring cell is written.
     producer_reservation: CacheAlignedAtomicSize,
     /// Visible-up-to sequence: advanced after a ring cell is written; consumers
@@ -45,6 +52,71 @@ pub(crate) struct ProducerLane {
     payload_size: usize,
 
     mask: usize, // capacity - 1
+}
+
+/// A borrowed view of one producer lane's metadata.
+///
+/// The view cannot outlive the broadcast mapping from which it was obtained.
+#[derive(Clone, Copy)]
+pub struct LaneMetadata<'a> {
+    header: &'a LaneHeader,
+    lane: LaneIndex<InitializedLane>,
+}
+
+impl<'a> LaneMetadata<'a> {
+    /// Builds a metadata view if the lane has completed acquisition.
+    pub(super) fn try_new(header: &'a LaneHeader, lane: LaneIndex<UnverifiedLane>) -> Option<Self> {
+        let state = header.state.load(Ordering::Acquire);
+
+        let lane_is_acquired = matches!(state, LANE_ACTIVE | LANE_RETIRED);
+        if !lane_is_acquired {
+            return None;
+        }
+
+        Some(Self {
+            header,
+            lane: LaneIndex {
+                index: lane.get(),
+                _state: PhantomData,
+            },
+        })
+    }
+
+    /// Builds a metadata view over a borrowed lane header.
+    pub(super) fn from_initialized_lane(
+        header: &'a LaneHeader,
+        lane: LaneIndex<InitializedLane>,
+    ) -> Self {
+        Self { header, lane }
+    }
+
+    /// The index of this producer lane.
+    #[inline]
+    pub fn lane(&self) -> usize {
+        self.lane.get()
+    }
+
+    /// The producer chosen [`ProducerId`] permanently associated with this lane.
+    #[inline]
+    pub fn producer_id(&self) -> ProducerId {
+        ProducerId::new(self.header.producer_id.load(Ordering::Relaxed))
+    }
+
+    /// Count of messages refused by backpressure on this lane.
+    #[inline]
+    pub fn rejected_items(&self) -> u64 {
+        self.header.rejected_items.load(Ordering::Relaxed)
+    }
+}
+
+impl core::fmt::Debug for LaneMetadata<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LaneMetadata")
+            .field("lane", &self.lane())
+            .field("producer_id", &self.producer_id())
+            .field("rejected_items", &self.rejected_items())
+            .finish()
+    }
 }
 
 #[inline]
@@ -90,6 +162,8 @@ impl ProducerLane {
     pub(crate) unsafe fn init(block: NonNull<u8>, consumer_slots: usize) {
         let header = LaneHeader {
             state: AtomicU64::new(LANE_FREE),
+            producer_id: AtomicU64::new(0),
+            rejected_items: AtomicU64::new(0),
             producer_reservation: CacheAlignedAtomicSize::default(),
             producer_publication: CacheAlignedAtomicSize::default(),
         };
@@ -139,6 +213,12 @@ impl ProducerLane {
         }
     }
 
+    /// Returns borrowed metadata for this lane.
+    #[inline]
+    pub(crate) fn metadata(&self, lane: LaneIndex<InitializedLane>) -> LaneMetadata<'_> {
+        LaneMetadata::from_initialized_lane(self.header(), lane)
+    }
+
     #[inline]
     pub(crate) fn capacity(&self) -> usize {
         self.mask.wrapping_add(1)
@@ -170,13 +250,28 @@ impl ProducerLane {
         unsafe { self.ring.byte_add(offset) }
     }
 
-    /// Claims the lane for a producer. Returns `false` if already owned.
+    /// Claims the lane for a producer, installing its `producer_id`. Returns
+    /// `false` if already owned.
     #[must_use]
-    pub(crate) fn try_acquire(&self) -> bool {
+    pub(crate) fn try_acquire(&self, producer_id: ProducerId) -> bool {
+        let acquire_result = self.header().state.compare_exchange(
+            LANE_FREE,
+            LANE_CLAIMING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+
+        if acquire_result.is_err() {
+            return false;
+        }
+
         self.header()
-            .state
-            .compare_exchange(LANE_FREE, LANE_ACTIVE, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
+            .producer_id
+            .store(producer_id.get(), Ordering::Relaxed);
+
+        self.header().state.store(LANE_ACTIVE, Ordering::Release);
+
+        true
     }
 
     /// Permanently retires the lane. A retired lane never returns to the free
@@ -215,6 +310,9 @@ impl ProducerLane {
         // consumer still needs. Unowned slots sit at the top, so they never
         // gate.
         if start.wrapping_add(count.get()) > self.consumer_state.reserve_limit() {
+            self.header()
+                .rejected_items
+                .fetch_add(count.get() as u64, Ordering::Relaxed);
             return None;
         }
         // Claim before the writes; consumers only read `< producer_publication`.
@@ -231,7 +329,6 @@ impl ProducerLane {
             .producer_publication
             .store(start.wrapping_add(count.get()), Ordering::Release);
     }
-
     #[inline]
     pub(crate) fn published(&self) -> usize {
         self.header().producer_publication.load(Ordering::Acquire)
@@ -250,6 +347,8 @@ mod tests {
     use std::num::NonZeroUsize;
 
     type Payload = u64;
+
+    const BOGUS_PRODUCER_ID: ProducerId = ProducerId::new(1111);
 
     /// Allocates and initializes a standalone lane block.
     fn lane(capacity: u32, consumer_slots: usize) -> (std::sync::Arc<Region>, ProducerLane) {
@@ -275,6 +374,10 @@ mod tests {
         consumer_state.join(consumer_index, || lane.reserved())
     }
 
+    fn metadata(lane: &ProducerLane) -> LaneMetadata<'_> {
+        LaneMetadata::try_new(lane.header(), LaneIndex::new(0)).expect("lane is active or retired")
+    }
+
     /// Reserves, writes, and publishes one value; `false` on backpressure.
     fn publish_value(lane: &mut ProducerLane, value: Payload) -> bool {
         let one = NonZeroUsize::new(1).unwrap();
@@ -290,22 +393,102 @@ mod tests {
     #[test]
     fn lane_ownership_is_exclusive() {
         let (_region, lane) = lane(4, 1);
-        assert!(lane.try_acquire());
-        assert!(!lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
+        assert!(!lane.try_acquire(BOGUS_PRODUCER_ID));
     }
 
     #[test]
     fn retired_lane_is_never_reclaimed() {
         let (_region, lane) = lane(4, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         lane.retire();
-        assert!(!lane.try_acquire());
+        assert!(!lane.try_acquire(BOGUS_PRODUCER_ID));
+    }
+
+    #[test]
+    fn never_owned_lane_has_not_completed_acquisition() {
+        let (_region, lane) = lane(4, 1);
+
+        let metadata = LaneMetadata::try_new(lane.header(), LaneIndex::new(0));
+
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn claiming_lane_has_not_completed_acquisition() {
+        let (_region, lane) = lane(4, 1);
+        let header = lane.header();
+        header
+            .state
+            .compare_exchange(
+                LANE_FREE,
+                LANE_CLAIMING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .expect("lane is free");
+        header.producer_id.store(42, Ordering::Relaxed);
+
+        let metadata = LaneMetadata::try_new(lane.header(), LaneIndex::new(0));
+
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn acquiring_installs_the_producer_id() {
+        let (_region, lane) = lane(4, 1);
+        let producer_id = ProducerId::new(42);
+
+        let _ = lane.try_acquire(producer_id);
+
+        assert_eq!(metadata(&lane).producer_id(), producer_id);
+    }
+
+    #[test]
+    fn refused_reserves_count_rejected_items() {
+        let (_region, mut lane) = lane(4, 1);
+        let _ = lane.try_acquire(BOGUS_PRODUCER_ID);
+        let _ = join_consumer(&lane, 0);
+        for value in 0..4u64 {
+            let _ = publish_value(&mut lane, value);
+        }
+
+        let _ = publish_value(&mut lane, 99);
+        let _ = lane.try_reserve(NonZeroUsize::new(2).unwrap());
+
+        assert_eq!(metadata(&lane).rejected_items(), 3);
+    }
+
+    #[test]
+    fn retired_lane_keeps_the_last_owner_id() {
+        let (_region, lane) = lane(4, 1);
+        let producer_id = ProducerId::new(42);
+        let _ = lane.try_acquire(producer_id);
+
+        lane.retire();
+
+        assert_eq!(metadata(&lane).producer_id(), producer_id);
+    }
+
+    #[test]
+    fn retired_lane_keeps_the_rejected_items_count() {
+        let (_region, mut lane) = lane(4, 1);
+        let _ = lane.try_acquire(ProducerId::new(42));
+        let _ = join_consumer(&lane, 0);
+        for value in 0..4u64 {
+            let _ = publish_value(&mut lane, value);
+        }
+        let _ = publish_value(&mut lane, 99);
+
+        lane.retire();
+
+        assert_eq!(metadata(&lane).rejected_items(), 1);
     }
 
     #[test]
     fn publishes_and_advances_cursors() {
         let (_region, mut lane) = lane(4, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         for value in 0..4u64 {
             assert!(publish_value(&mut lane, value * 10));
         }
@@ -319,7 +502,7 @@ mod tests {
     #[test]
     fn reserves_and_publishes_a_batch() {
         let (_region, mut lane) = lane(8, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         let count = NonZeroUsize::new(3).unwrap();
         let start = lane.try_reserve(count).expect("reserve");
         for offset in 0..count.get() {
@@ -343,14 +526,17 @@ mod tests {
     #[test]
     fn reserve_rejects_count_above_capacity() {
         let (_region, mut lane) = lane(4, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         assert!(lane.try_reserve(NonZeroUsize::new(5).unwrap()).is_none());
+        // A caller error is not backpressure, so it is not counted as
+        // rejected items.
+        assert_eq!(metadata(&lane).rejected_items(), 0);
     }
 
     #[test]
     fn no_active_consumers_allows_free_overwrite() {
         let (_region, mut lane) = lane(4, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         // Publish well past one revolution; with no active consumer there is
         // nothing to protect, so every reserve succeeds.
         for value in 0..16u64 {
@@ -366,7 +552,7 @@ mod tests {
     #[test]
     fn backpressure_when_consumer_lags() {
         let (_region, mut lane) = lane(4, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         // Join consumer 0; nothing published yet, so it starts at sequence 0.
         assert_eq!(join_consumer(&lane, 0), 0);
 
@@ -392,7 +578,7 @@ mod tests {
     #[test]
     fn released_consumer_no_longer_constrains() {
         let (_region, mut lane) = lane(4, 1);
-        assert!(lane.try_acquire());
+        assert!(lane.try_acquire(BOGUS_PRODUCER_ID));
         assert_eq!(join_consumer(&lane, 0), 0);
         for value in 0..4u64 {
             assert!(publish_value(&mut lane, value));


### PR DESCRIPTION
This PR adds new functionality for broadcast producers to record metadata that all other writers and readers can read from.
First two metadata fields added in this PR:
- `rejected_items`; a counter per producer that is incremented every time a producer is blocked from writing a new message due to backpressure.
- `identifier`; an unique identifier assigned to every producer. This allows readers to discern which producer a message they read came from.

closes #103