### PR TITLE
feat: expose shared-memory ABI version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ pub mod spsc;
 
 pub(crate) const VERSION_MAJOR: u16 = 3;
 pub(crate) const VERSION_PATCH: u16 = 0;
-pub(crate) const VERSION: u32 = (VERSION_MAJOR as u32) << 16 | VERSION_PATCH as u32;
+/// Packed shared-memory ABI version.
+pub const VERSION: u32 = (VERSION_MAJOR as u32) << 16 | VERSION_PATCH as u32;
 
 pub(crate) const fn normalized_capacity(capacity: usize) -> usize {
     if capacity == 0 {


### PR DESCRIPTION
### Problem
- We want to have agave reject early (i.e. before join time) if there's any disagreement on how/what data is shared with external scheduler

### Summary of Changes
- Expose the ABI version constant so we can send/check in the agave handshake