### PR TITLE
build: remove redundant package include list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://anza.xyz/"
 repository = "https://github.com/anza-xyz/shaq"
 license = "Apache-2.0"
 edition = "2021"
-include = ["src/*.rs", "Cargo.toml"]
 
 [target."cfg(unix)".dependencies]
 libc = { version = "0.2.180" }


### PR DESCRIPTION
### Problem
- The include line is unnecessary as default covers it, and current line messed up be excluding directories within src. This messed up release due to broadcast

### Summary of Changes
- Remove include from Cargo.toml