### PR TITLE
ci: use `git-cliff` in release step for better release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
           ref: ${{ needs.check.outputs.ref }}
+          # Default depth is 1. We need Entire history
+          # for git-cliff to view the history to generate
+          # the changelog
+          fetch-depth: 0
 
       - run: |
           git tag -a "${TAG}" -m "Release ${TAG}"
@@ -124,9 +128,17 @@ jobs:
           CRATE_NAME: ${{ inputs.crate }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGELOG.md
+
       - name: Create Github Release
         run: |
-          gh release create "${TAG}" --title "${TAG}" --generate-notes
+          gh release create "${TAG}" --title "${TAG}" --notes-file CHANGELOG.md
         env:
           TAG: ${{ needs.check.outputs.tag }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,50 @@
+# git-cliff configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | split(pat="\n") | first | trim | upper_first }} ({{ commit.id | truncate(length=7, end="") }})\
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+postprocessors = []
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+topo_order = false
+sort_commits = "oldest"
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^build\\(deps\\)", group = "Dependencies" },
+    { message = "^chore|^build", group = "Miscellaneous Tasks" },
+    { message = ".*", group = "Other" },
+]


### PR DESCRIPTION
### Problem
shaq is a crate we release with versioning, and we'd like to have good changelogs that are easy to read, and shows list of new features, improvements, breaking changes, etc. The github autogenerated one is decent, but `git-cliff` can automatically detect those categories of changes when paired with conventional commits, and presents the changes "better".

FWIW I see we (anza) use it in a couple of other projects as well https://github.com/search?q=org%3Aanza-xyz%20cliff.toml&type=code.

### Solution
Release action now generates release notes with git cliff.