### PR TITLE
ci: add cargo doc job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Check documentation
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --all-features --no-deps
+
       - name: Build release
         if: matrix.os == 'ubuntu-latest'
         run: cargo build --release


### PR DESCRIPTION
closes #120 
This PR introduces  a `cargo-doc` step to the CI job. 

The PR is stacked on top of #122 
