### PR TITLE
ci: update cargo versioning strategy to lockfile-only in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: cargo
+    versioning-strategy: lockfile-only
     directories:
       - "/"
     schedule:


### PR DESCRIPTION
#### Problem

keeping versions in cargo.toml as minimal as possible gives downstream users more flexibility

#### Summary of Changes

update `versioning-strategy`

(https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--)