### PR TITLE
ci: use tombi for TOML formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ permissions:
   contents: read
 
 jobs:
+  toml-format:
+    name: Check TOML formatting and sorting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Tombi
+        uses: tombi-toml/setup-tombi@a440d8b4f102acf7963db4fd2a99ca02e17f88f6 # v1.5.0
+
+      - name: Check TOML formatting and sorting
+        run: tombi format --check --diff
+
   check-and-test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ edition = "2021"
 libc = { version = "0.2.180" }
 
 [target."cfg(windows)".dependencies]
-windows-sys = { version = "0.61", features = [
-    "Win32_Foundation",
-    "Win32_Security",
-    "Win32_Storage_FileSystem",
-    "Win32_System_Memory",
-] }
+windows-sys = {
+    version = "0.61",
+    features = [
+        "Win32_Foundation",
+        "Win32_Security",
+        "Win32_Storage_FileSystem",
+        "Win32_System_Memory",
+    ]
+}
 
 [dev-dependencies]
 core_affinity = "0.8.3"

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,33 @@
+toml-version = "v1.1.0"
+
+[format.rules]
+comment-style = "preserve"
+date-time-delimiter = "preserve"
+indent-width = 4
+key-quote-style = "preserve"
+line-width = 200
+string-quote-style = "preserve"
+
+[[schemas]]
+path = "tombi://www.schemastore.org/cargo.json"
+include = ["Cargo.toml", "**/Cargo.toml"]
+
+[schemas.format.rules]
+array-values-order.enabled = false
+table-keys-order.enabled = false
+
+[[schemas.overrides]]
+targets = [
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+    "workspace.dependencies",
+    "target.*.dependencies",
+    "target.*.dev-dependencies",
+    "target.*.build-dependencies",
+]
+format.rules.table-keys-order = "ascending"
+
+[[schemas.overrides]]
+targets = ["workspace.members"]
+format.rules.array-values-order = "ascending"


### PR DESCRIPTION
Replace cargo-sort with Tombi for TOML formatting and dependency ordering.

Same changes as https://github.com/anza-xyz/agave/pull/15062 in for this repo.