### PR TITLE
ci(tombi): use toml version 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,12 @@ edition = "2021"
 libc = { version = "0.2.180" }
 
 [target."cfg(windows)".dependencies]
-windows-sys = {
-    version = "0.61",
-    features = [
-        "Win32_Foundation",
-        "Win32_Security",
-        "Win32_Storage_FileSystem",
-        "Win32_System_Memory",
-    ]
-}
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Memory",
+] }
 
 [dev-dependencies]
 core_affinity = "0.8.3"

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,4 +1,4 @@
-toml-version = "v1.1.0"
+toml-version = "v1.0.0"
 
 [format.rules]
 comment-style = "preserve"
@@ -9,6 +9,7 @@ line-width = 200
 string-quote-style = "preserve"
 
 [[schemas]]
+toml-version = "v1.0.0"
 path = "tombi://www.schemastore.org/cargo.json"
 include = ["Cargo.toml", "**/Cargo.toml"]
 


### PR DESCRIPTION
### Problem
toml version 1.1.0 is only supported since cargo 1.94.0. Due to use of the new feature of multi line inline tables in the Cargo.toml file, all downstream users must also be on >= 1.94.0 to be able to parse the manifest if depending directly as a git dep. Crates.io dependents are fine.

Since we haven't set a MSRV yet for this project, we should not use implicitly set it to 1.94.0 because of the toml formatting.

### Solution
Set tombi schema version to 1.0.0 and format