### PR TITLE
chore: bump API version to 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "shaq"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "core_affinity",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shaq"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
-version = "4.0.0"
+version = "4.1.0"
 description = "SPSC FIFO queue backed by shared memory for IPC"
 readme = "README.md"
 homepage = "https://anza.xyz/"


### PR DESCRIPTION
### Problem
- bump minor version so we can use new VERSION exposed in #129

### Summary of Changes
- bump version from 4.0.0 to 4.1.0