### PR TITLE
chore(clippy): harden clippy lints for unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ windows-sys = { version = "0.61", features = [
 [dev-dependencies]
 core_affinity = "0.8.3"
 ctrlc = "3.5.2"
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
+[lints.clippy]
+multiple_unsafe_ops_per_block = "deny"
+undocumented_unsafe_blocks = "deny"

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -270,6 +270,7 @@ impl SharedQueue {
     /// # Safety
     /// - `region` must reference memory laid out by [`Self::create_in_region`].
     unsafe fn join_region<T>(region: &Arc<Region>) -> Result<Self, Error> {
+        // SAFETY: caller guarantees `region` was laid out by `create_in_region`.
         unsafe { Self::join_region_with(region, QueueLayout::from_header::<T>) }
     }
 
@@ -279,6 +280,7 @@ impl SharedQueue {
     /// # Safety
     /// - `region` must reference memory laid out by [`Self::create_in_region`].
     unsafe fn join_region_untyped(region: &Arc<Region>) -> Result<Self, Error> {
+        // SAFETY: caller guarantees `region` was laid out by `create_in_region`.
         unsafe { Self::join_region_with(region, QueueLayout::from_header_payload) }
     }
 
@@ -308,6 +310,7 @@ impl SharedQueue {
         let base = region.addr();
 
         // Global consumer-ownership table: every index free.
+        // SAFETY: `consumer_state_offset` lies within the region (>= `layout.total`).
         let consumer_state = unsafe { base.byte_add(layout.consumer_state_offset) };
         // SAFETY: the layout reserves `consumer_slots` AtomicU64s here.
         unsafe { ConsumerState::init(consumer_state, layout.consumer_slots) };
@@ -493,6 +496,7 @@ impl Clone for SharedQueue {
 // SAFETY: the region is shared (file-backed / heap) and access is synchronized
 // by the queue protocol; the pointers are stable for the region's lifetime.
 unsafe impl Send for SharedQueue {}
+// SAFETY: shared access to the region is synchronized by the queue protocol.
 unsafe impl Sync for SharedQueue {}
 
 /// A producer: owns one lane and publishes into it. Single-threaded use (its
@@ -1711,11 +1715,10 @@ mod tests {
                 .expect("readable batch");
             assert_eq!(batch.len(), 2);
             assert_eq!(batch.payload_size(), size_of::<Payload>());
-            // SAFETY: both indexes are below `batch.len()`.
-            unsafe {
-                assert_eq!(batch.as_slice(0), 11u64.to_ne_bytes());
-                assert_eq!(batch.as_slice(1), 12u64.to_ne_bytes());
-            }
+            // SAFETY: index 0 < batch.len().
+            unsafe { assert_eq!(batch.as_slice(0), 11u64.to_ne_bytes()) };
+            // SAFETY: index 1 < batch.len().
+            unsafe { assert_eq!(batch.as_slice(1), 12u64.to_ne_bytes()) };
         }
 
         let guard = consumer.try_read().expect("remaining item");

--- a/src/broadcast/consumer_state.rs
+++ b/src/broadcast/consumer_state.rs
@@ -137,8 +137,10 @@ impl ConsumerState {
     #[inline]
     fn slot(&self, index: usize) -> &AtomicU64 {
         debug_assert!(index < self.slot_count);
-        // SAFETY: `index < slot_count`; the slot was initialized.
-        unsafe { self.slots.add(index).as_ref() }
+        // SAFETY: `index < slot_count`, so the offset stays in bounds.
+        let slot = unsafe { self.slots.add(index) };
+        // SAFETY: the slot was initialized at construction.
+        unsafe { slot.as_ref() }
     }
 }
 
@@ -293,8 +295,10 @@ impl LaneConsumerState {
     #[inline]
     fn limit(&self, consumer_index: usize) -> &CacheAlignedAtomicSize {
         debug_assert!(consumer_index < self.slot_count);
-        // SAFETY: `consumer_index < slot_count`; the slot was initialized.
-        unsafe { self.limits.add(consumer_index).as_ref() }
+        // SAFETY: `consumer_index < slot_count`, so the offset stays in bounds.
+        let limit = unsafe { self.limits.add(consumer_index) };
+        // SAFETY: the slot was initialized at construction.
+        unsafe { limit.as_ref() }
     }
 }
 

--- a/src/futex.rs
+++ b/src/futex.rs
@@ -331,7 +331,9 @@ mod imp {
 
     fn errno() -> i32 {
         // SAFETY: `__errno_location` returns this thread's errno location on Linux.
-        unsafe { *libc::__errno_location() }
+        let errno = unsafe { libc::__errno_location() };
+        // SAFETY: the returned pointer is valid and points to this thread's errno.
+        unsafe { *errno }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use core::sync::atomic::AtomicUsize;
 
 // NB: To simplify casting we only support 64bit or wider systems.

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -207,7 +207,11 @@ impl<T> Clone for Producer<T> {
     }
 }
 
+// SAFETY: All payload access is synchronized through the atomic reservation
+// and publication cursors in the shared header, so `T` is only touched by one
+// endpoint at a time; sending/sharing across threads is sound when `T: Send`.
 unsafe impl<T: Send> Send for Producer<T> {}
+// SAFETY: See the `Send` impl above; the queue protocol synchronizes all access.
 unsafe impl<T: Send> Sync for Producer<T> {}
 
 pub struct Consumer<T> {
@@ -456,7 +460,11 @@ impl<T> Clone for Consumer<T> {
     }
 }
 
+// SAFETY: All payload access is synchronized through the atomic reservation
+// and publication cursors in the shared header, so `T` is only touched by one
+// endpoint at a time; sending/sharing across threads is sound when `T: Send`.
 unsafe impl<T: Send> Send for Consumer<T> {}
+// SAFETY: See the `Send` impl above; the queue protocol synchronizes all access.
 unsafe impl<T: Send> Sync for Consumer<T> {}
 
 /// Calculates the minimum file size required for a queue with given capacity.
@@ -481,6 +489,8 @@ pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Erro
     let region = Region::alloc(NonZeroUsize::new(region_size).ok_or(Error::InvalidBufferSize)?)?;
     // SAFETY: `region` is freshly allocated and used only for this queue.
     let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
+    // SAFETY: `header` was just created in `region`, so it is valid, aligned,
+    // and paired with that region.
     let producer = unsafe { Producer::from_header(region, header) }?;
     let consumer = producer.join_as_consumer();
     Ok((producer, consumer))
@@ -505,16 +515,18 @@ impl<T> Drop for SharedQueue<T> {
             return;
         }
 
-        // SharedQueue is dropped by its Arc after the last endpoint disappears,
-        // so no endpoint can access the header or buffer during cleanup.
+        // SAFETY: SharedQueue is dropped by its Arc after the last endpoint
+        // disappears, so no endpoint can access the header during cleanup.
         let header = unsafe { self.header.as_ref() };
         let mut position = header.consumer_reservation.load(Ordering::Acquire);
         let publication = header.producer_publication.load(Ordering::Acquire);
 
         while position != publication {
+            // SAFETY: Mask keeps the index within the allocated buffer.
+            let slot = unsafe { self.buffer.add(position & self.buffer_mask) };
             // SAFETY: Positions from the consumer reservation cursor through
             // producer publication contain initialized, unclaimed values.
-            unsafe { self.buffer.add(position & self.buffer_mask).drop_in_place() };
+            unsafe { slot.drop_in_place() };
             position = position.wrapping_add(1);
         }
     }
@@ -623,6 +635,7 @@ impl<T> SharedQueue<T> {
         region: Arc<Region>,
         header: NonNull<SharedQueueHeader>,
     ) -> Result<Arc<Self>, Error> {
+        // SAFETY: caller guarantees `header` is non-null, aligned, and valid.
         let header_ref = unsafe { header.as_ref() };
         let buffer_mask = header_ref.buffer_mask as usize;
         let buffer_size_in_items = buffer_mask.wrapping_add(1);
@@ -1010,8 +1023,10 @@ impl<'a, T> WriteBatch<'a, T> {
     pub unsafe fn as_mut(&mut self, index: usize) -> &mut MaybeUninit<T> {
         debug_assert!(index < self.count.get());
         let position = self.start.wrapping_add(index);
+        // SAFETY: Mask keeps the index within the reserved buffer.
+        let slot = unsafe { self.buffer.add(position & self.buffer_mask) };
         // SAFETY: The position was reserved for writing.
-        unsafe { self.buffer.add(position & self.buffer_mask).cast().as_mut() }
+        unsafe { slot.cast().as_mut() }
     }
 
     /// Writes a value into the slot at index.
@@ -1023,8 +1038,10 @@ impl<'a, T> WriteBatch<'a, T> {
     pub unsafe fn write(&mut self, index: usize, value: T) {
         debug_assert!(index < self.count.get());
         let position = self.start.wrapping_add(index);
-        // SAFETY: The position was reserved for writing
-        unsafe { self.buffer.add(position & self.buffer_mask).write(value) }
+        // SAFETY: Mask keeps the index within the reserved buffer.
+        let slot = unsafe { self.buffer.add(position & self.buffer_mask) };
+        // SAFETY: The position was reserved for writing.
+        unsafe { slot.write(value) }
     }
 }
 
@@ -1073,8 +1090,10 @@ impl<'a, T> RawReadBatch<'a, T> {
     pub unsafe fn get_unchecked(&self, index: usize) -> &T {
         debug_assert!(index < self.count.get());
         let position = self.start.wrapping_add(index);
+        // SAFETY: Mask keeps the index within the buffer.
+        let slot = unsafe { self.buffer.add(position & self.buffer_mask) };
         // SAFETY: The position was reserved for reading and is initialized.
-        unsafe { self.buffer.add(position & self.buffer_mask).as_ref() }
+        unsafe { slot.as_ref() }
     }
 
     /// Reads the value at `index`.
@@ -1087,8 +1106,10 @@ impl<'a, T> RawReadBatch<'a, T> {
     pub unsafe fn get_owned_unchecked(&self, index: usize) -> T {
         debug_assert!(index < self.count.get());
         let position = self.start.wrapping_add(index);
+        // SAFETY: Mask keeps the index within the buffer.
+        let slot = unsafe { self.buffer.add(position & self.buffer_mask) };
         // SAFETY: The position was reserved for reading.
-        unsafe { self.buffer.add(position & self.buffer_mask).read() }
+        unsafe { slot.read() }
     }
 }
 
@@ -1265,8 +1286,10 @@ mod tests {
     fn create_file_backed_test_queue<T: Send>(capacity: usize) -> (Producer<T>, Consumer<T>) {
         let file = create_temp_shmem_file().expect("failed to create temp file");
         let file_size = minimum_file_size::<T>(capacity);
+        // SAFETY: test-only; sole producer for a freshly created file.
         let producer =
             unsafe { Producer::create(&file, file_size) }.expect("failed to create producer");
+        // SAFETY: test-only; sole consumer for this file.
         let consumer = unsafe { Consumer::join(&file) }.expect("failed to join consumer");
 
         (producer, consumer)
@@ -1374,6 +1397,7 @@ mod tests {
         for create_queue in test_queue_creators::<Item>() {
             let (producer, consumer) = create_queue(BUFFER_CAPACITY);
 
+            // SAFETY: test-only; slot is initialized below before the guard drops.
             let mut guard = unsafe { producer.try_reserve_write() }.expect("reserve failed");
             guard.as_mut().write(42);
             drop(guard);
@@ -1390,9 +1414,11 @@ mod tests {
             let (producer, consumer) = create_queue(BUFFER_CAPACITY);
 
             let batch_size = NonZeroUsize::new(4).unwrap();
+            // SAFETY: test-only; every slot is initialized below before drop.
             let mut batch = unsafe { producer.try_reserve_write_batch(batch_size) }
                 .expect("reserve_batch failed");
             for index in 0..batch.len() {
+                // SAFETY: test-only; index < batch.len().
                 unsafe {
                     batch.as_mut(index).write(index as u64);
                 }
@@ -1417,6 +1443,7 @@ mod tests {
         for create_queue in test_queue_creators::<Item>() {
             let (producer, consumer) = create_queue(BUFFER_CAPACITY);
 
+            // SAFETY: test-only; reservation fails so no slot is left uninitialized.
             unsafe {
                 assert!(producer
                     .try_reserve_write_batch(NonZeroUsize::new(BUFFER_CAPACITY + 1).unwrap())
@@ -1556,6 +1583,7 @@ mod tests {
                     .try_reserve_read_batch_raw(NonZeroUsize::new(4).unwrap())
                     .expect("raw read batch")
             };
+            // SAFETY: test-only; index 2 is in bounds and not yet moved out.
             assert_eq!(unsafe { batch.get_unchecked(2) }.value, 2);
             for index in [2, 0, 1] {
                 // SAFETY: Each in-bounds index is moved out exactly once.
@@ -1771,6 +1799,7 @@ mod tests {
             assert_eq!(*guard.as_ref(), 0);
             core::mem::forget(guard);
 
+            // SAFETY: test-only; sole consumer, no other live consumer.
             unsafe {
                 consumer.recover_as_exclusive_lossy();
             }
@@ -1795,6 +1824,7 @@ mod tests {
             assert_eq!(*guard.as_ref(), 0);
             core::mem::forget(guard);
 
+            // SAFETY: test-only; sole consumer, no other live consumer.
             unsafe {
                 consumer.recover_as_exclusive();
             }
@@ -1814,10 +1844,12 @@ mod tests {
 
             producer.try_write(10).unwrap();
 
+            // SAFETY: test-only; slot is initialized below before it is forgotten.
             let mut guard = unsafe { producer.try_reserve_write() }.expect("reserve write");
             guard.as_mut().write(99);
             core::mem::forget(guard);
 
+            // SAFETY: test-only; sole producer, no other live producer.
             unsafe {
                 producer.recover_as_exclusive();
             }

--- a/src/shmem.rs
+++ b/src/shmem.rs
@@ -74,6 +74,8 @@ enum RegionBacking {
 // SAFETY: The mapped memory is shared (MAP_SHARED / file-backed) and access
 // is synchronized by the queue protocol built on top of it.
 unsafe impl Send for Region {}
+// SAFETY: Shared access to the mapped memory is synchronized by the queue
+// protocol built on top of it, so the Region may be shared across threads.
 unsafe impl Sync for Region {}
 
 fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
@@ -93,6 +95,8 @@ fn validate_region_alignment(addr: NonNull<u8>) -> Result<(), Error> {
 fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
     use std::os::fd::AsRawFd;
 
+    // SAFETY: A null hint lets the kernel choose the address; size and fd come
+    // from a valid open file, and MAP_FAILED is checked below.
     let addr = unsafe {
         libc::mmap(
             core::ptr::null_mut(),
@@ -113,6 +117,7 @@ fn map_file(file: &File, size: usize) -> Result<NonNull<u8>, Error> {
 /// Unmaps a previously mapped file view.
 #[cfg(unix)]
 unsafe fn unmap_file(addr: NonNull<u8>, size: usize) {
+    // SAFETY: addr and size describe a mapping produced by a prior map_file call.
     let _ = unsafe { libc::munmap(addr.as_ptr().cast(), size) };
 }
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -41,7 +41,9 @@ pub fn pair<T: Send>(capacity: usize) -> Result<(Producer<T>, Consumer<T>), Erro
     let region = Region::alloc(NonZeroUsize::new(region_size).ok_or(Error::InvalidBufferSize)?)?;
     // SAFETY: `region` is freshly allocated and used only for this queue.
     let header = unsafe { SharedQueueHeader::create_in_region::<T>(&region) }?;
+    // SAFETY: `header` was just created in `region`, so it is valid for the queue.
     let producer = unsafe { Producer::from_header(Arc::clone(&region), header) }?;
+    // SAFETY: `header` was just created in `region`, so it is valid for the queue.
     let consumer = unsafe { Consumer::from_header(region, header) }?;
     Ok((producer, consumer))
 }
@@ -186,6 +188,9 @@ impl<T> Producer<T> {
     }
 }
 
+// SAFETY: The producer owns the write side exclusively and access to the
+// shared buffer is synchronized by the queue protocol, so it is safe to move
+// to another thread when `T: Send`.
 unsafe impl<T: Send> Send for Producer<T> {}
 
 /// Consumer side of the SPSC shared queue.
@@ -366,6 +371,9 @@ impl<T> Consumer<T> {
     }
 }
 
+// SAFETY: The consumer owns the read side exclusively and access to the
+// shared buffer is synchronized by the queue protocol, so it is safe to move
+// to another thread when `T: Send`.
 unsafe impl<T: Send> Send for Consumer<T> {}
 
 struct SharedQueue<T> {
@@ -637,8 +645,10 @@ mod tests {
     fn create_file_backed_test_queue<T: Send>(capacity: usize) -> (Producer<T>, Consumer<T>) {
         let file = create_temp_shmem_file().expect("failed to create temp file");
         let file_size = minimum_file_size::<T>(capacity);
+        // SAFETY: fresh temp file sized for the queue, no other users.
         let producer =
             unsafe { Producer::create(&file, file_size) }.expect("failed to create producer");
+        // SAFETY: file was just initialized by the producer above.
         let consumer = unsafe { Consumer::join(&file) }.expect("failed to join consumer");
 
         (producer, consumer)
@@ -662,51 +672,51 @@ mod tests {
             assert_eq!(producer.capacity(), BUFFER_CAPACITY);
             assert_eq!(consumer.capacity(), BUFFER_CAPACITY);
 
-            unsafe {
-                producer
-                    .reserve()
-                    .expect("Failed to reserve")
-                    .as_ref()
-                    .store(42, Ordering::Release);
-                assert!(consumer.try_read().is_none()); // not committed yet
-                producer.commit();
-                assert!(consumer.try_read().is_none()); // consumer has not synced yet
-                consumer.sync();
-                let item = consumer.try_read().expect("Failed to read item");
-                assert_eq!(item.load(Ordering::Acquire), 42);
-                assert!(consumer.try_read().is_none()); // no more items to read
-                consumer.finalize();
-                producer.sync();
+            // SAFETY: single producer over a freshly created queue.
+            let spot = unsafe { producer.reserve() }.expect("Failed to reserve");
+            // SAFETY: spot is a valid reserved slot.
+            unsafe { spot.as_ref() }.store(42, Ordering::Release);
+            assert!(consumer.try_read().is_none()); // not committed yet
+            producer.commit();
+            assert!(consumer.try_read().is_none()); // consumer has not synced yet
+            consumer.sync();
+            let item = consumer.try_read().expect("Failed to read item");
+            assert_eq!(item.load(Ordering::Acquire), 42);
+            assert!(consumer.try_read().is_none()); // no more items to read
+            consumer.finalize();
+            producer.sync();
 
-                // Ensure we can push up to the capacity.
-                for _ in 0..BUFFER_CAPACITY {
-                    let spot = producer.reserve().expect("Failed to reserve");
-                    spot.as_ref().store(1, Ordering::Release);
-                }
-                assert!(producer.reserve().is_none()); // buffer is full, we cannot reserve more
-                producer.commit();
-                consumer.sync();
-                for _ in 0..BUFFER_CAPACITY {
-                    let item = consumer.try_read().expect("Failed to read item");
-                    assert_eq!(item.load(Ordering::Acquire), 1);
-                }
-                assert!(consumer.try_read().is_none()); // no more items to read
-                consumer.finalize();
-                producer.sync();
-
-                // Ensure we can reserve again after finalizing/sync.
-                let spot = producer
-                    .reserve()
-                    .expect("Failed to reserve after finalize");
-                spot.as_ref().store(2, Ordering::Release);
-                producer.commit();
-                consumer.sync();
-                let item = consumer
-                    .try_read()
-                    .expect("Failed to read item after finalize");
-                assert_eq!(item.load(Ordering::Acquire), 2);
-                consumer.finalize();
+            // Ensure we can push up to the capacity.
+            for _ in 0..BUFFER_CAPACITY {
+                // SAFETY: single producer over the queue.
+                let spot = unsafe { producer.reserve() }.expect("Failed to reserve");
+                // SAFETY: spot is a valid reserved slot.
+                unsafe { spot.as_ref() }.store(1, Ordering::Release);
             }
+            // SAFETY: single producer; buffer is full so reserve yields None.
+            assert!(unsafe { producer.reserve() }.is_none()); // buffer is full, we cannot reserve more
+            producer.commit();
+            consumer.sync();
+            for _ in 0..BUFFER_CAPACITY {
+                let item = consumer.try_read().expect("Failed to read item");
+                assert_eq!(item.load(Ordering::Acquire), 1);
+            }
+            assert!(consumer.try_read().is_none()); // no more items to read
+            consumer.finalize();
+            producer.sync();
+
+            // Ensure we can reserve again after finalizing/sync.
+            // SAFETY: single producer over the queue after finalize.
+            let spot = unsafe { producer.reserve() }.expect("Failed to reserve after finalize");
+            // SAFETY: spot is a valid reserved slot.
+            unsafe { spot.as_ref() }.store(2, Ordering::Release);
+            producer.commit();
+            consumer.sync();
+            let item = consumer
+                .try_read()
+                .expect("Failed to read item after finalize");
+            assert_eq!(item.load(Ordering::Acquire), 2);
+            consumer.finalize();
         }
     }
 
@@ -781,7 +791,9 @@ mod tests {
         for create_queue in test_queue_creators::<u64>() {
             let (mut producer, mut consumer) = create_queue(64);
 
+            // SAFETY: single producer over a freshly created queue.
             let spot = unsafe { producer.reserve() }.expect("reserve failed");
+            // SAFETY: spot is a valid reserved slot.
             unsafe { spot.write(42) };
 
             assert!(matches!(


### PR DESCRIPTION
### Problem
Unsafe code can sometimes be hard to reason about, and require great care to not cause UB. There are two clippy lints than can help:
- `multiple_unsafe_ops_per_block`
- `undocumented_unsafe_blocks`

From why sections in https://rust-lang.github.io/rust-clippy/master respectively

> Combined with undocumented_unsafe_blocks, this lint ensures that each unsafe operation must be independently justified. Combined with unused_unsafe, this lint also ensures elimination of unnecessary unsafe blocks through refactoring.

> Undocumented unsafe blocks and impls can make it difficult to read and maintain code. Writing out the safety justification may help in discovering unsoundness or bugs.

This codebase mostly follows these best practices, but it's good to enforce on CI with clippy when it's just a simple setting.

### Solution
- deny the clippy lints in Cargo.toml
- `unsafe_op_in_unsafe_fn` was moved from lib.rs to cargo.toml for consistency
-  Make the lint pass by breaking up some unsafe into two unsafe blocks, and splitting the comments up. Comments were automated with Claude.
